### PR TITLE
WIP: Add Jellyfin support

### DIFF
--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -108,6 +108,7 @@
                 "pages/viki-page.js",
                 "pages/unext-page.js",
                 "pages/emby-page.js",
+                "pages/jellyfin-page.js",
                 "pages/osnplus-page.js",
                 "pages/bilibili-page.js",
                 "pages/nrk-tv-page.js",

--- a/extension/src/pages.json
+++ b/extension/src/pages.json
@@ -91,6 +91,14 @@
             }
         },
         {
+            "host": "jellyfin*|:8096*",
+            "script": "jellyfin-page.js",
+            "hash": "#/video",
+            "autoSync": {
+                "enabled": true
+            }
+        },
+        {
             "host": "emby*|:8096*",
             "script": "emby-page.js",
             "hash": "#!/videoosd/videoosd.html",

--- a/extension/src/pages/jellyfin-page.ts
+++ b/extension/src/pages/jellyfin-page.ts
@@ -1,0 +1,80 @@
+import { VideoDataSubtitleTrack } from '@project/common';
+import { VideoData } from '@project/common';
+import { trackFromDef } from './util';
+
+declare const ApiClient: any | undefined;
+
+document.addEventListener(
+    'asbplayer-get-synced-data',
+    async () => {
+        const response: VideoData = { error: '', basename: '', subtitles: [] };
+        if (!ApiClient) {
+            response.error = 'ApiClient is undefined';
+            return document.dispatchEvent(
+                new CustomEvent('asbplayer-synced-data', {
+                    detail: response,
+                }),
+            );
+        }
+
+        const deviceID = ApiClient?._deviceId;
+        const apikey = ApiClient?._serverInfo.AccessToken;
+
+        let session;
+        for (let attempt = 0; attempt < 5; attempt++) {
+            const sessions = await ApiClient.getSessions({ deviceId: deviceID });
+            session = sessions[0];
+            if (session.PlayState.MediaSourceId) {
+                break;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+
+        if (!session || !session.PlayState.MediaSourceId) {
+            response.error = 'Failed to retrieve a valid MediaSourceId after 5 attempts';
+            return document.dispatchEvent(
+                new CustomEvent('asbplayer-synced-data', {
+                    detail: response,
+                }),
+            );
+        }
+
+        const mediaID = session.PlayState.MediaSourceId;
+        const nowPlayingItem = session.NowPlayingItem;
+        response.basename = nowPlayingItem.Name;
+
+        const subtitles: VideoDataSubtitleTrack[] = [];
+        nowPlayingItem.MediaStreams.filter(
+            (stream: { IsTextSubtitleStream: any }) => stream.IsTextSubtitleStream,
+        ).forEach((sub: { DisplayTitle: any; Language: any; Index: number; Codec: string; Path: string }) => {
+            const extension = sub.Path ? sub.Path.split('.').pop() : sub.Codec;
+            var url =
+                '/Videos/' +
+                nowPlayingItem.Id +
+                '/' +
+                mediaID +
+                '/Subtitles/' +
+                sub.Index +
+                '/0/Stream.' +
+                extension +
+                '?api_key=' +
+                apikey;
+            subtitles.push(
+                trackFromDef({
+                    label: sub.DisplayTitle,
+                    language: sub.Language || '',
+                    url: url,
+                    extension,
+                }),
+            );
+        });
+        response.subtitles = subtitles;
+
+        document.dispatchEvent(
+            new CustomEvent('asbplayer-synced-data', {
+                detail: response,
+            }),
+        );
+    },
+    false,
+);


### PR DESCRIPTION
Closes https://github.com/killergerbah/asbplayer/issues/442

The API itself is very similar to Emby, with minor changes to `ApiClient`.

TODO:
- When the subtitle selection dialog is opened before subtitles are loaded, entries will have a spinner until you re-open the dialog
- Auto-pause works, but auto-play doesn't. Video element detection seems to work (because pause works), but hover event listener does not.
- Subtitles are hovering on top of media progress and controls bar <img width="1036" alt="image" src="https://github.com/user-attachments/assets/387b2ece-e2cb-4357-ba77-1a73df71dfdb">
- Jellyfin `pages.json` entry shouldn't conflict with Emby, because `hash` is different, but I didn't test it.
- I did a hacky timeout with five retries to fetch the subtitles, but I'm not sure if that's the best way to do it. I see that `netflix-page.ts` has the same approach.

Other than that, it works pretty well 🙂
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/21a2f820-47fc-41ee-8eac-b369d7aae672">
