### PR TITLE
Add Machine Translated Subtitles to YouTube

### DIFF
--- a/extension/src/pages/youtube-page.ts
+++ b/extension/src/pages/youtube-page.ts
@@ -45,19 +45,22 @@ const appendTranslatedTracks = (tracks: any, tlang: string) => {
     for (const track of tracks) {
         // Ignore subtitles that are already in the target language
         if (track.languageCode !== tlang) {
-            const translatedTrack = { 
+            const translatedTrack = {
                 ...track,
-                languageCode:`${track.languageCode} >> ${tlang}`,
-                baseUrl: `${track.baseUrl}&tlang=${tlang}` // YouTube API param for translation
+                name: {
+                    simpleText: `${track.name?.simpleText} >> ${tlang}`,
+                    runs: track.name?.runs?.map((run: any) => ({ ...run, text: `${run.text} >> ${tlang}` })),
+                },
+                languageCode: tlang,
+                baseUrl: `${track.baseUrl}&tlang=${tlang}`, // YouTube API param for translation
             };
 
             translatedTracks.push(translatedTrack);
         }
     }
-    
 
     return translatedTracks;
-}
+};
 
 document.addEventListener(
     'asbplayer-get-synced-data',
@@ -111,9 +114,10 @@ document.addEventListener(
             }
 
             response.basename = playerContext.videoDetails?.title || document.title;
-            response.subtitles = appendTranslatedTracks(playerContext?.captions?.playerCaptionsTracklistRenderer?.captionTracks || [], TLANG).map(
-                adaptYtTrack
-            );
+            response.subtitles = appendTranslatedTracks(
+                playerContext?.captions?.playerCaptionsTracklistRenderer?.captionTracks || [],
+                TLANG
+            ).map(adaptYtTrack);
         } catch (error) {
             if (error instanceof Error) {
                 response.error = error.message;


### PR DESCRIPTION
Implementation of #460 and #521

By adding `&tlang=LANG_CODE` after `track.baseUrl`, we can get machine translated subtitles for the videos.

This PR is not yet complete. I will continue to work on it.

TODO:

- [x] Get machine translated subtitles
- [ ] Select target language
  - [ ] Language selection in settings UI (or depending on settings/YouTube language?)
  - [ ] Pass language into `youtube-page.ts`

Preview:
![image](https://github.com/user-attachments/assets/c002ed22-5023-48e1-818b-267e7c8a3bea)
![image](https://github.com/user-attachments/assets/fde9c1e1-d3a0-40e7-b104-b065b8cc5813)

