### PR TITLE
Paint subtitle stroke behind text fill

### DIFF
--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -275,6 +275,7 @@ export function computeStyles({
         const thickness = subtitleOutlineThickness;
         const color = subtitleOutlineColor;
         styles['WebkitTextStroke'] = `${color} ${thickness}px`;
+        styles['paintOrder'] = `stroke fill`;
     }
 
     if (subtitleShadowThickness > 0) {


### PR DESCRIPTION
Currently subtitle outlines cause the text itself to be overdrawn. This limits the outline thickness one can select before the text becomes unreadable. It is possible to increase the font thickness to remedy this issue a bit, but the result can look odd and requires weird balancing between the two options.

<img width="929" alt="Screenshot 2025-05-26 at 19 51 48" src="https://github.com/user-attachments/assets/6a35d54b-b12d-485d-b397-fc066688bb3e" />

This PR forces the outline to be drawn behind the text itself, making all text outline and text thickness combinations work well without any issues.

<img width="929" alt="Screenshot 2025-05-26 at 19 51 30" src="https://github.com/user-attachments/assets/72132e4d-64ce-49c5-9b5e-94ea8c32de0d" />

The `paint-order` css property went baseline last year so using it should be fine.