### PR TITLE
Annotation tutorial for existing users

### DIFF
--- a/common/app/components/SettingsDialog.tsx
+++ b/common/app/components/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
@@ -16,6 +16,8 @@ import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
 import { type Theme } from '@mui/material';
 import { DictionaryProvider } from '../../dictionary-db';
+import { useAnnotationTutorial } from '@project/common/hooks/use-annotation-tutorial';
+import { AppExtensionGlobalStateProvider } from '../services/app-extension-global-state-provider';
 
 const appTestCard = () => {
     const basePath = window.location.pathname === '/' ? '' : window.location.pathname;
@@ -82,6 +84,8 @@ export default function SettingsDialog({
         updateLocalFontsPermission();
         updateLocalFonts();
     }, [updateLocalFontsPermission, updateLocalFonts]);
+    const globalStateProvider = useMemo(() => new AppExtensionGlobalStateProvider(extension), [extension]);
+    const { inAnnotationTutorial, handleAnnotationTutorialSeen } = useAnnotationTutorial({ globalStateProvider });
 
     return (
         <Dialog open={open} maxWidth="md" fullWidth className={classes.root} onClose={onClose}>
@@ -125,6 +129,8 @@ export default function SettingsDialog({
                     supportedLanguages={supportedLanguages}
                     testCard={appTestCard}
                     onUnlockLocalFonts={handleUnlockLocalFonts}
+                    inAnnotationTutorial={inAnnotationTutorial}
+                    onAnnotationTutorialSeen={handleAnnotationTutorialSeen}
                 />
             </DialogContent>
             {(!extension.installed || extension.supportsSettingsProfiles) && (

--- a/common/components/SettingsForm.tsx
+++ b/common/components/SettingsForm.tsx
@@ -22,6 +22,7 @@ import KeyboardShortcutsSettingsTab from './KeyboardShortcutsSettingsTab';
 import StreamingVideoSettingsTab from './StreamingVideoSettingsTab';
 import MiscSettingsTab from './MiscSettingsTab';
 import { DictionaryProvider } from '../dictionary-db';
+import TutorialBubble from './TutorialBubble';
 
 interface StylesProps {
     smallScreen: boolean;
@@ -186,6 +187,8 @@ interface Props {
     supportedLanguages: string[];
     forceVerticalTabs?: boolean;
     inTutorial?: boolean;
+    inAnnotationTutorial?: boolean;
+    onAnnotationTutorialSeen?: () => void;
     heightConstrained?: boolean;
     testCard?: () => Promise<CardModel>;
     onSettingsChanged: (settings: Partial<AsbplayerSettings>) => void;
@@ -225,6 +228,8 @@ export default function SettingsForm({
     supportedLanguages,
     forceVerticalTabs,
     inTutorial,
+    inAnnotationTutorial,
+    onAnnotationTutorialSeen,
     heightConstrained,
     testCard,
     onSettingsChanged,
@@ -285,6 +290,10 @@ export default function SettingsForm({
         }
     }, [tutorialStep, noteType]);
 
+    const handleAnnotationTutorialSeen = useCallback(() => {
+        onAnnotationTutorialSeen?.();
+    }, [onAnnotationTutorialSeen]);
+
     const ankiPanelRef = useRef<HTMLDivElement>(null);
     const keyboardShortcutsPanelRef = useRef<HTMLDivElement>(null);
 
@@ -313,7 +322,24 @@ export default function SettingsForm({
                 <Tab tabIndex={1} label={t('settings.mining')} id="mining-settings" />
                 <Tab tabIndex={2} label={t('settings.subtitleAppearance')} id="subtitle-appearance" />
                 <Tab tabIndex={3} label={t('settings.keyboardShortcuts')} id="keyboard-shortcuts" />
-                {supportsDictionary && <Tab tabIndex={4} label={t('settings.annotation')} id="dictionary" />}
+                {supportsDictionary && (
+                    <TutorialBubble
+                        show={inAnnotationTutorial}
+                        placement="right"
+                        text={t('settings.ftueAnnotation')}
+                        onConfirm={handleAnnotationTutorialSeen}
+                    >
+                        <Tab
+                            onClick={() => {
+                                setTabIndex(4);
+                                handleAnnotationTutorialSeen();
+                            }}
+                            tabIndex={4}
+                            label={t('settings.annotation')}
+                            id="dictionary"
+                        />
+                    </TutorialBubble>
+                )}
                 {extensionSupportsAppIntegration && (
                     <Tab
                         tabIndex={4 + Number(supportsDictionary)}

--- a/common/global-state/index.ts
+++ b/common/global-state/index.ts
@@ -3,14 +3,22 @@
 // "Global state" exists for other kinds of key/value pairs that should
 // not be affected by settings profiles. For example: FTUE state.
 
+export enum AnnotationTutorialState {
+    hasNotSeen = 0,
+    shouldSee = 1,
+    hasSeen = 2,
+}
+
 export const initialGlobalState: GlobalState = {
     ftueHasSeenAnkiDialogQuickSelectV2: false,
     ftueHasSeenSubtitleTrackSelector: false,
+    ftueAnnotation: AnnotationTutorialState.hasNotSeen,
 };
 
 export interface GlobalState {
     ftueHasSeenAnkiDialogQuickSelectV2: boolean;
     ftueHasSeenSubtitleTrackSelector: boolean;
+    ftueAnnotation: AnnotationTutorialState;
 }
 
 export interface GlobalStateProvider {

--- a/common/hooks/use-annotation-tutorial.ts
+++ b/common/hooks/use-annotation-tutorial.ts
@@ -1,0 +1,16 @@
+import { useEffect, useCallback, useState } from 'react';
+import { AnnotationTutorialState, GlobalStateProvider } from '@project/common/global-state';
+
+export const useAnnotationTutorial = ({ globalStateProvider }: { globalStateProvider: GlobalStateProvider }) => {
+    const handleAnnotationTutorialSeen = useCallback(() => {
+        globalStateProvider.set({ ftueAnnotation: AnnotationTutorialState.hasSeen });
+        setInAnnotationTutorial(false);
+    }, [globalStateProvider]);
+    const [inAnnotationTutorial, setInAnnotationTutorial] = useState<boolean>(false);
+    useEffect(() => {
+        globalStateProvider
+            .get(['ftueAnnotation'])
+            .then((s) => setInAnnotationTutorial(s.ftueAnnotation === AnnotationTutorialState.shouldSee));
+    }, [globalStateProvider]);
+    return { handleAnnotationTutorialSeen, inAnnotationTutorial };
+};

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "Auto-pause when mousing over subtitles",
         "createTestCard": "Create Test Card",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status is determined by your local collection then from Anki cards. Collect words locally through imports or by hovering over words and using the keyboard shortcuts.",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "Auto-pause when mousing over subtitles",
         "createTestCard": "Create Test Card",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status prioritizes your local word collection over your Anki word database. Collect words by importing them here, or by hovering over subtitles and using the <0>keyboard shortcuts</0>.",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "Auto-pause when mousing over subtitles",
         "createTestCard": "Create Test Card",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status is determined by your local collection then from Anki cards. Collect words locally through imports or by hovering over words and using the keyboard shortcuts.",

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "Pysäytä automaattisesti kun hiiri on tekstitysten päällä",
         "createTestCard": "Luo Testikortti",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status is determined by your local collection then from Anki cards. Collect words locally through imports or by hovering over words and using the keyboard shortcuts.",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "Pause automatique au survol des sous-titres",
         "createTestCard": "Créer une carte de test",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status is determined by your local collection then from Anki cards. Collect words locally through imports or by hovering over words and using the keyboard shortcuts.",

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "Jeda otomatis saat kursor diarahkan ke takarir",
         "createTestCard": "Buat Kartu Uji",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status is determined by your local collection then from Anki cards. Collect words locally through imports or by hovering over words and using the keyboard shortcuts.",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "マウスカーソルを字幕に重ねると自動一時停止",
         "createTestCard": "テストカードを作成",
         "annotation": "アノテーション",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "アノテーション機能は<0>Yomitan API</0>が必要です。",
         "annotationNoExtensionWarn": "単語がブラウザによって削除されないためには、asbplayer拡張機能のインストールをお勧めします。設定をなくさないためには拡張機能をインストールする前に設定のエクスポートもお勧めします。",
         "annotationLocalAnkiHelperText": "単語の成熟度は、Ankiの単語データベースより、ローカルの単語データベースが優先されます。単語を収集するためには、こちらのボタンでインポートするか、字幕にマウスカーソルを重ね、<0>キーボードショートカット</0>を使用することができます。",

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "자막 위에 마우스를 올리면 자동 일시정지",
         "createTestCard": "테스트 카드 생성",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status is determined by your local collection then from Anki cards. Collect words locally through imports or by hovering over words and using the keyboard shortcuts.",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "Auto-pause when mousing over subtitles",
         "createTestCard": "Create Test Card",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status is determined by your local collection then from Anki cards. Collect words locally through imports or by hovering over words and using the keyboard shortcuts.",

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "Pausar automaticamente ao posicionar o mouse sobre as legendas",
         "createTestCard": "Criar Cartão de Teste",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status is determined by your local collection then from Anki cards. Collect words locally through imports or by hovering over words and using the keyboard shortcuts.",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "Автоматически ставить на паузу при наведении на субтитры",
         "createTestCard": "Создать тестовую карточку",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status is determined by your local collection then from Anki cards. Collect words locally through imports or by hovering over words and using the keyboard shortcuts.",

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -451,6 +451,7 @@
         "pauseOnHoverMode": "当鼠标悬停在字幕上时自动暂停",
         "createTestCard": "Create Test Card",
         "annotation": "Annotation",
+        "ftueAnnotation": "Subtitle annotation features are now available.",
         "annotationHelperText": "Annotation requires <0>Yomitan API</0> to function.",
         "annotationNoExtensionWarn": "Installing the asbplayer extension is recommended to prevent your browser from deleting manually stored words. Export your settings before installing the extension to preserve your data.",
         "annotationLocalAnkiHelperText": "Word status is determined by your local collection then from Anki cards. Collect words locally through imports or by hovering over words and using the keyboard shortcuts.",

--- a/extension/src/services/extension-global-state-provider.test.ts
+++ b/extension/src/services/extension-global-state-provider.test.ts
@@ -22,5 +22,6 @@ it('can retrieve all keys', async () => {
     expect(await provider.getAll()).toEqual({
         ftueHasSeenAnkiDialogQuickSelectV2: false,
         ftueHasSeenSubtitleTrackSelector: false,
+        ftueAnnotation: 0,
     });
 });

--- a/extension/src/ui/components/Popup.tsx
+++ b/extension/src/ui/components/Popup.tsx
@@ -22,6 +22,10 @@ import Stack from '@mui/material/Stack';
 import TutorialIcon from '@project/common/components/TutorialIcon';
 import Paper from '@mui/material/Paper';
 import { DictionaryProvider } from '@project/common/dictionary-db';
+import { useAnnotationTutorial } from '@project/common/hooks/use-annotation-tutorial';
+import { ExtensionGlobalStateProvider } from '@/services/extension-global-state-provider';
+
+const globalStateProvider = new ExtensionGlobalStateProvider();
 
 interface Props {
     dictionaryProvider: DictionaryProvider;
@@ -77,6 +81,7 @@ const Popup = ({
     const { supportedLanguages } = useSupportedLanguages();
     const { localFontsAvailable, localFontsPermission, localFontFamilies } = useLocalFontFamilies();
     const theme = useTheme();
+    const { handleAnnotationTutorialSeen, inAnnotationTutorial } = useAnnotationTutorial({ globalStateProvider });
 
     if (!i18nInitialized) {
         return null;
@@ -133,6 +138,8 @@ const Popup = ({
                         onSettingsChanged={onSettingsChanged}
                         onOpenChromeExtensionShortcuts={onOpenExtensionShortcuts}
                         onUnlockLocalFonts={handleUnlockLocalFonts}
+                        inAnnotationTutorial={inAnnotationTutorial}
+                        onAnnotationTutorialSeen={handleAnnotationTutorialSeen}
                     />
                 </Grid>
                 <Grid item>

--- a/extension/src/ui/components/SettingsPage.tsx
+++ b/extension/src/ui/components/SettingsPage.tsx
@@ -42,6 +42,8 @@ interface Props {
     profiles: Profile[];
     activeProfile?: string;
     inTutorial?: boolean;
+    inAnnotationTutorial?: boolean;
+    onAnnotationTutorialSeen?: () => void;
     onNewProfile: (name: string) => void;
     onRemoveProfile: (name: string) => void;
     onSetActiveProfile: (name: string | undefined) => void;
@@ -54,7 +56,15 @@ const extensionTestCard: () => Promise<CardModel> = () => {
     });
 };
 
-const SettingsPage = ({ dictionaryProvider, settings, inTutorial, onSettingsChanged, ...profileContext }: Props) => {
+const SettingsPage = ({
+    dictionaryProvider,
+    settings,
+    inTutorial,
+    inAnnotationTutorial,
+    onAnnotationTutorialSeen,
+    onSettingsChanged,
+    ...profileContext
+}: Props) => {
     const { t } = useTranslation();
     const theme = useTheme();
     const anki = useMemo(
@@ -129,6 +139,8 @@ const SettingsPage = ({ dictionaryProvider, settings, inTutorial, onSettingsChan
                         onUnlockLocalFonts={handleUnlockLocalFonts}
                         scrollToId={section}
                         inTutorial={inTutorial}
+                        inAnnotationTutorial={inAnnotationTutorial}
+                        onAnnotationTutorialSeen={onAnnotationTutorialSeen}
                         testCard={extensionTestCard}
                     />
                 </DialogContent>

--- a/extension/src/ui/components/SettingsUi.tsx
+++ b/extension/src/ui/components/SettingsUi.tsx
@@ -5,12 +5,17 @@ import { useMemo } from 'react';
 import SettingsPage from './SettingsPage';
 import { createTheme } from '@project/common/theme';
 import { StyledEngineProvider } from '@mui/material/styles';
+import { useAnnotationTutorial } from '@project/common/hooks/use-annotation-tutorial';
+import { ExtensionGlobalStateProvider } from '@/services/extension-global-state-provider';
 
-const inTutorial = new URLSearchParams(window.location.search).get('tutorial') === 'true';
+const searchParams = new URLSearchParams(window.location.search);
+const inTutorial = searchParams.get('tutorial') === 'true';
+const globalStateProvider = new ExtensionGlobalStateProvider();
 
 const SettingsUi = () => {
     const { dictionaryProvider, settings, onSettingsChanged, profileContext } = useSettings();
     const theme = useMemo(() => settings && createTheme(settings.themeType), [settings]);
+    const { handleAnnotationTutorialSeen, inAnnotationTutorial } = useAnnotationTutorial({ globalStateProvider });
 
     if (!settings || !theme) {
         return null;
@@ -25,6 +30,8 @@ const SettingsUi = () => {
                     settings={settings}
                     onSettingsChanged={onSettingsChanged}
                     inTutorial={inTutorial}
+                    inAnnotationTutorial={inAnnotationTutorial}
+                    onAnnotationTutorialSeen={handleAnnotationTutorialSeen}
                     {...profileContext}
                 />
             </ThemeProvider>


### PR DESCRIPTION
This change shows a badge + tutorial bubble on the annotation settings section for existing users who upgrade to 1.14.0. Considered various possibilities but this seemed like the most minimalistic while still accomlishing the goal of letting people know about the new features.

https://github.com/user-attachments/assets/f8943043-bf89-4885-beff-a79fdb265842

