### PR TITLE
add default policy if one doesn't exist

### DIFF
--- a/extension/src/pages/youtube-page.ts
+++ b/extension/src/pages/youtube-page.ts
@@ -22,16 +22,7 @@ if (window.trustedTypes !== undefined) {
     trustedPolicy = window.trustedTypes.createPolicy('passThrough', {
         createHTML: (s: string) => s,
         createScript: (s: string) => s,
-        createScriptURL: (s: string) => s,
     });
-
-    if (window.trustedTypes.defaultPolicy === null) {
-        window.trustedTypes.createPolicy('default', {
-            createHTML: (s: string) => s,
-            createScript: (s: string) => s,
-            createScriptURL: (s: string) => s,
-        });
-    }
 }
 
 document.addEventListener(

--- a/extension/src/pages/youtube-page.ts
+++ b/extension/src/pages/youtube-page.ts
@@ -12,6 +12,8 @@ if (window.trustedTypes !== undefined) {
     // YouTube doesn't define a default policy
     // we create a default policy to avoid errors that seem to be caused by chrome not supporting trustedScripts in Function sinks
     // If YT enforce a strict default policy in the future, we may need to revisit this
+    // hopefully by then chrome will have fixed the issue: https://wpt.fyi/results/trusted-types/eval-function-constructor.html
+    // (in chrome 127 the final test was failing)
     if (window.trustedTypes.defaultPolicy === null) {
         window.trustedTypes.createPolicy('default', {
             createHTML: (s: string) => s,

--- a/extension/src/pages/youtube-page.ts
+++ b/extension/src/pages/youtube-page.ts
@@ -9,6 +9,16 @@ declare global {
 let trustedPolicy: any = undefined;
 
 if (window.trustedTypes !== undefined) {
+    // YouTube doesn't define a default policy
+    // we create a default policy to avoid errors that seem to be caused by chrome not supporting trustedScripts in Function sinks
+    // If YT enforce a strict default policy in the future, we may need to revisit this
+    if (window.trustedTypes.defaultPolicy === null) {
+        window.trustedTypes.createPolicy('default', {
+            createHTML: (s: string) => s,
+            createScript: (s: string) => s,
+            createScriptURL: (s: string) => s,
+        });
+    }
     trustedPolicy = window.trustedTypes.createPolicy('passThrough', {
         createHTML: (s: string) => s,
         createScript: (s: string) => s,


### PR DESCRIPTION
This seems to fix the issue reported on discord

I don't know if this is a chrome bug or something else
It seems without the default policy that chrome is treating the trustedScript as a string
would be nice to know why
With the default policy added, then the default policy is used

