### PR TITLE
Add clipboardWrite permission to Firefox manifest

### DIFF
--- a/extension/build.mts
+++ b/extension/build.mts
@@ -15,7 +15,7 @@ const manifestModifiedForFirefoxAndroid = (manifest) => {
     delete manifest['commands'];
     return {
         ...manifestModifiedForFirefox(manifest),
-        permissions: ['tabs', 'storage', 'webRequest', 'webRequestBlocking'],
+        permissions: ['tabs', 'storage', 'webRequest', 'webRequestBlocking', 'clipboardWrite'],
         browser_specific_settings: {
             gecko: {
                 id: '{49de9206-c73e-4829-be4d-bda770d7f4b5}',
@@ -32,7 +32,7 @@ const manifestModifiedForFirefox = (manifest) => {
     return {
         ...manifest,
         host_permissions: ['<all_urls>'],
-        permissions: ['tabs', 'storage', 'contextMenus', 'webRequest', 'webRequestBlocking'],
+        permissions: ['tabs', 'storage', 'contextMenus', 'webRequest', 'webRequestBlocking', 'clipboardWrite'],
         background: {
             scripts: ['background.js'],
             type: 'module',


### PR DESCRIPTION
Firefox needs this permission to continue to allow it to copy to the clipboard (as long as the doc is still focused in this case). Other wise it defaults to only allowing it if there was user interaction in the last few seconds. Seems like Chrome doesn't need it so I didn't add it to the base manifest for now.