### PR TITLE
Sanitize subtitle html

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -8,6 +8,7 @@
         "@types/semver": "^7.3.9",
         "ass-compiler": "0.1.1",
         "dexie": "^4.0.11",
+        "dompurify": "^3.3.1",
         "fast-xml-parser": "^4.0.7",
         "hotkeys-js": "^3.10.0",
         "i18next": "^22.4.14",

--- a/common/subtitle-reader/subtitle-reader.ts
+++ b/common/subtitle-reader/subtitle-reader.ts
@@ -3,6 +3,7 @@ import SrtParser from '@qgustavor/srt-parser';
 import { WebVTT } from 'vtt.js';
 import { XMLParser } from 'fast-xml-parser';
 import { SubtitleHtml, SubtitleTextImage, Token, Tokenization } from '@project/common';
+import DOMPurify from 'dompurify';
 
 const vttClassRegex = /<(\/)?c(\.[^>]*)?>/g;
 const assNewLineRegex = RegExp(/\\[nN]/, 'ig');
@@ -380,7 +381,7 @@ export default class SubtitleReader {
         if (file.name.endsWith('.bbjson')) {
             const body = JSON.parse(await file.text()).body;
             return body.map((s: any) => ({
-                text: s.content,
+                text: this._filterText(s.content),
                 start: s.from * 1000,
                 end: s.to * 1000,
                 track,
@@ -544,6 +545,7 @@ export default class SubtitleReader {
     }
 
     private _filterText(text: string): string {
+        text = DOMPurify.sanitize(text);
         text =
             this._textFilter === undefined
                 ? text

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,6 +3813,7 @@ __metadata:
     ass-compiler: 0.1.1
     core-js: ^3.44.0
     dexie: ^4.0.11
+    dompurify: ^3.3.1
     fast-xml-parser: ^4.0.7
     hotkeys-js: ^3.10.0
     i18next: ^22.4.14
@@ -4673,7 +4674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/trusted-types@npm:^2.0.2":
+"@types/trusted-types@npm:^2.0.2, @types/trusted-types@npm:^2.0.7":
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
@@ -7041,6 +7042,18 @@ __metadata:
   dependencies:
     domelementtype: ^2.3.0
   checksum: 0f58f4a6af63e6f3a4320aa446d28b5790a009018707bce2859dcb1d21144c7876482b5188395a188dfa974238c019e0a1e610d2fc269a12b2c192ea2b0b131c
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "dompurify@npm:3.3.1"
+  dependencies:
+    "@types/trusted-types": ^2.0.7
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 884fe0acc21a9a2e5aa1b8ce4cecc8f9a71217423b389f760fca7b44595d3c9376d234f1c4ba16d79824789762b3d611d10653c4a90a7e23b351b71e5ef7dd33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I was able to reproduce an XSS attack by inserting `<button onclick="alert('xss')">XSS BUTTON</button>` into an SRT file and turning on the `render html` option. This change seems to prevent the button from functioning.