### PR TITLE
feature: option to change name of tab

### DIFF
--- a/common/app/components/App.tsx
+++ b/common/app/components/App.tsx
@@ -1127,6 +1127,10 @@ function App({ origin, logoUrl, settings, extension, fetcher, onSettingsChanged 
         );
     }, [keyBinder, handleOpenCopyHistory, ankiDialogOpen]);
 
+    useEffect(() => {
+        document.title = settings.tabName;
+    }, [settings]);
+
     const { initialized: i18nInitialized } = useI18n({ language: settings.language });
 
     if (!i18nInitialized) {

--- a/common/app/components/App.tsx
+++ b/common/app/components/App.tsx
@@ -1129,7 +1129,7 @@ function App({ origin, logoUrl, settings, extension, fetcher, onSettingsChanged 
 
     useEffect(() => {
         document.title = settings.tabName;
-    }, [settings]);
+    }, [settings.tabName]);
 
     const { initialized: i18nInitialized } = useI18n({ language: settings.language });
 

--- a/common/app/services/video-channel.ts
+++ b/common/app/services/video-channel.ts
@@ -531,6 +531,7 @@ export default class VideoChannel {
             clickToMineDefaultAction,
             language,
             lastSubtitleOffset,
+            tabName,
         } = settings;
         const message: MiscSettingsToVideoMessage = {
             command: 'miscSettings',
@@ -550,6 +551,7 @@ export default class VideoChannel {
                 clickToMineDefaultAction,
                 language,
                 lastSubtitleOffset,
+                tabName,
             },
         };
         this.protocol.postMessage(message);

--- a/common/components/SettingsForm.tsx
+++ b/common/components/SettingsForm.tsx
@@ -680,6 +680,7 @@ export default function SettingsForm({
         rememberSubtitleOffset,
         autoCopyCurrentSubtitle,
         alwaysPlayOnSubtitleRepeat,
+        tabName,
         subtitleRegexFilter,
         subtitleRegexFilterTextReplacement,
         language,
@@ -1825,6 +1826,13 @@ export default function SettingsForm({
                                     min: 0,
                                     step: 1,
                                 }}
+                            />
+                            <TextField
+                                label={t('settings.tabName')}
+                                fullWidth
+                                value={tabName}
+                                color="secondary"
+                                onChange={(event) => handleSettingChanged('tabName', event.target.value)}
                             />
                             <TextField
                                 label={t('settings.subtitleRegexFilter')}

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -288,6 +288,7 @@
         "subtitleAlignment": "Untertitel-Position",
         "subtitleAlignmentBottom": "Unten",
         "subtitleAlignmentTop": "Oben",
+        "tabName": "Reiterbezeichnung",
         "subtitleRegexFilter": "Untertitelfilter (Regulärer Ausdruck)",
         "subtitleRegexFilterTextReplacement": "Untertitelfilter Ersetzung",
         "subtitleSize": "Untertitelgröße",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -288,6 +288,7 @@
         "subtitleAlignment": "Subtitle Alignment",
         "subtitleAlignmentBottom": "Bottom",
         "subtitleAlignmentTop": "Top",
+        "tabName": "Name of the tab",
         "subtitleRegexFilter": "Subtitle regex filter",
         "subtitleRegexFilterTextReplacement": "Subtitle regex filter text replacement",
         "subtitleSize": "Subtitle Size",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -288,6 +288,7 @@
         "subtitleAlignment": "Alineación de Subtítulos",
         "subtitleAlignmentBottom": "Inferior",
         "subtitleAlignmentTop": "Superior",
+        "tabName": "Nombre de la pestaña",
         "subtitleRegexFilter": "Filtro regex para subtítulos",
         "subtitleRegexFilterTextReplacement": "Texto de reemplazo para el filtro regex",
         "subtitleSize": "Tamaño de los subtítulos",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -288,6 +288,7 @@
         "subtitleAlignment": "字幕の表示位置",
         "subtitleAlignmentBottom": "下部",
         "subtitleAlignmentTop": "上部",
+        "tabName": "タブ名",
         "subtitleRegexFilter": "字幕の正規表現フィルタ",
         "subtitleRegexFilterTextReplacement": "字幕の正規表現フィルタの置き換えテキスト",
         "subtitleSize": "字幕のサイズ",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -288,6 +288,7 @@
         "subtitleAlignment": "Wyrównanie napisów",
         "subtitleAlignmentBottom": "Dół",
         "subtitleAlignmentTop": "Góra",
+        "tabName": "Nazwa karty",
         "subtitleRegexFilter": "Filtr Regex napisów",
         "subtitleRegexFilterTextReplacement": "Zamiana tekstu z filtru Regex napisów",
         "subtitleSize": "Wielkość napisów",

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -288,6 +288,7 @@
         "subtitleAlignment": "Alinhamento da legenda",
         "subtitleAlignmentBottom": "Inferior",
         "subtitleAlignmentTop": "Superior",
+        "tabName": "Nome da guia",
         "subtitleRegexFilter": "Filtro regex da legenda",
         "subtitleRegexFilterTextReplacement": "Substituição de texto do filtro regex da legenda",
         "subtitleSize": "Tamanho da legenda",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -288,6 +288,7 @@
         "subtitleAlignment": "Выравнивание субтитров",
         "subtitleAlignmentBottom": "По нижнему краю",
         "subtitleAlignmentTop": "По верхнему краю",
+        "tabName": "название вкладки",
         "subtitleRegexFilter": "Пропускать субтитры через фильтр с регулярным выражением",
         "subtitleRegexFilterTextReplacement": "Замена текста для фильтра регулярных выражений для субтитров",
         "subtitleSize": "Размер субтитров",

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -288,6 +288,7 @@
         "subtitleAlignment": "字幕对齐方式",
         "subtitleAlignmentBottom": "底部",
         "subtitleAlignmentTop": "顶部",
+        "tabName": "选项卡名称",
         "subtitleRegexFilter": "字幕正则筛选器",
         "subtitleRegexFilterTextReplacement": "字幕正则筛选器文本替换",
         "subtitleSize": "字幕大小",

--- a/common/settings/settings-import-export.test.ts
+++ b/common/settings/settings-import-export.test.ts
@@ -82,6 +82,7 @@ it('validates exported settings', () => {
             updateLastCard: { keys: '⇧+⌃+U' },
         },
         preferMp3: true,
+        tabName: "asbplayer",
         miningHistoryStorageLimit: 25,
         preCacheSubtitleDom: true,
         clickToMineDefaultAction: 1,

--- a/common/settings/settings-import-export.test.ts
+++ b/common/settings/settings-import-export.test.ts
@@ -82,7 +82,7 @@ it('validates exported settings', () => {
             updateLastCard: { keys: '⇧+⌃+U' },
         },
         preferMp3: true,
-        tabName: "asbplayer",
+        tabName: 'asbplayer',
         miningHistoryStorageLimit: 25,
         preCacheSubtitleDom: true,
         clickToMineDefaultAction: 1,

--- a/common/settings/settings-import-export.ts
+++ b/common/settings/settings-import-export.ts
@@ -143,6 +143,9 @@ const settingsSchema = {
         preferMp3: {
             type: 'boolean',
         },
+        tabName: {
+            type: 'string',
+        },
         miningHistoryStorageLimit: {
             type: 'number',
         },

--- a/common/settings/settings-provider.ts
+++ b/common/settings/settings-provider.ts
@@ -68,6 +68,7 @@ export const defaultSettings: AsbplayerSettings = {
         toggleRepeat: { keys: isMacOs ? '⇧+R' : 'shift+R' },
     },
     preferMp3: true,
+    tabName: 'asbplayer',
     miningHistoryStorageLimit: 25,
     preCacheSubtitleDom: true,
     clickToMineDefaultAction: PostMineAction.showAnkiDialog,

--- a/common/settings/settings.ts
+++ b/common/settings/settings.ts
@@ -16,6 +16,7 @@ export interface MiscSettings {
     readonly language: string;
     readonly clickToMineDefaultAction: PostMineAction;
     readonly lastSubtitleOffset: number;
+    readonly tabName: string;
 }
 
 export interface AnkiSettings {


### PR DESCRIPTION
This adds the option to change the name of the player tab. 
The use case for this is being able to use the document-title field in yomitan with asbplayer. Say for example you're watching several episodes of a show, simply set the title of the show as the tab name and all anki cards can then be tagged with the name of the show. 

All translations were done with DeepL, and the German, English, Spanish and Japanese translations were double checked by a human.