### PR TITLE
Multiple file upload button implementation #380

### DIFF
--- a/common/src/message.ts
+++ b/common/src/message.ts
@@ -6,7 +6,7 @@ import {
     AudioModel,
     AudioTrackModel,
     AnkiUiSavedState,
-    EmbeddedSubtitle,
+    SubtitleTrack,
     PostMineAction,
     PlayMode,
     CardModel,
@@ -416,7 +416,7 @@ export interface AnkiUiBridgeRerecordMessage extends Message {
 
 export interface VideoDataUiBridgeConfirmMessage extends Message {
     readonly command: 'confirm';
-    readonly data: EmbeddedSubtitle[];
+    readonly data: SubtitleTrack[];
     readonly shouldRememberTrackChoices: boolean;
 }
 

--- a/common/src/message.ts
+++ b/common/src/message.ts
@@ -6,7 +6,7 @@ import {
     AudioModel,
     AudioTrackModel,
     AnkiUiSavedState,
-    ConfirmedVideoDataSubtitleTrack,
+    VideoDataSubtitleTrack,
     PostMineAction,
     PlayMode,
     CardModel,
@@ -420,7 +420,7 @@ export interface AnkiUiBridgeRerecordMessage extends Message {
 
 export interface VideoDataUiBridgeConfirmMessage extends Message {
     readonly command: 'confirm';
-    readonly data: ConfirmedVideoDataSubtitleTrack[];
+    readonly data: VideoDataSubtitleTrack[];
     readonly shouldRememberTrackChoices: boolean;
 }
 

--- a/common/src/message.ts
+++ b/common/src/message.ts
@@ -6,12 +6,13 @@ import {
     AudioModel,
     AudioTrackModel,
     AnkiUiSavedState,
-    VideoDataSubtitleTrack,
+    EmbeddedSubtitle,
     PostMineAction,
     PlayMode,
     CardModel,
     CardTextFieldValues,
     MobileOverlayModel,
+    SerializedSubtitleFile,
 } from './model';
 import { AsbPlayerToVideoCommandV2 } from './command';
 
@@ -234,11 +235,6 @@ export interface ShowAnkiUiAfterRerecordMessage extends Message {
     readonly uiState: AnkiUiSavedState;
 }
 
-export interface SerializedSubtitleFile {
-    name: string;
-    base64: string;
-}
-
 export interface LegacyPlayerSyncMessage extends Message {
     readonly command: 'sync';
     readonly subtitles: SerializedSubtitleFile;
@@ -420,7 +416,7 @@ export interface AnkiUiBridgeRerecordMessage extends Message {
 
 export interface VideoDataUiBridgeConfirmMessage extends Message {
     readonly command: 'confirm';
-    readonly data: VideoDataSubtitleTrack[];
+    readonly data: EmbeddedSubtitle[];
     readonly shouldRememberTrackChoices: boolean;
 }
 

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -133,7 +133,26 @@ export interface AnkiUiSavedState {
     dialogRequestedTimestamp: number;
 }
 
-export interface VideoDataSubtitleTrack {
+export type SubtitleTrack = SerializedSubtitleFile | EmbeddedSubtitle;
+
+// typeguard 
+export const isSubtitleFile = (b:SubtitleTrack): b is SerializedSubtitleFile => {
+    return (b as SerializedSubtitleFile).type === "file";
+}
+
+// typeguard 
+export const isEmbeddedSubtitle = (b:SubtitleTrack): b is EmbeddedSubtitle => {
+    return (b as EmbeddedSubtitle).type === "url";
+}
+
+export interface SerializedSubtitleFile {
+    type: "file";
+    name: string;
+    base64: string;
+}
+
+export interface EmbeddedSubtitle {
+    type: "url";
     label: string;
     language: string;
     url: string;
@@ -144,14 +163,14 @@ export interface VideoDataSubtitleTrack {
 export interface VideoData {
     basename: string;
     error?: string;
-    subtitles?: VideoDataSubtitleTrack[];
+    subtitles?: EmbeddedSubtitle[];
 }
 
 export interface VideoDataUiState {
     open?: boolean;
     isLoading?: boolean;
     suggestedName?: string;
-    subtitles?: VideoDataSubtitleTrack[];
+    subtitles?: EmbeddedSubtitle[];
     error?: string;
     themeType?: string;
     selectedSubtitle?: string[];

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -141,14 +141,6 @@ export interface VideoDataSubtitleTrack {
     extension: string;
 }
 
-export interface ConfirmedVideoDataSubtitleTrack {
-    name: string;
-    language: string;
-    subtitleUrl: string;
-    m3U8BaseUrl?: string;
-    extension: string;
-}
-
 export interface VideoData {
     basename: string;
     error?: string;

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -1,5 +1,4 @@
 import {
-    ConfirmedVideoDataSubtitleTrack,
     ExtensionSyncMessage,
     SerializedSubtitleFile,
     VideoData,
@@ -187,28 +186,28 @@ export default class VideoDataSyncController {
             const themeType = await this._context.settings.getSingle('themeType');
             let state: VideoDataUiState = this._syncedData
                 ? {
-                      open: true,
-                      isLoading: this._syncedData.subtitles === undefined,
-                      suggestedName: this._syncedData.basename,
-                      selectedSubtitle: ['-'],
-                      subtitles: subtitleTrackChoices,
-                      error: this._syncedData.error,
-                      themeType: themeType,
-                      openedFromMiningCommand,
-                      defaultCheckboxState: defaultCheckboxState,
-                  }
+                    open: true,
+                    isLoading: this._syncedData.subtitles === undefined,
+                    suggestedName: this._syncedData.basename,
+                    selectedSubtitle: ['-'],
+                    subtitles: subtitleTrackChoices,
+                    error: this._syncedData.error,
+                    themeType: themeType,
+                    openedFromMiningCommand,
+                    defaultCheckboxState: defaultCheckboxState,
+                }
                 : {
-                      open: true,
-                      isLoading: this._context.subSyncAvailable && this._waitingForSubtitles,
-                      suggestedName: document.title,
-                      selectedSubtitle: ['-'],
-                      error: '',
-                      showSubSelect: true,
-                      subtitles: subtitleTrackChoices,
-                      themeType: themeType,
-                      openedFromMiningCommand,
-                      defaultCheckboxState: defaultCheckboxState,
-                  };
+                    open: true,
+                    isLoading: this._context.subSyncAvailable && this._waitingForSubtitles,
+                    suggestedName: document.title,
+                    selectedSubtitle: ['-'],
+                    error: '',
+                    showSubSelect: true,
+                    subtitles: subtitleTrackChoices,
+                    themeType: themeType,
+                    openedFromMiningCommand,
+                    defaultCheckboxState: defaultCheckboxState,
+                };
             state.selectedSubtitle = selectedSub.map((subtitle) => subtitle.url || '-');
             const client = await this._client();
             this._prepareShow();
@@ -294,10 +293,10 @@ export default class VideoDataSyncController {
                         this.lastLanguageSynced = confirmMessage.data.map((track) => track.language);
                         await this._context.settings
                             .set({ streamingLastLanguagesSynced: this._lastLanguagesSynced })
-                            .catch(() => {});
+                            .catch(() => { });
                     }
 
-                    const data = confirmMessage.data as ConfirmedVideoDataSubtitleTrack[];
+                    const data = confirmMessage.data as VideoDataSubtitleTrack[];
 
                     shallUpdate = await this._syncDataArray(data);
                 } else if ('openFile' === message.command) {
@@ -398,13 +397,13 @@ export default class VideoDataSyncController {
         }
     }
 
-    private async _syncDataArray(data: ConfirmedVideoDataSubtitleTrack[]) {
+    private async _syncDataArray(data: VideoDataSubtitleTrack[]) {
         try {
             let subtitles: SerializedSubtitleFile[] = [];
 
             for (let i = 0; i < data.length; i++) {
-                const { name, extension, subtitleUrl, m3U8BaseUrl } = data[i];
-                const subtitleFiles = await this._subtitlesForUrl(name, extension, subtitleUrl, m3U8BaseUrl);
+                const { label, extension, url, m3U8BaseUrl } = data[i];
+                const subtitleFiles = await this._subtitlesForUrl(label, extension, url, m3U8BaseUrl);
                 if (subtitleFiles !== undefined) {
                     subtitles.push(...subtitleFiles);
                 }

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -186,28 +186,28 @@ export default class VideoDataSyncController {
             const themeType = await this._context.settings.getSingle('themeType');
             let state: VideoDataUiState = this._syncedData
                 ? {
-                    open: true,
-                    isLoading: this._syncedData.subtitles === undefined,
-                    suggestedName: this._syncedData.basename,
-                    selectedSubtitle: ['-'],
-                    subtitles: subtitleTrackChoices,
-                    error: this._syncedData.error,
-                    themeType: themeType,
-                    openedFromMiningCommand,
-                    defaultCheckboxState: defaultCheckboxState,
-                }
+                      open: true,
+                      isLoading: this._syncedData.subtitles === undefined,
+                      suggestedName: this._syncedData.basename,
+                      selectedSubtitle: ['-'],
+                      subtitles: subtitleTrackChoices,
+                      error: this._syncedData.error,
+                      themeType: themeType,
+                      openedFromMiningCommand,
+                      defaultCheckboxState: defaultCheckboxState,
+                  }
                 : {
-                    open: true,
-                    isLoading: this._context.subSyncAvailable && this._waitingForSubtitles,
-                    suggestedName: document.title,
-                    selectedSubtitle: ['-'],
-                    error: '',
-                    showSubSelect: true,
-                    subtitles: subtitleTrackChoices,
-                    themeType: themeType,
-                    openedFromMiningCommand,
-                    defaultCheckboxState: defaultCheckboxState,
-                };
+                      open: true,
+                      isLoading: this._context.subSyncAvailable && this._waitingForSubtitles,
+                      suggestedName: document.title,
+                      selectedSubtitle: ['-'],
+                      error: '',
+                      showSubSelect: true,
+                      subtitles: subtitleTrackChoices,
+                      themeType: themeType,
+                      openedFromMiningCommand,
+                      defaultCheckboxState: defaultCheckboxState,
+                  };
             state.selectedSubtitle = selectedSub.map((subtitle) => subtitle.url || '-');
             const client = await this._client();
             this._prepareShow();
@@ -293,7 +293,7 @@ export default class VideoDataSyncController {
                         this.lastLanguageSynced = confirmMessage.data.map((track) => track.language);
                         await this._context.settings
                             .set({ streamingLastLanguagesSynced: this._lastLanguagesSynced })
-                            .catch(() => { });
+                            .catch(() => {});
                     }
 
                     const data = confirmMessage.data as VideoDataSubtitleTrack[];

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -298,7 +298,7 @@ export default class VideoDataSyncController {
 
                     const data = confirmMessage.data as VideoDataSubtitleTrack[];
 
-                    shallUpdate = await this._syncDataArray(data);
+                    shallUpdate = await this._syncData(data);
                 } else if ('openFile' === message.command) {
                     const openFileMessage = message as VideoDataUiBridgeOpenFileMessage;
                     const subtitles = openFileMessage.subtitles as SerializedSubtitleFile[];
@@ -378,32 +378,6 @@ export default class VideoDataSyncController {
                     url,
                     m3U8BaseUrl
                 );
-                if (subtitleFiles !== undefined) {
-                    subtitles.push(...subtitleFiles);
-                }
-            }
-
-            this._syncSubtitles(
-                subtitles,
-                data.some((track) => track.m3U8BaseUrl !== undefined)
-            );
-            return true;
-        } catch (error) {
-            if (typeof (error as Error).message !== 'undefined') {
-                this._reportError(`Data Sync failed: ${(error as Error).message}`);
-            }
-
-            return false;
-        }
-    }
-
-    private async _syncDataArray(data: VideoDataSubtitleTrack[]) {
-        try {
-            let subtitles: SerializedSubtitleFile[] = [];
-
-            for (let i = 0; i < data.length; i++) {
-                const { label, extension, url, m3U8BaseUrl } = data[i];
-                const subtitleFiles = await this._subtitlesForUrl(label, extension, url, m3U8BaseUrl);
                 if (subtitleFiles !== undefined) {
                     subtitles.push(...subtitleFiles);
                 }

--- a/extension/src/pages/amazon-prime-page.ts
+++ b/extension/src/pages/amazon-prime-page.ts
@@ -13,6 +13,7 @@ inferTracks({
                     const label = `${value.catalogMetadata.catalog.title} ${track.displayName}`;
 
                     addTrack({
+                        type: "url",
                         label: label,
                         language: track.languageCode.toLowerCase(),
                         url: track.url,

--- a/extension/src/pages/apps-disney-plus-page.ts
+++ b/extension/src/pages/apps-disney-plus-page.ts
@@ -17,6 +17,7 @@ inferTracksFromInterceptedMpd(/https:\/\/.+\.apps\.disneyplus\..+\.mpd/, (playli
     }
 
     return {
+        type: "url",
         label,
         language,
         url: playlist.resolvedUri,

--- a/extension/src/pages/bandai-channel-page.ts
+++ b/extension/src/pages/bandai-channel-page.ts
@@ -37,6 +37,7 @@ inferTracks({
                         typeof track.label === 'string' ? `${track.srclang} - ${track?.label}` : track.srclang;
                     const url = track.sources[0].src.replace(/^http:\/\//, 'https://');
                     addTrack({
+                        type: "url",
                         label: label,
                         language: track.srclang.toLowerCase(),
                         url: url,

--- a/extension/src/pages/bilibili-page.ts
+++ b/extension/src/pages/bilibili-page.ts
@@ -14,6 +14,7 @@ inferTracks({
                     const extension = extractExtension(url, 'srt');
 
                     addTrack({
+                        type: "url",
                         label: track.lang,
                         language: track.lang_key,
                         url,

--- a/extension/src/pages/disney-plus-page.ts
+++ b/extension/src/pages/disney-plus-page.ts
@@ -1,4 +1,4 @@
-import { VideoDataSubtitleTrack } from '@project/common';
+import { EmbeddedSubtitle } from '@project/common';
 import { Parser } from 'm3u8-parser';
 
 setTimeout(() => {
@@ -64,7 +64,7 @@ setTimeout(() => {
         });
     }
 
-    function completeM3U8(url: string): Promise<VideoDataSubtitleTrack[]> {
+    function completeM3U8(url: string): Promise<EmbeddedSubtitle[]> {
         return new Promise((resolve, reject) => {
             setTimeout(async () => {
                 try {
@@ -75,7 +75,7 @@ setTimeout(() => {
 
                         if (subtitleGroup && subtitleGroup['sub-main']) {
                             const tracks = subtitleGroup['sub-main'];
-                            const subtitles: VideoDataSubtitleTrack[] = [];
+                            const subtitles: EmbeddedSubtitle[] = [];
 
                             for (const label of Object.keys(tracks)) {
                                 const track = tracks[label];
@@ -84,6 +84,7 @@ setTimeout(() => {
                                     const baseUrl = baseUrlForUrl(url);
                                     const subtitleM3U8Url = `${baseUrl}/${track.uri}`;
                                     subtitles.push({
+                                        type: 'url',
                                         label: label,
                                         language: track.language,
                                         url: subtitleM3U8Url,
@@ -106,7 +107,7 @@ setTimeout(() => {
         });
     }
 
-    let subtitlesPromise: Promise<VideoDataSubtitleTrack[]> | undefined;
+    let subtitlesPromise: Promise<EmbeddedSubtitle[]> | undefined;
 
     const originalParse = JSON.parse;
     JSON.parse = function () {

--- a/extension/src/pages/emby-page.ts
+++ b/extension/src/pages/emby-page.ts
@@ -1,4 +1,4 @@
-import { VideoDataSubtitleTrack } from '@project/common';
+import { EmbeddedSubtitle } from '@project/common';
 import { VideoData } from '@project/common';
 
 declare const ApiClient: any | undefined;
@@ -26,7 +26,7 @@ document.addEventListener(
                 var mediaID = session.PlayState.MediaSourceId;
                 var nowPlayingItem = session.NowPlayingItem;
                 response.basename = nowPlayingItem.FileName;
-                const subtitles: VideoDataSubtitleTrack[] = [];
+                const subtitles: EmbeddedSubtitle[] = [];
                 nowPlayingItem.MediaStreams.filter(
                     (stream: { IsTextSubtitleStream: any }) => stream.IsTextSubtitleStream
                 ).forEach((sub: { Codec: string; DisplayTitle: any; Language: any; Index: number }) => {
@@ -42,6 +42,7 @@ document.addEventListener(
                         '?api_key=' +
                         apikey;
                     subtitles.push({
+                        type: 'url',
                         label: sub.DisplayTitle,
                         language: sub.Language,
                         url: url,

--- a/extension/src/pages/hulu-page.ts
+++ b/extension/src/pages/hulu-page.ts
@@ -1,4 +1,4 @@
-import { VideoDataSubtitleTrack } from '@project/common';
+import { EmbeddedSubtitle } from '@project/common';
 import { extractExtension } from './util';
 
 setTimeout(() => {
@@ -7,7 +7,7 @@ setTimeout(() => {
     }
 
     function extractSubtitleTracks(value: any) {
-        const subtitles = [];
+        const subtitles: EmbeddedSubtitle[] = [];
         if (isObject(value.transcripts_urls?.webvtt)) {
             const urls = value.transcripts_urls.webvtt;
 
@@ -17,6 +17,7 @@ setTimeout(() => {
                 if (typeof url === 'string') {
                     if (subtitles.find((s) => s.label === s.language) === undefined) {
                         subtitles.push({
+                            type: "url",
                             label: language,
                             language: language.toLowerCase(),
                             url: url,
@@ -32,7 +33,7 @@ setTimeout(() => {
 
     let playlistController: AbortController | undefined;
 
-    function fetchPlaylistAndExtractSubtitles(payload: any): Promise<VideoDataSubtitleTrack[]> {
+    function fetchPlaylistAndExtractSubtitles(payload: any): Promise<EmbeddedSubtitle[]> {
         playlistController?.abort();
         return new Promise((resolve, reject) => {
             setTimeout(() => {
@@ -86,7 +87,7 @@ setTimeout(() => {
         });
     }
 
-    let subtitlesPromise: Promise<VideoDataSubtitleTrack[]> | undefined;
+    let subtitlesPromise: Promise<EmbeddedSubtitle[]> | undefined;
     let basenamePromise: Promise<string> | undefined;
 
     const originalStringify = JSON.stringify;
@@ -109,7 +110,7 @@ setTimeout(() => {
         'asbplayer-get-synced-data',
         async () => {
             let basename = '';
-            let subtitles: VideoDataSubtitleTrack[] = [];
+            let subtitles: EmbeddedSubtitle[] = [];
             let error = '';
 
             try {

--- a/extension/src/pages/mpd-util.ts
+++ b/extension/src/pages/mpd-util.ts
@@ -1,4 +1,4 @@
-import { VideoDataSubtitleTrack } from '@project/common';
+import { EmbeddedSubtitle } from '@project/common';
 import { extractExtension, inferTracks } from './util';
 import { parse } from 'mpd-parser';
 
@@ -9,15 +9,15 @@ export interface Playlist {
 
 export const inferTracksFromInterceptedMpd = (
     mpdUrlRegex: RegExp,
-    trackExtractor: (playlist: Playlist, language: string) => VideoDataSubtitleTrack | undefined
+    trackExtractor: (playlist: Playlist, language: string) => EmbeddedSubtitle | undefined
 ) => {
     const originalFetch = window.fetch;
 
-    const tryExtractSubtitleTracks = async (mpdUrl: string): Promise<VideoDataSubtitleTrack[]> => {
+    const tryExtractSubtitleTracks = async (mpdUrl: string): Promise<EmbeddedSubtitle[]> => {
         const manifest = await (await originalFetch(mpdUrl)).text();
         const parsedManifest = parse(manifest, { manifestUri: mpdUrl });
         const subGroups = parsedManifest.mediaGroups?.SUBTITLES?.subs ?? {};
-        const tracks: VideoDataSubtitleTrack[] = [];
+        const tracks: EmbeddedSubtitle[] = [];
 
         if (typeof subGroups !== 'object') {
             return [];

--- a/extension/src/pages/osnplus-page.ts
+++ b/extension/src/pages/osnplus-page.ts
@@ -4,6 +4,7 @@ import { extractExtension } from './util';
 inferTracksFromInterceptedMpd(/https:\/\/(.+\.)?osn\.com.+\.mpd/, (playlist, language) => {
     const name = playlist.attributes?.NAME;
     return {
+        type: "url",
         label: name === undefined ? language : `${language} - ${name}`,
         language,
         url: playlist.resolvedUri,

--- a/extension/src/pages/tver-page.ts
+++ b/extension/src/pages/tver-page.ts
@@ -18,6 +18,7 @@ inferTracks({
                     const url = track.sources[0].src;
 
                     addTrack({
+                        type: "url",
                         label: label,
                         language: language,
                         url: url.replace(/^http:\/\//, 'https://'),

--- a/extension/src/pages/util.ts
+++ b/extension/src/pages/util.ts
@@ -1,4 +1,4 @@
-import { VideoDataSubtitleTrack } from '@project/common';
+import { EmbeddedSubtitle } from '@project/common';
 
 export function extractExtension(url: string, fallback: string) {
     const dotIndex = url.lastIndexOf('.');
@@ -40,15 +40,15 @@ export function poll(test: () => boolean, timeout: number = 10000): Promise<bool
     });
 }
 
-type SubtitlesByPath = { [key: string]: VideoDataSubtitleTrack[] };
+type SubtitlesByPath = { [key: string]: EmbeddedSubtitle[] };
 
 export interface InferHooks {
     onJson?: (
         value: any,
-        addTrack: (track: VideoDataSubtitleTrack) => void,
+        addTrack: (track: EmbeddedSubtitle) => void,
         setBasename: (basename: string) => void
     ) => void;
-    onRequest?: (addTrack: (track: VideoDataSubtitleTrack) => void, setBasename: (basename: string) => void) => void;
+    onRequest?: (addTrack: (track: EmbeddedSubtitle) => void, setBasename: (basename: string) => void) => void;
     waitForBasename: boolean;
 }
 

--- a/extension/src/pages/viki-page.ts
+++ b/extension/src/pages/viki-page.ts
@@ -4,6 +4,7 @@ import { extractExtension } from './util';
 inferTracksFromInterceptedMpd(/https:\/\/.+\.viki\..+manifest\.mpd/, (playlist, language) => {
     const name = playlist.attributes?.NAME;
     return {
+        type: "url",
         label: name === undefined ? language : `${language} - ${name}`,
         language,
         url: playlist.resolvedUri,

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -1224,6 +1224,7 @@ export default class Binding {
                                 const base64 = await bufferToBase64(await f.arrayBuffer());
 
                                 return {
+                                    type: "file",
                                     name: f.name,
                                     base64: base64,
                                 };

--- a/extension/src/ui/components/VideoDataSyncDialog.tsx
+++ b/extension/src/ui/components/VideoDataSyncDialog.tsx
@@ -14,7 +14,7 @@ import Typography from '@material-ui/core/Typography';
 import makeStyles from '@material-ui/styles/makeStyles';
 import Switch from '@material-ui/core/Switch';
 import LabelWithHoverEffect from '@project/common/components/LabelWithHoverEffect';
-import { VideoDataSubtitleTrack } from '@project/common';
+import { EmbeddedSubtitle } from '@project/common';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -51,14 +51,14 @@ interface Props {
     isLoading: boolean;
     suggestedName: string;
     showSubSelect: boolean;
-    subtitles: VideoDataSubtitleTrack[];
+    subtitles: EmbeddedSubtitle[];
     selectedSubtitle: string[];
     defaultCheckboxState: boolean;
     error: string;
     openedFromMiningCommand: boolean;
     onCancel: () => void;
     onOpenFile: () => void;
-    onConfirm: (track: VideoDataSubtitleTrack[], shouldRememberTrackChoices: boolean) => void;
+    onConfirm: (track: EmbeddedSubtitle[], shouldRememberTrackChoices: boolean) => void;
 }
 
 export default function VideoDataSyncDialog({
@@ -131,7 +131,7 @@ export default function VideoDataSyncDialog({
     }, [suggestedName, selectedSubtitles, subtitles]);
 
     function handleOkButtonClick() {
-        const selectedSubtitleTracks: VideoDataSubtitleTrack[] = allSelectedSubtitleTracks();
+        const selectedSubtitleTracks: EmbeddedSubtitle[] = allSelectedSubtitleTracks();
         onConfirm(selectedSubtitleTracks, shouldRememberTrackChoices);
     }
 
@@ -140,12 +140,13 @@ export default function VideoDataSyncDialog({
     }
 
     function allSelectedSubtitleTracks() {
-        const selectedSubtitleTracks: VideoDataSubtitleTrack[] = selectedSubtitles
-            .map((selected): VideoDataSubtitleTrack | undefined => {
+        const selectedSubtitleTracks: EmbeddedSubtitle[] = selectedSubtitles
+            .map((selected): EmbeddedSubtitle | undefined => {
                 const subtitle = subtitles.find((subtitle) => subtitle.url === selected);
                 if (subtitle) {
                     const { language, extension, m3U8BaseUrl } = subtitle;
                     return {
+                        type: "url",
                         label: suggestedName.trim() + language.trim(),
                         extension: extension,
                         url: selected,
@@ -154,7 +155,7 @@ export default function VideoDataSyncDialog({
                     };
                 }
             })
-            .filter((track): track is VideoDataSubtitleTrack => track !== undefined);
+            .filter((track): track is EmbeddedSubtitle => track !== undefined);
 
         // Give the first track the trimmed name from the name field in case it has been changed by the user
         selectedSubtitleTracks[0].label = trimmedName;

--- a/extension/src/ui/components/VideoDataSyncDialog.tsx
+++ b/extension/src/ui/components/VideoDataSyncDialog.tsx
@@ -14,7 +14,7 @@ import Typography from '@material-ui/core/Typography';
 import makeStyles from '@material-ui/styles/makeStyles';
 import Switch from '@material-ui/core/Switch';
 import LabelWithHoverEffect from '@project/common/components/LabelWithHoverEffect';
-import { ConfirmedVideoDataSubtitleTrack, VideoDataSubtitleTrack } from '@project/common';
+import { VideoDataSubtitleTrack } from '@project/common';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -58,7 +58,7 @@ interface Props {
     openedFromMiningCommand: boolean;
     onCancel: () => void;
     onOpenFile: () => void;
-    onConfirm: (track: ConfirmedVideoDataSubtitleTrack[], shouldRememberTrackChoices: boolean) => void;
+    onConfirm: (track: VideoDataSubtitleTrack[], shouldRememberTrackChoices: boolean) => void;
 }
 
 export default function VideoDataSyncDialog({
@@ -131,7 +131,7 @@ export default function VideoDataSyncDialog({
     }, [suggestedName, selectedSubtitles, subtitles]);
 
     function handleOkButtonClick() {
-        const selectedSubtitleTracks: ConfirmedVideoDataSubtitleTrack[] = allSelectedSubtitleTracks();
+        const selectedSubtitleTracks: VideoDataSubtitleTrack[] = allSelectedSubtitleTracks();
         onConfirm(selectedSubtitleTracks, shouldRememberTrackChoices);
     }
 
@@ -140,24 +140,24 @@ export default function VideoDataSyncDialog({
     }
 
     function allSelectedSubtitleTracks() {
-        const selectedSubtitleTracks: ConfirmedVideoDataSubtitleTrack[] = selectedSubtitles
-            .map((selected): ConfirmedVideoDataSubtitleTrack | undefined => {
+        const selectedSubtitleTracks: VideoDataSubtitleTrack[] = selectedSubtitles
+            .map((selected): VideoDataSubtitleTrack | undefined => {
                 const subtitle = subtitles.find((subtitle) => subtitle.url === selected);
                 if (subtitle) {
                     const { language, extension, m3U8BaseUrl } = subtitle;
                     return {
-                        name: suggestedName.trim() + language.trim(),
+                        label: suggestedName.trim() + language.trim(),
                         extension: extension,
-                        subtitleUrl: selected,
+                        url: selected,
                         language: language,
                         m3U8BaseUrl: m3U8BaseUrl,
                     };
                 }
             })
-            .filter((track): track is ConfirmedVideoDataSubtitleTrack => track !== undefined);
+            .filter((track): track is VideoDataSubtitleTrack => track !== undefined);
 
         // Give the first track the trimmed name from the name field in case it has been changed by the user
-        selectedSubtitleTracks[0].name = trimmedName;
+        selectedSubtitleTracks[0].label = trimmedName;
 
         return selectedSubtitleTracks;
     }

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -5,7 +5,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import VideoDataSyncDialog from './VideoDataSyncDialog';
 import Bridge from '../bridge';
 import {
-    ConfirmedVideoDataSubtitleTrack,
     Message,
     SerializedSubtitleFile,
     UpdateStateMessage,
@@ -45,7 +44,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
         bridge.sendMessageFromServer({ command: 'cancel' });
     }, [bridge]);
     const handleConfirm = useCallback(
-        (data: ConfirmedVideoDataSubtitleTrack[], shouldRememberTrackChoices: boolean) => {
+        (data: VideoDataSubtitleTrack[], shouldRememberTrackChoices: boolean) => {
             setOpen(false);
             const message: VideoDataUiBridgeConfirmMessage = { command: 'confirm', data, shouldRememberTrackChoices };
             bridge.sendMessageFromServer(message);

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -8,7 +8,7 @@ import {
     Message,
     SerializedSubtitleFile,
     UpdateStateMessage,
-    EmbeddedSubtitle,
+    SubtitleTrack,
     VideoDataUiBridgeConfirmMessage,
     VideoDataUiBridgeOpenFileMessage,
 } from '@project/common';
@@ -28,7 +28,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [suggestedName, setSuggestedName] = useState<string>('');
     const [showSubSelect, setShowSubSelect] = useState<boolean>(true);
-    const [subtitles, setSubtitles] = useState<EmbeddedSubtitle[]>([
+    const [subtitles, setSubtitles] = useState<SubtitleTrack[]>([
         { type: "url", language: '', url: '-', label: t('extension.videoDataSync.emptySubtitleTrack'), extension: 'srt' },
     ]);
     const [selectedSubtitle, setSelectedSubtitle] = useState<string[]>(['-', '-', '-']);
@@ -44,7 +44,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
         bridge.sendMessageFromServer({ command: 'cancel' });
     }, [bridge]);
     const handleConfirm = useCallback(
-        (data: EmbeddedSubtitle[], shouldRememberTrackChoices: boolean) => {
+        (data: SubtitleTrack[], shouldRememberTrackChoices: boolean) => {
             setOpen(false);
             const message: VideoDataUiBridgeConfirmMessage = { command: 'confirm', data, shouldRememberTrackChoices };
             bridge.sendMessageFromServer(message);
@@ -118,13 +118,13 @@ export default function VideoDataSyncUi({ bridge }: Props) {
         if (files && files.length > 0) {
             try {
                 setDisabled(true);
-                const subtitles: SerializedSubtitleFile[] = [];
+                const subtitleFiles: SerializedSubtitleFile[] = [];
 
                 for (let i = 0; i < files.length; ++i) {
                     const f = files[i];
                     const base64 = await bufferToBase64(await f.arrayBuffer());
 
-                    subtitles.push({
+                    subtitleFiles.push({
                         type: "file",
                         name: f.name,
                         base64: base64,
@@ -132,8 +132,9 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                 }
 
                 setOpen(false);
-                const message: VideoDataUiBridgeOpenFileMessage = { command: 'openFile', subtitles };
-                bridge.sendMessageFromServer(message);
+                // setSubtitles([...subtitles, ...subtitleFiles])
+                // const message: VideoDataUiBridgeOpenFileMessage = { command: 'openFile', subtitles };
+                // bridge.sendMessageFromServer(message);
             } finally {
                 setDisabled(false);
             }

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -8,7 +8,7 @@ import {
     Message,
     SerializedSubtitleFile,
     UpdateStateMessage,
-    VideoDataSubtitleTrack,
+    EmbeddedSubtitle,
     VideoDataUiBridgeConfirmMessage,
     VideoDataUiBridgeOpenFileMessage,
 } from '@project/common';
@@ -28,8 +28,8 @@ export default function VideoDataSyncUi({ bridge }: Props) {
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [suggestedName, setSuggestedName] = useState<string>('');
     const [showSubSelect, setShowSubSelect] = useState<boolean>(true);
-    const [subtitles, setSubtitles] = useState<VideoDataSubtitleTrack[]>([
-        { language: '', url: '-', label: t('extension.videoDataSync.emptySubtitleTrack'), extension: 'srt' },
+    const [subtitles, setSubtitles] = useState<EmbeddedSubtitle[]>([
+        { type: "url", language: '', url: '-', label: t('extension.videoDataSync.emptySubtitleTrack'), extension: 'srt' },
     ]);
     const [selectedSubtitle, setSelectedSubtitle] = useState<string[]>(['-', '-', '-']);
     const [defaultCheckboxState, setDefaultCheckboxState] = useState<boolean>(false);
@@ -44,7 +44,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
         bridge.sendMessageFromServer({ command: 'cancel' });
     }, [bridge]);
     const handleConfirm = useCallback(
-        (data: VideoDataSubtitleTrack[], shouldRememberTrackChoices: boolean) => {
+        (data: EmbeddedSubtitle[], shouldRememberTrackChoices: boolean) => {
             setOpen(false);
             const message: VideoDataUiBridgeConfirmMessage = { command: 'confirm', data, shouldRememberTrackChoices };
             bridge.sendMessageFromServer(message);
@@ -125,6 +125,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                     const base64 = await bufferToBase64(await f.arrayBuffer());
 
                     subtitles.push({
+                        type: "file",
                         name: f.name,
                         base64: base64,
                     });


### PR DESCRIPTION
resolves #380 

I'm a big fan of this project, so I decided to pick one of the tickets up to begin contributing to! 

# What
In order to complete this ticket, there needs to be some changes to how we currently process uploaded files. 

### Upload Path
The "Open Files" button runs a function which takes the uploaded file(s) from the input element and sends them to the BE as `SerializedSubtitleFile`. 

### Complete Button Path
The "OK" button takes the selected subtitles, figures out which from ~`Confirmed`~`VideoDataSubtitleTrack[]` are selected, sends them to BE, and the Server will then serialise each one into a `SerializedSubtitleFile`. 

In both cases, we eventually reach a `SerializedSubtitleFile`.
# The ask
The proposal I have to support #380 is to:
- [x] refactor out `ConfirmedVideoDataSubtitleTrack`.
- [ ] modify `handleFileInputChange` to not send the `openFile` message to bridge/server, but instead update `subtitles[]`. That way, users can then select in the dropdown the newly uploaded subtitle files.
- [ ] figure out a way to store the information of uploaded (`SerializedSubtitleFile`) and video-parsed (`VideoDataSubtitleTrack`) subtitles in the `VideoDataUiBridgeConfirmMessage`. Current contenders are typescript union array, or two separate arrays of tuples which maintain order.
- [ ] process the data, keeping the `SerializedSubtitleFile` as-is, but doing the same processing as before for `VideoDataSubtitleTrack`
- [ ] remove the `openFile` message/command to server, as now uploads are handled by `confirm`.

The user flow will look like this instead:
1. user clicks "LOAD SUBTITLES"
2. user clicks "OPEN FILES" in dialogue
3. user selects file(s)
4. user returns to dialogue, and then can use the dropdown to select which parsed subtitle/subtitle file to use for 1st/2nd/3rd. 
5. user clicks OK and this data is sent to server for processing

## Notes:
- I refactor out `ConfirmedVideoDataSubtitleTrack`, as it seems to be a duplicated class providing little utility, so I've merged it into one interface.
- I recognise that the new flow will actually make it slightly slower for people accustomed to just uploading files and expecting it to automatically start. I'm happy to recieve feedback on how to improve this aspect if this is a must.
- This is also not following spec directly, but I think this will solve the original issue, in a slightly different way. Multiple buttons can be done if we think this is better.
