### PR TITLE
fix: Building extension script in directories with spaces

### DIFF
--- a/common/audio-clip/mp3-encoder.ts
+++ b/common/audio-clip/mp3-encoder.ts
@@ -19,7 +19,7 @@ export default class Mp3Encoder {
                     }
 
                     const audioBuffer = await audioContext.decodeAudioData(e.target.result as ArrayBuffer);
-                    const channels = [];
+                    const channels: Float32Array[] = [];
 
                     for (let i = 0; i < audioBuffer.numberOfChannels; ++i) {
                         channels.push(audioBuffer.getChannelData(i));

--- a/scripts/package
+++ b/scripts/package
@@ -15,7 +15,7 @@ PLATFORM=$1
 SCRIPTPATH="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
 DISTPATH=$SCRIPTPATH/../extension/dist/$PLATFORM
 
-pushd $DISTPATH
+pushd "$DISTPATH"
 
 NAME="asbplayer-extension-$(jq -r .version manifest.json)-$PLATFORM.zip"
 


### PR DESCRIPTION
The current build script doesn't account for directories with spaces due to how `pwd` doesn't escape space characters returned and how the `pushd` command accepts arguments. Simple fix is to quote the arg.

Also just added a random lint fix that I ran into when peeking around the codebase lol.