### PR TITLE
Implement bulk export

### DIFF
--- a/common/app/components/BulkExportModal.tsx
+++ b/common/app/components/BulkExportModal.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import LinearProgress from '@mui/material/LinearProgress';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+
+interface BulkExportModalProps {
+    open: boolean;
+    currentIndex: number; // completed count
+    totalItems: number;   // total count
+    onCancel: () => void;
+}
+
+export default function BulkExportModal({ open, currentIndex, totalItems, onCancel }: BulkExportModalProps) {
+    const { t } = useTranslation();
+    const progress = totalItems > 0 ? (currentIndex / totalItems) * 100 : 0;
+    return (
+        <Dialog
+            open={open}
+            onClose={(event, reason) => {
+                if (reason === 'backdropClick' || reason === 'escapeKeyDown') return;
+                onCancel();
+            }}
+            fullWidth
+            maxWidth="sm"
+            aria-labelledby="bulk-export-title"
+            aria-describedby="bulk-export-description"
+            disableEscapeKeyDown
+            sx={{
+                '& .MuiDialog-paper': {
+                    bgcolor: 'background.default',
+                },
+            }}
+            BackdropProps={{ sx: { backgroundColor: 'rgba(0, 0, 0, 1)' } }}
+        >
+            <DialogTitle id="bulk-export-title">
+                {t('info.bulkExport.title', 'Bulk Export in Progress')}
+            </DialogTitle>
+            <DialogContent dividers>
+                <Box display="flex" alignItems="center" justifyContent="center" mb={3}>
+                    <CircularProgress size={64} color="primary" />
+                </Box>
+                <Typography id="bulk-export-description" variant="body1" align="center" gutterBottom>
+                    {t('info.bulkExport.description', 'Exporting subtitles to Anki. Please wait...')}
+                </Typography>
+                <Box width="100%" mt={3}>
+                    <Typography variant="h6" align="center" gutterBottom>
+                        {t('info.bulkExport.progressCompleted', 'Exported {{current}} of {{total}}', { current: currentIndex, total: totalItems })}
+                    </Typography>
+                    <LinearProgress
+                        variant="determinate"
+                        value={progress}
+                        sx={{ height: 10, borderRadius: 5 }}
+                    />
+                </Box>
+            </DialogContent>
+            <DialogActions sx={{ justifyContent: 'center' }}>
+                <Button onClick={onCancel} variant="outlined" color="primary" data-testid="bulk-export-cancel-button">
+                    {t('action.cancel', 'Cancel')}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/common/app/components/Player.tsx
+++ b/common/app/components/Player.tsx
@@ -1075,6 +1075,7 @@ const Player = React.memo(function Player({
                         settings={settings}
                         keyBinder={keyBinder}
                         webSocketClient={webSocketClient}
+                        exporting={miningContext.bulkExporting}
                     />
                 </Grid>
             </Grid>

--- a/common/app/components/SubtitlePlayer.tsx
+++ b/common/app/components/SubtitlePlayer.tsx
@@ -364,6 +364,7 @@ interface SubtitlePlayerProps {
     keyBinder: KeyBinder;
     maxResizeWidth: number;
     webSocketClient?: WebSocketClient;
+    exporting: boolean;
 }
 
 export default function SubtitlePlayer({

--- a/common/app/services/mining-context.ts
+++ b/common/app/services/mining-context.ts
@@ -1,15 +1,70 @@
-type MiningEvent = 'started-mining' | 'stopped-mining';
+type MiningEvent =
+    | 'started-mining'
+    | 'stopped-mining'
+    | 'bulk-export-started'
+    | 'bulk-export-completed'
+    | 'bulk-export-item-completed'
+    | 'bulk-export-cancelled';
 type Callback = () => void;
+
+export interface BulkExportItem {
+    subtitle: import('../../src/model').SubtitleModel;
+    index: number;
+}
 
 export class MiningContext {
     private readonly _callbacks: { [event in MiningEvent]: Callback[] } = {
         'started-mining': [],
         'stopped-mining': [],
+        'bulk-export-started': [],
+        'bulk-export-completed': [],
+        'bulk-export-item-completed': [],
+        'bulk-export-cancelled': [],
     };
     private _mining = false;
+    private _bulkExporting = false;
+    private _bulkExportCancelled = false;
+    private _bulkExportQueue: BulkExportItem[] = [];
+    private _currentBulkExportIndex = 0;
 
     get mining() {
         return this._mining;
+    }
+
+    get bulkExporting() {
+        return this._bulkExporting;
+    }
+
+    get bulkExportCancelled() {
+        return this._bulkExportCancelled;
+    }
+
+    get bulkExportQueue() {
+        return this._bulkExportQueue;
+    }
+
+    get currentBulkExportIndex() {
+        return this._currentBulkExportIndex;
+    }
+
+    isBulkExportCancelled() {
+        return this._bulkExportCancelled;
+    }
+
+    get bulkExportProgress() {
+        if (!this._bulkExporting || this._bulkExportQueue.length === 0) {
+            return { current: 0, total: 0, remaining: 0 };
+        }
+        
+        const totalRemaining = this._bulkExportQueue.length;
+        const currentProgress = this._currentBulkExportIndex;
+        const remaining = Math.max(0, totalRemaining - currentProgress);
+        
+        return {
+            current: currentProgress,
+            total: totalRemaining,
+            remaining: remaining
+        };
     }
 
     onEvent(event: MiningEvent, callback: Callback) {
@@ -26,6 +81,52 @@ export class MiningContext {
         this._mining = false;
         this._callbacks['stopped-mining'].forEach((c) => c());
     }
+
+    startBulkExport(items: BulkExportItem[], startIndex: number = 0) {
+        this._bulkExporting = true;
+        this._bulkExportCancelled = false;
+        this._bulkExportQueue = startIndex > 0 ? items.slice(startIndex) : items;
+        this._currentBulkExportIndex = 0;
+        
+        this._callbacks['bulk-export-started'].forEach((c) => c());
+    }
+
+    completeBulkExportItem() {
+        this._currentBulkExportIndex++;
+        
+        this._callbacks['bulk-export-item-completed'].forEach((c) => c());
+        
+        if (this._currentBulkExportIndex >= this._bulkExportQueue.length) {
+            this.completeBulkExport();
+        }
+    }
+
+    completeBulkExport() {
+        this._bulkExporting = false;
+        this._bulkExportCancelled = false;
+        this._bulkExportQueue = [];
+        this._currentBulkExportIndex = 0;
+        this._callbacks['bulk-export-completed'].forEach((c) => c());
+    }
+
+    cancelBulkExport() {
+        if (this._bulkExportCancelled) {
+            return;
+        }
+        
+        this._bulkExportCancelled = true;
+        this._bulkExporting = false;
+        this._bulkExportQueue = [];
+        this._currentBulkExportIndex = 0;
+        
+        this._callbacks['bulk-export-cancelled'].forEach((c) => c());
+        
+        // Force stop any ongoing mining operations
+        this._mining = false;
+        this._callbacks['stopped-mining'].forEach((c) => c());
+    }
+
+    // Removed unused processBulkExportQueue to reduce API surface
 
     private _remove(callback: Function, callbacks: Callback[]) {
         for (let i = callbacks.length - 1; i >= 0; --i) {

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -6,6 +6,7 @@
         "downloadAudio": "Audio herunterladen",
         "downloadImage": "Bild herunterladen",
         "downloadSubtitlesAsSrt": "Untertitel als SRT herunterladen",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "Springe zu",
         "ok": "OK",
         "mineSubtitle": "Mine Subtitle",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "Condensed playback: On",
         "enabledFastForwardPlayback": "Fast forward playback: On",
         "exportedCard": "Exported card: {{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "Playback Rate: {{rate}}",
         "savedTimestamp": "Saved: {{timestamp}}",
         "updatedCard": "Updated card: {{result}}",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -6,6 +6,7 @@
         "downloadAudio": "Download Audio",
         "downloadImage": "Download Image",
         "downloadSubtitlesAsSrt": "Download Subtitles as SRT",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "Jump To",
         "ok": "OK",
         "mineSubtitle": "Mine Subtitle",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "Condensed playback: On",
         "enabledFastForwardPlayback": "Fast forward playback: On",
         "exportedCard": "Exported card: {{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "Playback Rate: {{rate}}",
         "savedTimestamp": "Saved: {{timestamp}}",
         "updatedCard": "Updated card: {{result}}",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -6,6 +6,7 @@
         "downloadAudio": "Descargar Audio",
         "downloadImage": "Descargar Imagen",
         "downloadSubtitlesAsSrt": "Descargar Subtítulos como SRT",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "Saltar A",
         "ok": "OK",
         "mineSubtitle": "Minar Subtítulo",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "Reproducción condensada: Activada",
         "enabledFastForwardPlayback": "Reproducción acelerada: Activada",
         "exportedCard": "Tarjeta exportada: {{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "Velocidad de Reproducción: {{rate}}",
         "savedTimestamp": "Guardado: {{timestamp}}",
         "updatedCard": "Tarjeta actualizada: {{result}}",

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -6,6 +6,7 @@
         "downloadAudio": "Lataa ääni",
         "downloadImage": "Lataa kuva",
         "downloadSubtitlesAsSrt": "Lataa (SRT)",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "Siirry kohtaan",
         "ok": "Okei",
         "mineSubtitle": "Lähetä tekstitykset Ankin",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "Lyhennetty soitto: Päällä",
         "enabledFastForwardPlayback": "Nopea eteenpäin soitto: Päällä",
         "exportedCard": "Viedyt kortti: {{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "Toiston nopeus: {{rate}}",
         "savedTimestamp": "Tallennettu: {{timestamp}}",
         "updatedCard": "Päivitetty kortti: {{result}}",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -6,6 +6,7 @@
         "downloadAudio": "Télécharger l'audio",
         "downloadImage": "Télécharger l'image",
         "downloadSubtitlesAsSrt": "Télécharger les sous-titres au format SRT",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "Aller à",
         "ok": "OK",
         "mineSubtitle": "Miner sous-titre",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "Lecture condensée : Activée",
         "enabledFastForwardPlayback": "Lecture en avance rapide : Activé",
         "exportedCard": "Carte exportée : {{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "Vitesse de lecture : {{rate}}",
         "savedTimestamp": "Enregistré : {{timestamp}}",
         "updatedCard": "Carte mise à jour : {{result}}",

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -6,6 +6,7 @@
         "downloadAudio": "Unduh Audio",
         "downloadImage": "Unduh Gambar",
         "downloadSubtitlesAsSrt": "Unduh Takarir sebagai SRT",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "Loncat ke",
         "ok": "OK",
         "mineSubtitle": "Tambang Takarir",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "Pemutaran ringkas: Aktif",
         "enabledFastForwardPlayback": "Pemutaran cepat: Aktif",
         "exportedCard": "Kartu berhasil diekspor: {{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "Kecepatan Pemutaran: {{rate}}",
         "savedTimestamp": "Disimpan: {{timestamp}}",
         "updatedCard": "Kartu diperbarui: {{result}}",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -6,6 +6,7 @@
         "downloadAudio": "音声をダウンロード",
         "downloadImage": "画像をダウンロード",
         "downloadSubtitlesAsSrt": "SRT 形式字幕をダウンロード",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "ジャンプ",
         "ok": "OK",
         "mineSubtitle": "字幕をマイニングする",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "短縮プレイバック：オン",
         "enabledFastForwardPlayback": "早送りプレイバック：オン",
         "exportedCard": "カードのエクスポート：{{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "再生速度：{{rate}}",
         "savedTimestamp": "保存しました：{{timestamp}}",
         "updatedCard": "カードの更新：{{result}}",

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -6,6 +6,7 @@
         "downloadAudio": "오디오 파일 다운로드",
         "downloadImage": "이미지 파일 다운로드",
         "downloadSubtitlesAsSrt": "SRT 파일로 자막 다운로드",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "이동",
         "ok": "확인",
         "mineSubtitle": "자막 추출",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "자막 없는 부분 건너뛰기: 켜짐",
         "enabledFastForwardPlayback": "자막 없는 부분 빨리 감기: 켜짐",
         "exportedCard": "카드 내보내기 완료: {{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "재생 속도: {{rate}}",
         "savedTimestamp": "저장 완료: {{timestamp}}",
         "updatedCard": "카드 업데이트 완료: {{result}}",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -6,6 +6,7 @@
         "downloadAudio": "Pobierz audio",
         "downloadImage": "Pobierz obraz",
         "downloadSubtitlesAsSrt": "Pobierz napisy w formacie SRT",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "Przeskocz do",
         "ok": "OK",
         "mineSubtitle": "Wykop napisy",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "Odtwarzanie skondensowane: Włączone",
         "enabledFastForwardPlayback": "Tryb przyspieszonego odtwarzania: Włączony",
         "exportedCard": "Wyeksportowana karta: {{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "Prędkość odtwarzania: {{rate}}",
         "savedTimestamp": "Zapisano: {{timestamp}}",
         "updatedCard": "Zaktualizowana karta: {{result}}",

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -6,6 +6,7 @@
         "downloadAudio": "Baixar áudio",
         "downloadImage": "Baixar imagem",
         "downloadSubtitlesAsSrt": "Baixar legenda como SRT",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "Pular para",
         "ok": "OK",
         "mineSubtitle": "Minerar legenda",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "Reprodução condensada: On",
         "enabledFastForwardPlayback": "Reprodução de avanço rápido: On",
         "exportedCard": "Card exportado: {{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "Taxa de reprodução: {{rate}}",
         "savedTimestamp": "Salvo: {{timestamp}}",
         "updatedCard": "Atualizar card: {{result}}",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -6,6 +6,7 @@
         "downloadAudio": "Скачать аудио",
         "downloadImage": "Скачать изображение",
         "downloadSubtitlesAsSrt": "Скачать субтитры в формате SRT",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "Перейти к этому субтитру",
         "ok": "ОК",
         "mineSubtitle": "Майнить субтитр",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "Сжатое воспроизведение: Вкл",
         "enabledFastForwardPlayback": "Ускоренное воспроизведение: Вкл",
         "exportedCard": "Карточка экспортирована: {{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "Скорость воспроизведения: {{rate}}",
         "savedTimestamp": "Сохранено: {{timestamp}}",
         "updatedCard": "Карточка обновлена: {{result}}",

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -6,6 +6,7 @@
         "downloadAudio": "下载音频",
         "downloadImage": "下载图像",
         "downloadSubtitlesAsSrt": "下载字幕保存为srt文件",
+        "bulkExportSubtitles": "Bulk Export Subtitles",
         "jumpTo": "跳转到",
         "ok": "确认",
         "mineSubtitle": "Mine Subtitle",
@@ -269,6 +270,12 @@
         "enabledCondensedPlayback": "浓缩播放：打开",
         "enabledFastForwardPlayback": "Fast forward playback: On",
         "exportedCard": "导出的卡：{{result}}",
+        "bulkExporting": "Bulk exporting subtitles: {{current}}/{{total}}",
+        "bulkExport": {
+            "title": "Bulk Export in Progress",
+            "description": "Exporting subtitles to Anki. Please wait...",
+            "progressCompleted": "Exported {{current}} of {{total}}"
+        },
         "playbackRate": "播放速率：{{Rate}}",
         "savedTimestamp": "已保存：{{时间戳}}",
         "updatedCard": "更新的卡：{{result}}",

--- a/common/src/message.ts
+++ b/common/src/message.ts
@@ -112,6 +112,7 @@ export interface RecordMediaAndForwardSubtitleMessage extends Message, CardTextF
     readonly imageDelay: number;
     readonly playbackRate: number;
     readonly mediaTimestamp: number;
+    readonly exportMode?: AnkiExportMode;
 }
 
 export interface StartRecordingMediaMessage extends Message, ImageCaptureParams {
@@ -160,6 +161,7 @@ export interface CopySubtitleMessage extends Message, CardTextFieldValues {
     readonly postMineAction: PostMineAction;
     readonly subtitle?: SubtitleModel;
     readonly surroundingSubtitles?: SubtitleModel[];
+    readonly exportMode?: AnkiExportMode;
 }
 
 export interface CopySubtitleWithAdditionalFieldsMessage extends Message, CardTextFieldValues {
@@ -190,6 +192,9 @@ export interface CardUpdatedMessage extends Message, CardModel {
 export interface CardExportedMessage extends Message, CardModel {
     readonly command: 'card-exported';
     readonly cardName: string;
+    readonly isBulkExport?: boolean;
+    readonly skippedDuplicate?: boolean;
+    readonly exportError?: string;
 }
 
 export interface CardSavedMessage extends Message, CardModel {
@@ -367,6 +372,10 @@ export interface SubtitlesToVideoMessage extends Message {
 
 export interface RequestSubtitlesMessage extends Message {
     readonly command: 'request-subtitles';
+}
+
+export interface RequestCurrentSubtitleMessage extends Message {
+    readonly command: 'request-current-subtitle';
 }
 
 export interface RequestSubtitlesFromAppMessage extends MessageWithId {
@@ -662,6 +671,11 @@ export interface AckMessage extends MessageWithId {
 export interface RequestSubtitlesResponse {
     subtitles: SubtitleModel[];
     subtitleFileNames: string[];
+}
+
+export interface RequestCurrentSubtitleResponse {
+    readonly currentSubtitle: SubtitleModel | null;
+    readonly currentSubtitleIndex: number | null;
 }
 
 export interface JumpToSubtitleMessage extends Message {

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -47,6 +47,7 @@ export interface CardModel extends CardTextFieldValues {
     readonly audio?: AudioModel;
     readonly file?: FileModel;
     readonly mediaTimestamp: number;
+    readonly exportMode?: AnkiExportMode;
 }
 
 export interface FileModel {
@@ -88,7 +89,7 @@ export interface AudioModel {
     readonly error?: AudioErrorCode;
 }
 
-export type AnkiExportMode = 'gui' | 'updateLast' | 'default';
+export type AnkiExportMode = 'gui' | 'updateLast' | 'default' | 'bulk';
 
 export interface AnkiDialogSettings extends AnkiSettings {
     themeType: string;

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -46,6 +46,8 @@ import { RequestingActiveTabPermissionHandler } from '@/handlers/video/requestin
 import { CardPublisher } from '@/services/card-publisher';
 import AckMessageHandler from '@/handlers/video/ack-message-handler';
 import PublishCardHandler from '@/handlers/asbplayerv2/publish-card-handler';
+import BulkExportCancellationHandler from '@/handlers/asbplayerv2/bulk-export-cancellation-handler';
+import BulkExportStartedHandler from '@/handlers/asbplayerv2/bulk-export-started-handler';
 import { bindWebSocketClient, unbindWebSocketClient } from '@/services/web-socket-client-binding';
 import { isFirefoxBuild } from '@/services/build-flags';
 import { CaptureStreamAudioRecorder, OffscreenAudioRecorder } from '@/services/audio-recorder-delegate';
@@ -55,6 +57,7 @@ import UpdateMobileOverlayModelHandler from '@/handlers/video/update-mobile-over
 import { isMobile } from '@project/common/device-detection/mobile';
 import { enqueueUpdateAlert } from '@/services/update-alert';
 import RequestSubtitlesHandler from '@/handlers/asbplayerv2/request-subtitles-handler';
+import RequestCurrentSubtitleHandler from '@/handlers/asbplayerv2/request-current-subtitle-handler';
 import MobileOverlayForwarderHandler from '@/handlers/mobile-overlay/mobile-overlay-forwarder-handler';
 import RequestCopyHistoryHandler from '@/handlers/asbplayerv2/request-copy-history-handler';
 import DeleteCopyHistoryHandler from '@/handlers/asbplayerv2/delete-copy-history-handler';
@@ -137,11 +140,14 @@ export default defineBackground(() => {
         new CopySubtitleHandler(tabRegistry),
         new LoadSubtitlesHandler(tabRegistry),
         new RequestSubtitlesHandler(),
+        new RequestCurrentSubtitleHandler(),
         new RequestCopyHistoryHandler(),
         new SaveCopyHistoryHandler(settings),
         new DeleteCopyHistoryHandler(settings),
         new ClearCopyHistoryHandler(settings),
         new PublishCardHandler(cardPublisher),
+        new BulkExportCancellationHandler(cardPublisher),
+        new BulkExportStartedHandler(cardPublisher),
         new AckMessageHandler(tabRegistry),
         new AudioBase64Handler(audioRecorder),
         new UpdateMobileOverlayModelHandler(),

--- a/extension/src/entrypoints/offscreen-audio-recorder/offscreen-audio-recorder.ts
+++ b/extension/src/entrypoints/offscreen-audio-recorder/offscreen-audio-recorder.ts
@@ -9,7 +9,7 @@ import {
     StopRecordingErrorCode,
     StopRecordingResponse,
 } from '@project/common';
-import AudioRecorder, { TimedRecordingInProgressError } from '@/services/audio-recorder';
+import AudioRecorder, { TimedRecordingInProgressError, NoRecordingInProgressError } from '@/services/audio-recorder';
 import { Mp3Encoder } from '@project/common/audio-clip';
 import { bufferToBase64 } from '@project/common/base64';
 import { mp3WorkerFactory } from '@/services/mp3-worker-factory';
@@ -124,6 +124,9 @@ window.onload = async () => {
 
                             if (e instanceof TimedRecordingInProgressError) {
                                 errorCode = StopRecordingErrorCode.timedAudioRecordingInProgress;
+                            } else if (e instanceof NoRecordingInProgressError) {
+                                // Just no-op if nothing is recording--this can happen in bulk export.
+                                errorCode = StopRecordingErrorCode.other;
                             } else {
                                 console.error(e);
                                 errorCode = StopRecordingErrorCode.other;

--- a/extension/src/handlers/asbplayerv2/bulk-export-cancellation-handler.ts
+++ b/extension/src/handlers/asbplayerv2/bulk-export-cancellation-handler.ts
@@ -1,0 +1,20 @@
+import { CardPublisher } from '../../services/card-publisher';
+
+export default class BulkExportCancellationHandler {
+    readonly sender = 'asbplayerv2';
+    readonly command = 'bulk-export-cancelled';
+    
+    constructor(private readonly _cardPublisher: CardPublisher) {}
+    
+    handle(request: any, sender: any, sendResponse: any): boolean {
+        // Check if we already processed this cancellation to prevent duplicate processing
+        if (this._cardPublisher.bulkExportCancelled) {
+            return false;
+        }
+        
+        // Notify the card-publisher that bulk export was cancelled
+        this._cardPublisher.setBulkExportCancelled(true);
+        
+        return false;
+    }
+}

--- a/extension/src/handlers/asbplayerv2/bulk-export-started-handler.ts
+++ b/extension/src/handlers/asbplayerv2/bulk-export-started-handler.ts
@@ -1,0 +1,15 @@
+import { CardPublisher } from '../../services/card-publisher';
+
+export default class BulkExportStartedHandler {
+    readonly sender = 'asbplayerv2';
+    readonly command = 'bulk-export-started';
+    
+    constructor(private readonly _cardPublisher: CardPublisher) {}
+    
+    handle(request: any, sender: any, sendResponse: any): boolean {
+        // Reset the card-publisher cancellation state
+        this._cardPublisher.resetBulkExportCancellation();
+        
+        return false;
+    }
+}

--- a/extension/src/handlers/asbplayerv2/copy-subtitle-handler.ts
+++ b/extension/src/handlers/asbplayerv2/copy-subtitle-handler.ts
@@ -37,6 +37,7 @@ export default class CopySubtitleHandler {
                         postMineAction: copySubtitleCommand.message.postMineAction,
                         subtitle: copySubtitleCommand.message.subtitle,
                         surroundingSubtitles: copySubtitleCommand.message.surroundingSubtitles,
+                        exportMode: copySubtitleCommand.message.exportMode,
                     },
                     src: videoElement.src,
                 };

--- a/extension/src/handlers/asbplayerv2/request-current-subtitle-handler.ts
+++ b/extension/src/handlers/asbplayerv2/request-current-subtitle-handler.ts
@@ -1,0 +1,32 @@
+import {
+    AsbPlayerToVideoCommandV2,
+    Command,
+    ExtensionToVideoCommand,
+    Message,
+    RequestCurrentSubtitleMessage,
+} from '@project/common';
+
+export default class RequestCurrentSubtitleHandler {
+    get sender() {
+        return 'asbplayerv2';
+    }
+
+    get command() {
+        return 'request-current-subtitle';
+    }
+
+    handle(command: Command<Message>, sender: Browser.runtime.MessageSender, sendResponse: (response?: any) => void) {
+        const { tabId, src } = command as AsbPlayerToVideoCommandV2<RequestCurrentSubtitleMessage>;
+        const requestCurrentSubtitleFromTabCommand: ExtensionToVideoCommand<RequestCurrentSubtitleMessage> = {
+            sender: 'asbplayer-extension-to-video',
+            src,
+            message: {
+                command: 'request-current-subtitle',
+            },
+        };
+        browser.tabs.sendMessage(tabId, requestCurrentSubtitleFromTabCommand).then((response) => {
+            sendResponse(response);
+        });
+        return true;
+    }
+}

--- a/extension/src/handlers/video/record-media-handler.ts
+++ b/extension/src/handlers/video/record-media-handler.ts
@@ -112,10 +112,12 @@ export default class RecordMediaHandler {
 
             try {
                 const audioBase64 = await audioPromise;
-                audioModel = {
-                    ...baseAudioModel,
-                    base64: audioBase64,
-                };
+                if (audioBase64 !== '') {
+                    audioModel = {
+                        ...baseAudioModel,
+                        base64: audioBase64,
+                    };
+                }
             } catch (e) {
                 if (!(e instanceof DrmProtectedStreamError)) {
                     throw e;

--- a/extension/src/handlers/video/rerecord-media-handler.ts
+++ b/extension/src/handlers/video/rerecord-media-handler.ts
@@ -47,15 +47,22 @@ export default class RerecordMediaHandler {
         let audio: AudioModel;
 
         try {
-            audio = {
-                ...baseAudioModel,
-                base64: await this._audioRecorder.startWithTimeout(
-                    rerecordCommand.message.duration / rerecordCommand.message.playbackRate +
-                        rerecordCommand.message.audioPaddingEnd,
-                    false,
-                    { src: rerecordCommand.src, tabId: sender.tab?.id! }
-                ),
-            };
+            const audioBase64 = await this._audioRecorder.startWithTimeout(
+                rerecordCommand.message.duration / rerecordCommand.message.playbackRate +
+                    rerecordCommand.message.audioPaddingEnd,
+                false,
+                { src: rerecordCommand.src, tabId: sender.tab?.id! }
+            );
+            audio =
+                audioBase64 === ''
+                    ? {
+                          ...baseAudioModel,
+                          base64: '',
+                      }
+                    : {
+                          ...baseAudioModel,
+                          base64: audioBase64,
+                      };
         } catch (e) {
             if (!(e instanceof DrmProtectedStreamError)) {
                 throw e;

--- a/extension/src/handlers/video/stop-recording-media-handler.ts
+++ b/extension/src/handlers/video/stop-recording-media-handler.ts
@@ -13,7 +13,7 @@ import {
 import { SettingsProvider } from '@project/common/settings';
 import { mockSurroundingSubtitles } from '@project/common/util';
 import { CardPublisher } from '../../services/card-publisher';
-import AudioRecorderService, { TimedRecordingInProgressError } from '../../services/audio-recorder-service';
+import AudioRecorderService, { TimedRecordingInProgressError, NoRecordingInProgressServiceError } from '../../services/audio-recorder-service';
 
 export default class StopRecordingMediaHandler {
     private readonly _audioRecorder: AudioRecorderService;
@@ -121,14 +121,20 @@ export default class StopRecordingMediaHandler {
                 stopRecordingCommand.src
             );
         } catch (e) {
-            if (!(e instanceof TimedRecordingInProgressError)) {
-                throw e;
+            // Ignore benign stop conditions where recording is already finished or not in progress
+            if (e instanceof TimedRecordingInProgressError) {
+                // A recording scheduled from record-media-handler (or rerecord-media-handler) was in-progress
+                // and the call to stop() just above force-stopped it.
+                // We should do nothing else because execution in record-media-handler will continue
+                // and publish the card etc.
+                return;
+            }
+            else if (e instanceof NoRecordingInProgressServiceError) {
+                
+                return;
             }
 
-            // Else a recording scheduled from record-media-handler (or rerecord-media-handler) was in-progress
-            // and the call to stop() just above force-stopped it.
-            // We should do nothing else because execution in record-media-handler will continue
-            // and publish the card etc.
+            throw e;
         }
     }
 }

--- a/extension/src/services/audio-recorder-service.ts
+++ b/extension/src/services/audio-recorder-service.ts
@@ -22,6 +22,8 @@ export class DrmProtectedStreamError extends Error {}
 
 export class TimedRecordingInProgressError extends Error {}
 
+export class NoRecordingInProgressServiceError extends Error {}
+
 export default class AudioRecorderService {
     private readonly _tabRegistry: TabRegistry;
     private readonly _delegate: AudioRecorderDelegate;
@@ -111,10 +113,10 @@ export default class AudioRecorderService {
 
     async stop(encodeAsMp3: boolean, requester: Requester): Promise<string> {
         if (this.audioBase64Promise === undefined) {
-            const errorMessage = 'Cannot stop because audio recording is not in progress';
-            this._notifyError(errorMessage, requester);
+            // Benign no-op: If the user spams cancel on a bulk export,
+            // we can get a cancel request on a non-recording state.
             this._notifyRecordingFinished(requester);
-            throw new Error(errorMessage);
+            throw new NoRecordingInProgressServiceError();
         }
 
         const response = await this._delegate.stop(encodeAsMp3, requester);
@@ -175,9 +177,10 @@ export default class AudioRecorderService {
 
     private _prepareForAudioDataResponse(requestId: string): Promise<string> {
         if (this.audioBase64Promise !== undefined) {
-            this.audioBase64Reject!(
-                new Error('New audio recording request received before the current one could finish')
-            );
+            // During bulk export, a new audio request can arrive while a previous one
+            // is still pending. Resolve the previous request with an empty string so
+            // downstream handlers interpret it as "no audio" and continue gracefully.
+            this.audioBase64Resolve?.('');
             this.audioBase64Resolve = undefined;
             this.audioBase64Reject = undefined;
             this.audioBase64Promise = undefined;

--- a/extension/src/services/audio-recorder.ts
+++ b/extension/src/services/audio-recorder.ts
@@ -1,6 +1,7 @@
 import { bufferToBase64 } from '@project/common/base64';
 
 export class TimedRecordingInProgressError extends Error {}
+export class NoRecordingInProgressError extends Error {}
 
 export default class AudioRecorder {
     private recording: boolean;
@@ -106,7 +107,7 @@ export default class AudioRecorder {
 
     async stop(doNotManageStream: boolean = false): Promise<string> {
         if (!this.recording) {
-            throw new Error('Not recording, unable to stop');
+            throw new NoRecordingInProgressError();
         }
 
         this.recording = false;

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -635,6 +635,18 @@ export default class Binding {
                             subtitleFileNames: this.subtitleController.subtitleFileNames ?? [],
                         });
                         break;
+                    // This is useful because when we kick off bulk export the side panel needs to know
+                    // what subtitle to start from.
+                    case 'request-current-subtitle':
+                        const [currentSubtitle] = this.subtitleController.currentSubtitle();
+                        const currentSubtitleIndex = currentSubtitle ? this.subtitleController.subtitles.findIndex(s => 
+                            s.start === currentSubtitle.start && s.end === currentSubtitle.end && s.text === currentSubtitle.text
+                        ) : -1;
+                        sendResponse({
+                            currentSubtitle: currentSubtitle,
+                            currentSubtitleIndex: currentSubtitleIndex >= 0 ? currentSubtitleIndex : null,
+                        });
+                        break;
                     case 'offset':
                         const offsetMessage = request.message as OffsetToVideoMessage;
                         this.subtitleController.offset(offsetMessage.value, !offsetMessage.echo);
@@ -1052,6 +1064,7 @@ export default class Binding {
         definition,
         word,
         customFieldValues,
+        exportMode,
     }: CopySubtitleMessage) {
         if (!subtitle || !surroundingSubtitles) {
             return;
@@ -1104,6 +1117,7 @@ export default class Binding {
                 definition,
                 word,
                 customFieldValues,
+                exportMode,
                 ...this._imageCaptureParams,
             },
             src: this.video.src,

--- a/extension/src/ui/components/SidePanelTopControls.tsx
+++ b/extension/src/ui/components/SidePanelTopControls.tsx
@@ -2,6 +2,7 @@ import IconButton from '@mui/material/IconButton';
 import HistoryIcon from '@mui/icons-material/History';
 import LoadSubtitlesIcon from '@project/common/components/LoadSubtitlesIcon';
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
+import ImportExportIcon from '@mui/icons-material/ImportExport';
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 import Fade from '@mui/material/Fade';
@@ -15,11 +16,12 @@ interface Props {
     canDownloadSubtitles: boolean;
     onLoadSubtitles: () => void;
     onDownloadSubtitles: () => void;
+    onBulkExportSubtitles: () => void;
     onShowMiningHistory: () => void;
 }
 
 const SidePanelTopControls = React.forwardRef(function SidePanelTopControls(
-    { show, canDownloadSubtitles, onLoadSubtitles, onDownloadSubtitles, onShowMiningHistory }: Props,
+    { show, canDownloadSubtitles, onLoadSubtitles, onDownloadSubtitles, onBulkExportSubtitles, onShowMiningHistory }: Props,
     ref: ForwardedRef<HTMLDivElement>
 ) {
     const { t } = useTranslation();
@@ -44,13 +46,22 @@ const SidePanelTopControls = React.forwardRef(function SidePanelTopControls(
                         </Tooltip>
                     </Grid>
                     {canDownloadSubtitles && (
-                        <Grid item>
-                            <Tooltip title={t('action.downloadSubtitlesAsSrt')!}>
-                                <IconButton onClick={onDownloadSubtitles}>
-                                    <SaveAltIcon />
-                                </IconButton>
-                            </Tooltip>
-                        </Grid>
+                        <>
+                            <Grid item>
+                                <Tooltip title={t('action.downloadSubtitlesAsSrt')!}>
+                                    <IconButton onClick={onDownloadSubtitles}>
+                                        <SaveAltIcon />
+                                    </IconButton>
+                                </Tooltip>
+                            </Grid>
+                            <Grid item>
+                                <Tooltip title={t('action.bulkExportSubtitles')!}>
+                                    <IconButton onClick={onBulkExportSubtitles}>
+                                        <ImportExportIcon />
+                                    </IconButton>
+                                </Tooltip>
+                            </Grid>
+                        </>
                     )}
                     <Grid item>
                         <IconButton onClick={onShowMiningHistory}>


### PR DESCRIPTION
New functionality:
This adds a button to the side panel overlay between `Download Subtitles as SRT` and `Mining History` that starts exporting one card after another from the current subtitle to the end of the video. While it does this, it blocks out the side panel with a cancellable progress bar to avoid weird state if you try to seek around/kick off an export.

Architecture:
This driven by a queue, with events being consumed by logic in SidePanel. SidePanel will kick off the export of the next card every time it gets a card-exported message back.
I found that this put the extension into some weird states, most notably that I was getting a lot of pausing-stopped-video and empty-card-created errors. I downgraded those from exceptions to a no-op and empty cards, respectively.

I tested this almost exclusively on one YouTube video--happy to look at whatever else you'd like to see covered.