### PR TITLE
Add title to keybinds' textfields in settings

### DIFF
--- a/common/components/SettingsForm.tsx
+++ b/common/components/SettingsForm.tsx
@@ -601,6 +601,7 @@ function KeyBindField({ label, keys, boundViaChrome, onKeysChange, onOpenExtensi
                     disabled={boundViaChrome}
                     helperText={boundViaChrome ? t('settings.extensionShortcut') : undefined}
                     value={currentKeyString}
+                    title={currentKeyString}
                     color="primary"
                     slotProps={{
                         input: {


### PR DESCRIPTION
Hello there! I sporadically mine from netflix and always forget what shortcuts to use after not having used it for awhile 😅. However, long shortcuts appear cut-off in the popup's settings, and i need to open up the fullscreen settings to see what they are

This pr proposes to show a tooltip by way of the `title` attr (tested on edge/firefox)

<img width="220" height="118" alt="image" src="https://github.com/user-attachments/assets/e9666fb4-0ff8-4c5d-9fe9-4307ce09f670" />

Admittedly a very minor annoyance, but would be appreciated nonetheless, thanks!