### PR TITLE
enhancement(yomitan): support optimizations for tokenization

### DIFF
--- a/common/components/DictionarySettingsTab.tsx
+++ b/common/components/DictionarySettingsTab.tsx
@@ -75,8 +75,8 @@ const DictionarySettingsTab: React.FC<Props> = ({ settings, onSettingChanged, an
     const [dictionaryYomitanUrlError, setDictionaryYomitanUrlError] = useState<string>();
     const dictionaryRequestYomitan = useCallback(async () => {
         try {
-            const yomitan = new Yomitan();
-            await yomitan.version(selectedDictionary.dictionaryYomitanUrl);
+            const yomitan = new Yomitan(selectedDictionary);
+            await yomitan.version();
             setDictionaryYomitanUrlError(undefined);
         } catch (e) {
             console.error(e);


### PR DESCRIPTION
This feature is guarded by a version check so it won't try to use it, it's currently always set to `false` until the Yomitan PR yomidevs/yomitan#2251 is resolved. In the event there are any changes there, the implementation can be easily tweaked before enabling the version check.

I'm making a PR now as the `IndexedDB` code was written on top of it. I refactored the Yomitan class to be per track rather than global as there is too much state to manage now per track. Also fixes #837.