### PR TITLE
fix width of rememberTrackPreference label in track selector

### DIFF
--- a/extension/src/ui/components/VideoDataSyncDialog.tsx
+++ b/extension/src/ui/components/VideoDataSyncDialog.tsx
@@ -250,10 +250,10 @@ export default function VideoDataSyncDialog({
                                 label={t('extension.videoDataSync.rememberTrackPreference')}
                                 labelPlacement="start"
                                 style={{
-                                    justifyContent: 'end',
-                                    width: '100%',
-                                    flexDirection: 'row-reverse',
-                                    marginLeft: '13px',
+                                    display: 'flex',
+                                    marginLeft: 'auto',
+                                    marginRight: '-13px',
+                                    width: 'fit-content',
                                 }}
                             />
                         </Grid>


### PR DESCRIPTION
The clickable area was too wide

![image](https://github.com/killergerbah/asbplayer/assets/19358097/18c11cbb-a61a-4fec-83ea-47e7ba07adac)
