### PR TITLE
Properly fetch subtitles from Jellyfin with a base URL configured

### DIFF
--- a/extension/src/entrypoints/emby-jellyfin-page.ts
+++ b/extension/src/entrypoints/emby-jellyfin-page.ts
@@ -17,7 +17,7 @@ export default defineUnlistedScript(() => {
                 );
             }
 
-            const deviceID = ApiClient?._deviceId;
+            const deviceID = ApiClient.deviceId();
 
             let session;
             for (let attempt = 0; attempt < 5; attempt++) {
@@ -49,7 +49,7 @@ export default defineUnlistedScript(() => {
             ).forEach((sub: { Codec: string; DisplayTitle: any; Language: any; Index: number; Path: string }) => {
                 const extension = 'srt';
                 var url =
-                    ApiClient._serverAddress +
+                    ApiClient.serverAddress() +
                     '/Videos/' +
                     nowPlayingItem.Id +
                     '/' +


### PR DESCRIPTION
Instead of assuming that the Jellyfin server is running on `/`, use the API path from the API client we're hooking as a base.

fixes #586 