### PR TITLE
App.tsx: support .m4v media files

### DIFF
--- a/common/app/components/App.tsx
+++ b/common/app/components/App.tsx
@@ -112,6 +112,7 @@ function extractSources(files: FileList | File[]): MediaSources {
                 break;
             case 'mkv':
             case 'mp4':
+            case 'm4v':
             case 'avi':
             case 'webm':
                 if (videoFile) {
@@ -1314,7 +1315,7 @@ function App({
                             ref={fileInputRef}
                             onChange={handleFileInputChange}
                             type="file"
-                            accept=".srt,.ass,.vtt,.sup,.mp3,.m4a,.aac,.flac,.ogg,.wav,.opus,.mkv,.mp4,.avi"
+                            accept=".srt,.ass,.vtt,.sup,.mp3,.m4a,.aac,.flac,.ogg,.wav,.opus,.mkv,.mp4,.avi,.m4v"
                             multiple
                             hidden
                         />


### PR DESCRIPTION
m4v is the same as an mp4 basically. 
Renaming the file to mp4 and loading it in works, but is annoying.

(To avoid this)
![image](https://github.com/user-attachments/assets/3ff7f9fa-731d-4fd2-8972-d147339e9eb9)
