### PR TITLE
fix(videoName): don't duplicate subtitle label

### DIFF
--- a/extension/src/ui/components/VideoDataSyncDialog.tsx
+++ b/extension/src/ui/components/VideoDataSyncDialog.tsx
@@ -44,7 +44,7 @@ function calculateVideoName(baseName: string, label: string, localFile: boolean 
         return label;
     }
 
-    if (label && localFile !== true) {
+    if (label && !baseName.includes(label) && localFile !== true) {
         return `${baseName} - ${label}`;
     }
 


### PR DESCRIPTION
I was seeing things like `Movie - Japanese SDH (SRT External) - Japanese SDH (SRT External)` the app view as well as the source title in my Anki cards.