### PR TITLE
Stremio Support {Rough} 

### DIFF
--- a/extension/src/entrypoints/stremio-page.ts
+++ b/extension/src/entrypoints/stremio-page.ts
@@ -1,0 +1,72 @@
+import {
+    VideoData,
+    VideoDataSubtitleTrack
+} from '@project/common';
+import {
+    trackFromDef
+} from '@/pages/util';
+
+export default defineUnlistedScript(() => {
+    const discoveredSubtitles = new Map < string, VideoDataSubtitleTrack > ();
+    let trackIndex = 1;
+
+    const dispatchSubtitles = () => {
+        const response = {
+            error: '',
+            basename: document.title,
+            subtitles: Array.from(discoveredSubtitles.values()),
+        };
+
+        document.dispatchEvent(
+            new CustomEvent('asbplayer-synced-data', {
+                detail: response,
+            })
+        );
+    };
+
+    const originalFetch = window.fetch;
+    window.fetch = async (...args) => {
+        const url = typeof args[0] === 'string' ?
+            args[0] :
+            args[0] instanceof Request ?
+            args[0].url :
+            null;
+
+        if (url) {
+            const stremioSubtitleMatch = url.match(/https:\/\/subs\d+\.strem\.io\/.+\/file\/\d+/);
+            const opensubtitlesMatch = url.match(/https:\/\/opensubtitles\.stremio\.homes\/sub\.vtt/);
+            //const babyBeamupMatch = url.match(/https:\/\/.*baby-beamup\.club\/subtitle\/sub\.vtt/);
+            
+            let extension = null;
+            if (stremioSubtitleMatch) {
+                extension = 'srt';
+            } else if (opensubtitlesMatch) {
+                extension = 'vtt';
+            }
+            
+            if (extension) {
+                if (!discoveredSubtitles.has(url)) {
+                    const track = trackFromDef({
+                        label: `Stremio ${trackIndex++}`,
+                        language: '',
+                        url: url,
+                        extension: extension,
+                    });
+                    discoveredSubtitles.set(url, track);
+
+                    dispatchSubtitles();
+                }
+            }
+        }
+
+        return originalFetch(...args);
+    };
+
+    document.addEventListener(
+        'asbplayer-get-synced-data',
+        async () => {
+            dispatchSubtitles();
+        },
+        false
+    );
+});

--- a/extension/src/pages.json
+++ b/extension/src/pages.json
@@ -149,6 +149,14 @@
             "autoSync": {
                 "enabled": true
             }
+        },
+        {
+            "host": "web.stremio.com",
+            "script": "stremio-page.js",
+            "path": ".*",
+            "autoSync": {
+             "enabled": true
+          }
         }
     ]
 }

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
                         'icon/image.png',
                         'netflix-page.js',
                         'youtube-page.js',
+                        'stremio-page.js',
                         'tver-page.js',
                         'bandai-channel-page.js',
                         'amazon-prime-page.js',


### PR DESCRIPTION
A rough, initial start for Stremio Support. 

Subtitles MUST be enabled first on the site, before ASB will recognize them. (This is unavoidable AFAIK)
Subtitles are named ``Subtitle 1 -> Subtitle 2`` and so on, as Stremio subs have same/no names... 

Known Errors:
- Certain Subtitle Sources Fail 
- Subtitles duplicate sometimes

Solves issue #716 