### PR TITLE
Focus on Open files for unsupported websites

### DIFF
--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -198,6 +198,7 @@ export interface VideoDataUiModel {
     defaultCheckboxState?: boolean;
     settings: VideoDataUiSettings;
     hasSeenFtue: boolean;
+    isSupportedPage: boolean;
     hideRememberTrackPreferenceToggle: boolean;
 }
 

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -202,6 +202,7 @@ export default class VideoDataSyncController {
         const activeProfilePromise = this._context.settings.activeProfile();
         const hasSeenFtue = (await globalStateProvider.get(['ftueHasSeenSubtitleTrackSelector']))
             .ftueHasSeenSubtitleTrackSelector;
+        const isSupportedPage = typeof (await currentPageDelegate()) != 'undefined';
         const hideRememberTrackPreferenceToggle = this._isTutorial || (await this._pageHidesTrackPrefToggle());
         return this._syncedData
             ? {
@@ -218,6 +219,7 @@ export default class VideoDataSyncController {
                       activeProfile: (await activeProfilePromise)?.name,
                   },
                   hasSeenFtue,
+                  isSupportedPage,
                   hideRememberTrackPreferenceToggle,
                   ...additionalFields,
               }
@@ -236,6 +238,7 @@ export default class VideoDataSyncController {
                       activeProfile: (await activeProfilePromise)?.name,
                   },
                   hasSeenFtue,
+                  isSupportedPage,
                   hideRememberTrackPreferenceToggle,
                   ...additionalFields,
               };

--- a/extension/src/ui/components/VideoDataSyncDialog.tsx
+++ b/extension/src/ui/components/VideoDataSyncDialog.tsx
@@ -67,6 +67,7 @@ interface Props {
     profiles: Profile[];
     activeProfile?: string;
     hasSeenFtue?: boolean;
+    isSupportedPage?: boolean;
     hideRememberTrackPreferenceToggle?: boolean;
     onCancel: () => void;
     onOpenFile: (track?: number) => void;
@@ -90,6 +91,7 @@ export default function VideoDataSyncDialog({
     profiles,
     activeProfile,
     hasSeenFtue,
+    isSupportedPage,
     hideRememberTrackPreferenceToggle,
     onCancel,
     onOpenFile,
@@ -233,12 +235,14 @@ export default function VideoDataSyncDialog({
     }
 
     const threeSubtitleTrackSelectors = generateSubtitleTrackSelectors(3);
+    const disabledRef = useRef<ButtonBaseActions | null>(null);
     const okActionRef = useRef<ButtonBaseActions | null>(null);
     const videoNameRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         if (open && trimmedName && !videoNameRef.current?.contains(document.activeElement) && !disabled) {
-            okActionRef.current?.focusVisible();
+            const focusEl = isSupportedPage ? okActionRef : disabledRef;
+            focusEl.current?.focusVisible();
         }
     }, [open, trimmedName, disabled]);
 
@@ -326,7 +330,7 @@ export default function VideoDataSyncDialog({
                 </form>
             </DialogContent>
             <DialogActions>
-                <Button disabled={disabled} onClick={() => onOpenFile()}>
+                <Button action={disabledRef} disabled={disabled} onClick={() => onOpenFile()}>
                     {t('action.openFiles')}
                 </Button>
                 <Button action={okActionRef} disabled={!trimmedName || disabled} onClick={handleOkButtonClick}>

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -49,6 +49,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
     const [activeProfile, setActiveProfile] = useState<string>();
     const [fileInputTrackNumber, setFileInputTrackNumber] = useState<number>();
     const [hasSeenFtue, setHasSeenFtue] = useState<boolean>();
+    const [isSupportedPage, setIsSupportedPage] = useState<boolean>();
     const [hideRememberTrackPreferenceToggle, setHideRememberTrackPreferenceToggle] = useState<boolean>();
 
     const theme = useMemo(() => createTheme((themeType || 'dark') as PaletteMode), [themeType]);
@@ -153,6 +154,10 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                 setHasSeenFtue(model.hasSeenFtue);
             }
 
+            if (model.isSupportedPage !== undefined) {
+                setIsSupportedPage(model.isSupportedPage);
+            }
+
             if (model.hideRememberTrackPreferenceToggle !== undefined) {
                 setHideRememberTrackPreferenceToggle(model.hideRememberTrackPreferenceToggle);
             }
@@ -252,6 +257,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                     profiles={profiles}
                     activeProfile={activeProfile}
                     hasSeenFtue={hasSeenFtue}
+                    isSupportedPage={isSupportedPage}
                     hideRememberTrackPreferenceToggle={hideRememberTrackPreferenceToggle}
                     onCancel={handleCancel}
                     onOpenFile={handleOpenFile}


### PR DESCRIPTION
My attempt at fixing https://github.com/killergerbah/asbplayer/issues/818 

If the website is unsupported, it should now focus on `Open files`, and will focus on OK for all the supported websites, just as before. I'm not sure if there's anything else that can be done for that issue, or would this PR close the original issue?

Feel free to modify this PR directly if you feel it's easier than explaining :)