### PR TITLE
Improved Naming scheme for video in Emby/Jellyfin

### DIFF
--- a/extension/src/entrypoints/emby-jellyfin-page.ts
+++ b/extension/src/entrypoints/emby-jellyfin-page.ts
@@ -41,7 +41,7 @@ export default defineUnlistedScript(() => {
             const mediaID = session.PlayState.MediaSourceId;
             const nowPlayingItem = session.NowPlayingItem;
             const path = nowPlayingItem.Path;
-            response.basename = path ? path.split(/[\\/]/).pop() : (nowPlayingItem.FileName ?? nowPlayingItem.Name);
+            response.basename = nowPlayingItem.FileName ?? (path ? path.split(/[\\/]/).pop() : nowPlayingItem.Name);
 
             const subtitles: VideoDataSubtitleTrack[] = [];
             nowPlayingItem.MediaStreams.filter(

--- a/extension/src/entrypoints/emby-jellyfin-page.ts
+++ b/extension/src/entrypoints/emby-jellyfin-page.ts
@@ -39,9 +39,10 @@ export default defineUnlistedScript(() => {
                 );
             }
 
-            var mediaID = session.PlayState.MediaSourceId;
-            var nowPlayingItem = session.NowPlayingItem;
-            response.basename = nowPlayingItem.FileName ?? nowPlayingItem.Name;
+            const mediaID = session.PlayState.MediaSourceId;
+            const nowPlayingItem = session.NowPlayingItem;
+            response.basename =
+                `${nowPlayingItem.SeriesName} - S${nowPlayingItem.ParentIndexNumber}E${nowPlayingItem.IndexNumber} - ${nowPlayingItem.Name} - ${nowPlayingItem.Id}`.trim();
 
             const subtitles: VideoDataSubtitleTrack[] = [];
             nowPlayingItem.MediaStreams.filter(

--- a/extension/src/entrypoints/emby-jellyfin-page.ts
+++ b/extension/src/entrypoints/emby-jellyfin-page.ts
@@ -1,5 +1,4 @@
-import { VideoDataSubtitleTrack } from '@project/common';
-import { VideoData } from '@project/common';
+import { VideoData, VideoDataSubtitleTrack } from '@project/common';
 import { trackFromDef } from '@/pages/util';
 
 declare const ApiClient: any | undefined;
@@ -41,8 +40,8 @@ export default defineUnlistedScript(() => {
 
             const mediaID = session.PlayState.MediaSourceId;
             const nowPlayingItem = session.NowPlayingItem;
-            response.basename =
-                `${nowPlayingItem.SeriesName} - S${nowPlayingItem.ParentIndexNumber}E${nowPlayingItem.IndexNumber} - ${nowPlayingItem.Name} - ${nowPlayingItem.Id}`.trim();
+            const path = nowPlayingItem.Path;
+            response.basename = path ? path.split(/[\\/]/).pop() : (nowPlayingItem.FileName ?? nowPlayingItem.Name);
 
             const subtitles: VideoDataSubtitleTrack[] = [];
             nowPlayingItem.MediaStreams.filter(


### PR DESCRIPTION
Unify and improve the the naming scheme for the "Video Name" in both Emby and Jellyfin. This will result in more consistent naming between the two and provide a lot more useful information for jellyfin folk.

Before and After JF:
![chrome_Otxp2BrRrs](https://github.com/user-attachments/assets/a6ea7397-f08d-4add-88e3-f310e3c57198)


Before and After Emby:
![chrome_X5RX2HU1Xm](https://github.com/user-attachments/assets/ed55784b-1f75-410f-8f1c-93be2853f18d)
