### PR TITLE
Fix bug with empty subtitle names showing up on the screen when user has 'Open subtitle list when loading subtitle' enabled in the settings.

### DIFF
--- a/extension/src/controllers/subtitle-controller.ts
+++ b/extension/src/controllers/subtitle-controller.ts
@@ -486,25 +486,19 @@ export default class SubtitleController {
         }, 3000);
     }
 
-    showLoadedMessage(isEmptySubtitle?: boolean[]) {
+    showLoadedMessage(nonEmptyTrackIndex: number[]) {
         if (!this.subtitleFileNames) {
             return;
         }
 
         let loadedMessage: string;
 
-        let nonEmptySubtitleFileNames: string[];
+        const nonEmptySubtitleFileNames: string[] = this._nonEmptySubtitleNames(nonEmptyTrackIndex);
 
-        if (isEmptySubtitle?.length) {
-            nonEmptySubtitleFileNames = this._nonEmptySubtitleNames(isEmptySubtitle);
-
-            if (nonEmptySubtitleFileNames.length === 0) {
-                loadedMessage = this.subtitleFileNames[0];
-            } else {
-                loadedMessage = nonEmptySubtitleFileNames.join('<br>');
-            }
+        if (nonEmptySubtitleFileNames.length === 0) {
+            loadedMessage = this.subtitleFileNames[0];
         } else {
-            loadedMessage = this.subtitleFileNames.join('<br>');
+            loadedMessage = nonEmptySubtitleFileNames.join('<br>');
         }
 
         if (this.subtitles.length > 0) {
@@ -526,13 +520,12 @@ export default class SubtitleController {
         this.lastLoadedMessageTimestamp = Date.now();
     }
 
-    private _nonEmptySubtitleNames(isEmptySubtitle: boolean[]) {
-        const nonEmptySubtitleFileNames = [];
+    private _nonEmptySubtitleNames(nonEmptyTrackIndex: number[]) {
+        if (nonEmptyTrackIndex.length === 0) return [];
 
-        for (let i = 0; i < isEmptySubtitle.length; i++) {
-            if (!isEmptySubtitle[i]) {
-                nonEmptySubtitleFileNames.push(this.subtitleFileNames![i]);
-            }
+        const nonEmptySubtitleFileNames = [];
+        for (let i = 0; i < nonEmptyTrackIndex.length; i++) {
+            nonEmptySubtitleFileNames.push(this.subtitleFileNames![nonEmptyTrackIndex[i]]);
         }
 
         return nonEmptySubtitleFileNames;

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -420,9 +420,6 @@ export default class VideoDataSyncController {
     }
 
     private async _syncSubtitles(serializedFiles: SerializedSubtitleFile[], flatten: boolean) {
-        const isEmptySubtitle: boolean[] = serializedFiles.map((file) => {
-            return file.base64 === '' ? true : false;
-        });
         if ((await this._settings.getSingle('streamingSubtitleListPreference')) === SubtitleListPreference.app) {
             const command: VideoToExtensionCommand<ExtensionSyncMessage> = {
                 sender: 'asbplayer-video',
@@ -440,7 +437,7 @@ export default class VideoDataSyncController {
                     async (f) => new File([await (await fetch('data:text/plain;base64,' + f.base64)).blob()], f.name)
                 )
             );
-            this._context.loadSubtitles(files, flatten, isEmptySubtitle);
+            this._context.loadSubtitles(files, flatten);
         }
     }
 

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -910,7 +910,7 @@ export default class Binding {
         return await cropAndResize(maxWidth, maxHeight, rect, tabImageDataUrl);
     }
 
-    async loadSubtitles(files: File[], flatten: boolean, isEmptySubtitle?: boolean[]) {
+    async loadSubtitles(files: File[], flatten: boolean) {
         const {
             streamingSubtitleListPreference,
             subtitleRegexFilter,
@@ -943,8 +943,7 @@ export default class Binding {
                         originalStart: s.start,
                         originalEnd: s.end,
                     })),
-                    files.map((f) => f.name),
-                    isEmptySubtitle
+                    files.map((f) => f.name)
                 );
                 break;
             case SubtitleListPreference.app:
@@ -970,11 +969,7 @@ export default class Binding {
         }
     }
 
-    private _updateSubtitles(
-        subtitles: SubtitleModelWithIndex[],
-        subtitleFileNames: string[],
-        isEmptySubtitle?: boolean[]
-    ) {
+    private _updateSubtitles(subtitles: SubtitleModelWithIndex[], subtitleFileNames: string[]) {
         this.subtitleController.subtitles = subtitles;
         this.subtitleController.subtitleFileNames = subtitleFileNames;
         this.subtitleController.cacheHtml();
@@ -983,7 +978,13 @@ export default class Binding {
             this.playMode = PlayMode.normal;
         }
 
-        this.subtitleController.showLoadedMessage(isEmptySubtitle);
+        let nonEmptyTrackIndex: number[] = [];
+        for (let i = 0; i < subtitles.length; i++) {
+            if (!nonEmptyTrackIndex.includes(subtitles[i].track)) {
+                nonEmptyTrackIndex.push(subtitles[i].track);
+            }
+        }
+        this.subtitleController.showLoadedMessage(nonEmptyTrackIndex);
         this.videoDataSyncController.unbindVideoSelect();
         this.ankiUiSavedState = undefined;
         this._synced = true;


### PR DESCRIPTION
Get rid of isEmptySubtitle and detect empty tracks in binding.ts instead. That way it's handled regardless of which path it takes to get there.