### PR TITLE
Regex filter for "sentence" text when exporting to Anki

### DIFF
--- a/client/src/components/AnkiDialog.js
+++ b/client/src/components/AnkiDialog.js
@@ -19,6 +19,8 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import ZoomInIcon from '@material-ui/icons/ZoomIn';
 import TagsTextField from './TagsTextField';
+import { speakerRegex, getSubtitleWithoutSpeaker } from '../services/Util.js';
+import { Checkbox, FormControlLabel } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -39,6 +41,10 @@ const useStyles = makeStyles((theme) => ({
         '& .MuiSlider-markLabel': {
             transform: 'translateX(-3%)',
         },
+    },
+    alignRight: {
+        display: 'flex',
+        justifyContent: 'flex-end',
     },
 }));
 
@@ -111,7 +117,10 @@ export default function AnkiDialog({
 }) {
     const classes = useStyles();
     const [definition, setDefinition] = useState('');
+    const [isSpeakerTextHidden, setIsSpeakerTextHidden] = useState(false);
     const [text, setText] = useState();
+    const [originalText, setOriginalText] = useState();
+    const [isTextChanged, setIsTextChanged] = useState(false);
     const [word, setWord] = useState();
     const [lastSearchedWord, setLastSearchedWord] = useState();
     const [source, setSource] = useState(initialSource);
@@ -131,6 +140,9 @@ export default function AnkiDialog({
 
     useEffect(() => {
         setText(initialText);
+        setOriginalText(initialText);
+        handleToggleSpeakerText(true);
+        setIsTextChanged(false);
         setDefinition('');
         setWord('');
         setSource(initialSource);
@@ -281,6 +293,20 @@ export default function AnkiDialog({
         [customFieldValues]
     );
 
+    const handleChangeText = (e) => {
+        setIsTextChanged(true);
+        return setText(e.target.value);
+    };
+
+    const handleToggleSpeakerText = (showSpeakerText) => {
+        if (showSpeakerText) {
+            setText(getSubtitleWithoutSpeaker(originalText));
+        } else {
+            setText(originalText);
+        }
+        setIsSpeakerTextHidden(showSpeakerText);
+    };
+
     let wordHelperText;
 
     if (word && word.trim() === lastSearchedWord && settingsProvider.wordField) {
@@ -322,7 +348,7 @@ export default function AnkiDialog({
                         rowsMax={8}
                         label="Sentence"
                         value={text}
-                        onChange={(e) => setText(e.target.value)}
+                        onChange={handleChangeText}
                         InputProps={{
                             endAdornment: timestampInterval && (
                                 <InputAdornment position="end">
@@ -346,6 +372,18 @@ export default function AnkiDialog({
                             ),
                         }}
                     />
+                    <div className={classes.alignRight}>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={isSpeakerTextHidden}
+                                    onChange={(e) => handleToggleSpeakerText(e.target.checked)}
+                                />
+                            }
+                            label="Hide Speakers"
+                            disabled={isTextChanged}
+                        />
+                    </div>
                     <TextField
                         variant="filled"
                         color="secondary"

--- a/client/src/components/AnkiDialog.js
+++ b/client/src/components/AnkiDialog.js
@@ -121,6 +121,7 @@ export default function AnkiDialog({
     const [text, setText] = useState();
     const [originalText, setOriginalText] = useState();
     const [isTextChanged, setIsTextChanged] = useState(false);
+    const [isSpeakerTextToggleShown, setIsSpeakerTextToggleShown] = useState(false);
     const [word, setWord] = useState();
     const [lastSearchedWord, setLastSearchedWord] = useState();
     const [source, setSource] = useState(initialSource);
@@ -141,7 +142,8 @@ export default function AnkiDialog({
     useEffect(() => {
         setText(initialText);
         setOriginalText(initialText);
-        handleToggleSpeakerText(true);
+        setIsSpeakerTextToggleShown(speakerRegex.test(initialText));
+        setIsSpeakerTextHidden(false);
         setIsTextChanged(false);
         setDefinition('');
         setWord('');
@@ -150,7 +152,7 @@ export default function AnkiDialog({
         setDuplicateNotes([]);
         setCustomFieldValues({});
         setTags(settingsProvider.tags);
-    }, [initialText, initialSource, initialUrl, settingsProvider.tags]);
+    }, [open, initialText, initialSource, initialUrl, settingsProvider.tags]);
 
     useEffect(() => {
         const timestampInterval = sliderContext && [sliderContext.subtitleStart, sliderContext.subtitleEnd];
@@ -299,6 +301,10 @@ export default function AnkiDialog({
     };
 
     const handleToggleSpeakerText = (showSpeakerText) => {
+        if (!originalText) {
+            return;
+        }
+
         if (showSpeakerText) {
             setText(getSubtitleWithoutSpeaker(originalText));
         } else {
@@ -372,18 +378,20 @@ export default function AnkiDialog({
                             ),
                         }}
                     />
-                    <div className={classes.alignRight}>
-                        <FormControlLabel
-                            control={
-                                <Checkbox
-                                    checked={isSpeakerTextHidden}
-                                    onChange={(e) => handleToggleSpeakerText(e.target.checked)}
-                                />
-                            }
-                            label="Hide Speakers"
-                            disabled={isTextChanged}
-                        />
-                    </div>
+                    {isSpeakerTextToggleShown && (
+                        <div className={classes.alignRight}>
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={isSpeakerTextHidden}
+                                        onChange={(e) => handleToggleSpeakerText(e.target.checked)}
+                                    />
+                                }
+                                label="Hide Speakers"
+                                disabled={isTextChanged}
+                            />
+                        </div>
+                    )}
                     <TextField
                         variant="filled"
                         color="secondary"

--- a/client/src/services/Util.js
+++ b/client/src/services/Util.js
@@ -124,5 +124,5 @@ function padEnd(n) {
  */
 export function getSubtitleWithoutSpeaker(text) {
     const globalRegex = new RegExp(speakerRegex.source, 'g');
-    return text?.replaceAll(globalRegex, '') || '';
+    return text?.replaceAll(globalRegex, '');
 }

--- a/client/src/services/Util.js
+++ b/client/src/services/Util.js
@@ -1,3 +1,6 @@
+// Regular expression for the speaker
+export const speakerRegex = /[（([].*[）)\]][\s]*/;
+
 export function arrayEquals(a, b, equals = (a, b) => a === b) {
     if (a.length !== b.length) {
         return false;
@@ -109,4 +112,17 @@ function pad(n) {
 
 function padEnd(n) {
     return String(n).padEnd(3, '0');
+}
+
+/**
+ * Remove the speaker from subtitles
+ * example:
+ *      before: （ガモちゃん）ふんふん
+ *      after: ふんふん
+ * @param {string} text
+ * @returns sliced text
+ */
+export function getSubtitleWithoutSpeaker(text) {
+    const globalRegex = new RegExp(speakerRegex.source, 'g');
+    return text?.replaceAll(globalRegex, '') || '';
 }


### PR DESCRIPTION
https://github.com/killergerbah/asbplayer/issues/106

Added now a button where you can hide the speaker.

![grafik](https://user-images.githubusercontent.com/30508429/158895855-32d373a1-6752-4424-97ef-ef0c10d85d30.png)

![grafik](https://user-images.githubusercontent.com/30508429/158895894-92fe41ab-bf70-4863-98d5-c33c5acb1552.png)

It removes the speaker (along with the spaces). The regex currently targets japanese and english parenphesis. I Couldnt find an example with japanese brackets (if someone provides an example I can add it)

If the user edits the text, the toggle will be disabled
![grafik](https://user-images.githubusercontent.com/30508429/158896816-5d6e89c8-e3f1-4b50-a020-d0188b9f4f52.png)


It also checks if the pattern is reckognized. If it wasnt found it hides the toggle completely.
![grafik](https://user-images.githubusercontent.com/30508429/158896685-b6571fd0-416a-47ef-bf83-2e4f6ef3f5d6.png)

