### PR TITLE
Missing Jellyfin server name in subtitles URL for Firefox browsers

### DIFF
--- a/extension/src/entrypoints/emby-jellyfin-page.ts
+++ b/extension/src/entrypoints/emby-jellyfin-page.ts
@@ -49,7 +49,7 @@ export default defineUnlistedScript(() => {
             ).forEach((sub: { Codec: string; DisplayTitle: any; Language: any; Index: number; Path: string }) => {
                 const extension = 'srt';
                 var url =
-                    '/Videos/' + nowPlayingItem.Id + '/' + mediaID + '/Subtitles/' + sub.Index + '/Stream.' + extension;
+                    window.location.origin + '/Videos/' + nowPlayingItem.Id + '/' + mediaID + '/Subtitles/' + sub.Index + '/Stream.' + extension;
                 subtitles.push(
                     trackFromDef({
                         label: sub.DisplayTitle,


### PR DESCRIPTION
The Jellyfin server name was missing from the URL when fetching for subtitles, would cause the loading of the subtitles to fail, only on Firefox based browsers.

Mainly fixes #745 