### PR TITLE
use 'v' flag for regex subtitle parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Useful examples of regular expressions:
 -   `(.*)\n+(?!-)(.*)` : Some subtitles are split in several lines and this regex forces them into a single line. For this filter to work, you must also put `$1 $2` in the "Subtitle regex filter text replacement" field.
     -   **NB**: When using this regex pattern in combination with other patterns (using the `|` operator, see below), place this pattern at the end. This ensures that all other regex transformations are applied first, and then the results are finally combined into a single line.
 -   `-?\[.*\]` : Remove indications enclosed by square brackets that sound or music that is playing (e.g. "**\[PLAYFUL MUSIC]**" or "**\-[GASPS]**")
-    -   `^[-\(\)\.\sA-ZAÂÃÀÇÉÊÍÓÔÕÚÑ]+$` : As an alternative to the above, filter out descriptions written in capital letters, but without the square brackets (e.g. "**PLAYFUL MUSIC**"). If your language has additional letters with diacritics, you feel free to add them to this list.
+    -   `^[\-\(\)\.\s\p{Lu}]+$` : As an alternative to the above, filter out descriptions written in capital letters, but without the square brackets (e.g. "**PLAYFUL MUSIC**"). If your language has additional letters with diacritics, you feel free to add them to this list.
 -   `[♪♬#～〜]+` : Any combination of symbols on their own that represent playing music (e.g. `♪♬♪`)
 
 Regular expressions can be combined with the character `|` (no spaces needed inbetween). E.g., if you want to use the 2 last regexes from this list, you can use `-?\[.*\]|[♪♬#～〜]+`. You can combine as many regexes as you wish this way.

--- a/common/subtitle-reader/subtitle-reader.ts
+++ b/common/subtitle-reader/subtitle-reader.ts
@@ -38,7 +38,7 @@ export default class SubtitleReader {
         let regex: RegExp | undefined;
 
         try {
-            regex = regexFilter.trim() === '' ? undefined : new RegExp(regexFilter, 'g');
+            regex = regexFilter.trim() === '' ? undefined : new RegExp(regexFilter, 'gv');
         } catch (e) {
             regex = undefined;
         }


### PR DESCRIPTION
We've had a brief discussion about this on discord, so I just wanted to create this so it won't be totally forgotten.

My current regex looks like this `^[#\-\(\.\)\s\p{Lu}]+$|-?\[.+\]|[♪♬#～〜]+|(.*)\n+(?!(?:[\p{L}\s]+:\s*)?-)(.*)`, which is the combination of several existing regexes from the Readme file. I've been running this flag for 3+ months now and haven't noticed any issues