### PR TITLE
fix(subtitle-reader): Handle a file with an extension .subrip as with .srt

### DIFF
--- a/common/subtitle-reader/subtitle-reader.ts
+++ b/common/subtitle-reader/subtitle-reader.ts
@@ -60,7 +60,7 @@ export default class SubtitleReader {
     }
 
     async _subtitles(file: File, track: number): Promise<SubtitleNode[]> {
-        if (file.name.endsWith('.srt')) {
+    if (file.name.endsWith('.srt') || file.name.endsWith('.subrip')) {
             const parser = new SrtParser({ numericTimestamps: true });
             const nodes = parser.fromSrt(await file.text());
             return nodes.map((node) => {


### PR DESCRIPTION
I downloaded a video from a torrent, and opened it in jelly, for some reason, when I wanted fetch  subtitle track, I  get the error "Unsupported subtitle format", I opened debug and saw that the file format was ".subrip" for some reason, so I added handling for this case as well
![image](https://github.com/user-attachments/assets/1759f843-f33c-44fa-89cc-af3ad376f1f3)
