### PR TITLE
Fix Jellyfin Subtitles

### DIFF
--- a/extension/src/pages/emby-jellyfin-page.ts
+++ b/extension/src/pages/emby-jellyfin-page.ts
@@ -46,7 +46,7 @@ document.addEventListener(
         nowPlayingItem.MediaStreams.filter(
             (stream: { IsTextSubtitleStream: any }) => stream.IsTextSubtitleStream
         ).forEach((sub: { Codec: string; DisplayTitle: any; Language: any; Index: number; Path: string }) => {
-            const extension = sub.Path ? sub.Path.split('.').pop()! : sub.Codec;
+            const extension = 'srt';
             var url =
                 '/Videos/' + nowPlayingItem.Id + '/' + mediaID + '/Subtitles/' + sub.Index + '/Stream.' + extension;
             subtitles.push(


### PR DESCRIPTION
For some subtitle types like `.mov_text` Jellyfin will return an error bad request. Luckily we can just request `.srt` and Jellyfin will produce one, even if the subtitle wasn't originally `.srt`. Not sure if it works with all types of subs though, might need some testing.