### PR TITLE
Enable sidebar for firefox

### DIFF
--- a/extension/src/entrypoints/sidepanel/index.html
+++ b/extension/src/entrypoints/sidepanel/index.html
@@ -3,7 +3,15 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="manifest.include" content="['chrome']" />
+        <meta name="manifest.open_at_install" content="false" />
+        <meta
+            name="manifest.default_icon"
+            content="{
+                '16': 'icon/icon16.png',
+                '48': 'icon/icon48.png',
+                '128': 'icon/icon128.png',
+            }"
+            />
         <title>asbplayer</title>
         <style>
             @import url('/fonts/fonts.css');

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -192,6 +192,9 @@ export default defineConfig({
             manifest = {
                 ...manifest,
                 host_permissions: ['<all_urls>'],
+                sidebar_action: {
+                    default_panel: 'index.html',
+                },
                 commands,
                 browser_specific_settings: {
                     gecko,


### PR DESCRIPTION
Everything I tried seems to work out of the box just with this small config change.

~I am still looking into why the sidebar does not get any icon.~
