### PR TITLE
Websocket - Sync timestamp command

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ See the proxy's [example configuration file](https://github.com/killergerbah/asb
 
 #### WebSocket interface
 
-The asbplayer website can be controlled remotely through a WebSocket connection, which enables [one-click mining flows](#one-click-mining-flow) with the right setup. Currently asbplayer responds to two types of payloads:
+The asbplayer website can be controlled remotely through a WebSocket connection, which enables [one-click mining flows](#one-click-mining-flow) with the right setup. Currently asbplayer responds to three types of payloads:
 
 -   `mine-subtitle` request:
 
@@ -350,6 +350,31 @@ The asbplayer website can be controlled remotely through a WebSocket connection,
         "command": "response",
         // Same message ID received in request
         "messageId": "3565510c-342f-4cec-ad2e-dee81af88d75",
+        "body": {}
+    }
+    ```
+
+-   `seek-timestamp` request:
+
+    ```javascript
+    {
+        "command": "seek-timestamp",
+        // Message ID to correlate with asbplayer's response
+        "messageId": "6e4b2d8f-3a1c-4d9e-8f7b-2c0a9d5e1f3b",
+        "body": {
+            //The timestamp to seek in seconds
+            "timestamp": 30.5,
+        }
+    }
+    ```
+
+    `seek-timestamp` response:
+
+    ```javascript
+    {
+        "command": "response",
+        // Same message ID received in request
+        "messageId": "6e4b2d8f-3a1c-4d9e-8f7b-2c0a9d5e1f3b",
         "body": {}
     }
     ```

--- a/common/web-socket-client/web-socket-client.ts
+++ b/common/web-socket-client/web-socket-client.ts
@@ -32,8 +32,8 @@ export interface LoadSubtitlesCommand {
     };
 }
 
-export interface SyncTimestampCommand {
-    command: 'sync-timestamp';
+export interface SeekTimestampCommand {
+    command: 'seek-timestamp';
     messageId: string;
     body: {
         timestamp: number;
@@ -49,7 +49,7 @@ export class WebSocketClient {
     private _connectPromise?: { resolve: (value: unknown) => void; reject: (error: any) => void };
     onMineSubtitle?: (command: MineSubtitleCommand) => Promise<boolean>;
     onLoadSubtitles?: (command: LoadSubtitlesCommand) => Promise<void>;
-    onSyncTimestamp?: (command: SyncTimestampCommand) => Promise<void>;
+    onSeekTimestamp?: (command: SeekTimestampCommand) => Promise<void>;
 
     get socket() {
         return this._socket;
@@ -118,9 +118,9 @@ export class WebSocketClient {
                             body: {},
                         };
                         this._socket?.send(JSON.stringify(response));
-                    } else if (payload.command === 'sync-timestamp') {
+                    } else if (payload.command === 'seek-timestamp') {
                         const messageId = payload.messageId;
-                        await this.onSyncTimestamp?.(payload);
+                        await this.onSeekTimestamp?.(payload);
                         const response: Response<{}> = {
                             command: 'response',
                             messageId,
@@ -194,7 +194,7 @@ export class WebSocketClient {
         this._connectPromise?.reject('Disconnecting');
         this._connectPromise = undefined;
         this.onMineSubtitle = undefined;
-        this.onSyncTimestamp = undefined;
+        this.onSeekTimestamp = undefined;
         this.onLoadSubtitles = undefined;
     }
 }

--- a/extension/src/services/web-socket-client-binding.ts
+++ b/extension/src/services/web-socket-client-binding.ts
@@ -1,5 +1,5 @@
 import { SettingsProvider, ankiSettingsKeys } from '@project/common/settings';
-import { LoadSubtitlesCommand, MineSubtitleCommand, SyncTimestampCommand, WebSocketClient } from '@project/common/web-socket-client';
+import { LoadSubtitlesCommand, MineSubtitleCommand, SeekTimestampCommand, WebSocketClient } from '@project/common/web-socket-client';
 import TabRegistry from './tab-registry';
 import {
     CurrentTimeToVideoMessage,
@@ -125,7 +125,7 @@ export const bindWebSocketClient = async (settings: SettingsProvider, tabRegistr
             return toggleVideoSelectCommand;
         });
     };
-    client.onSyncTimestamp = async ({ body: { timestamp } }: SyncTimestampCommand) => {
+    client.onSeekTimestamp = async ({ body: { timestamp } }: SeekTimestampCommand) => {
         return new Promise<void>((resolve) => {
             // Publish the command to all active video elements
             tabRegistry.publishCommandToVideoElements((videoElement) => {

--- a/extension/src/services/web-socket-client-binding.ts
+++ b/extension/src/services/web-socket-client-binding.ts
@@ -1,5 +1,10 @@
 import { SettingsProvider, ankiSettingsKeys } from '@project/common/settings';
-import { LoadSubtitlesCommand, MineSubtitleCommand, SeekTimestampCommand, WebSocketClient } from '@project/common/web-socket-client';
+import {
+    LoadSubtitlesCommand,
+    MineSubtitleCommand,
+    SeekTimestampCommand,
+    WebSocketClient,
+} from '@project/common/web-socket-client';
 import TabRegistry from './tab-registry';
 import {
     CurrentTimeToVideoMessage,
@@ -135,7 +140,7 @@ export const bindWebSocketClient = async (settings: SettingsProvider, tabRegistr
                         command: 'currentTime',
                         value: timestamp,
                     },
-                    src: videoElement.src
+                    src: videoElement.src,
                 };
             });
 


### PR DESCRIPTION
This adds a new WebSocket command to sync to a specific timestamp in the video. I’ve tested it locally in Chrome and followed the `load-subtitles` implementation to keep it consistent with existing code.

I’m building a vocabulary mining program that scans subtitles to find words and phrases you haven’t mined yet. This feature makes it convenient—users can click a timestamp in the program and jump straight to that spot in the video to mine it with asbplayer. I’m sure other projects could find this useful too.



