### PR TITLE
fix: captureStream usage in Firefox 149

### DIFF
--- a/extension/src/entrypoints/sidepanel/index.html
+++ b/extension/src/entrypoints/sidepanel/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="manifest.open_at_install" content="true" />
+        <meta name="manifest.open_at_install" content="false" />
         <meta
             name="manifest.default_icon"
             content="{
@@ -11,7 +11,7 @@
                 '48': 'icon/icon48.png',
                 '128': 'icon/icon128.png',
             }"
-            />
+        />
         <title>asbplayer</title>
         <style>
             @import url('/fonts/fonts.css');

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -182,6 +182,8 @@ export default class Binding {
     // In the case of firefox, we need to avoid capturing the audio stream more than once,
     // so we keep a reference to the first one we capture here.
     private audioStream?: MediaStream;
+    private audioContext?: AudioContext;
+    private audioVolumeChangeListener?: () => void;
     private currentAudioRecordingRequestId?: string;
 
     private readonly frameId?: string;
@@ -1059,6 +1061,14 @@ export default class Binding {
             this.heartbeatInterval = undefined;
         }
 
+        if (this.audioVolumeChangeListener) {
+            this.video.removeEventListener('volumechange', this.audioVolumeChangeListener);
+            this.audioVolumeChangeListener = undefined;
+        }
+
+        this.audioContext?.close();
+        this.audioContext = undefined;
+
         if (this.listener) {
             browser.runtime.onMessage.removeListener(this.listener);
             this.listener = undefined;
@@ -1534,12 +1544,14 @@ export default class Binding {
             try {
                 let stream: MediaStream | undefined;
 
-                if (typeof (this.video as any).captureStream === 'function') {
-                    stream = (this.video as any).captureStream();
-                }
+                let usedMozCapture = false;
 
-                if (typeof (this.video as any).mozCaptureStreamUntilEnded === 'function') {
+                if (typeof (this.video as any).captureStream === 'function') {
+                    // Introduced in Firefox 149
+                    stream = (this.video as any).captureStream();
+                } else if (typeof (this.video as any).mozCaptureStreamUntilEnded === 'function') {
                     stream = (this.video as any).mozCaptureStreamUntilEnded();
+                    usedMozCapture = true;
                 }
 
                 if (stream === undefined) {
@@ -1559,13 +1571,37 @@ export default class Binding {
                     }
                 }
 
-                // Ensure audio keeps playing through computer speakers
-                const output = new AudioContext();
-                const source = output.createMediaStreamSource(audioStream);
-                source.connect(output.destination);
+                let recordingStream = audioStream;
 
-                this.audioStream = audioStream;
-                resolve(audioStream);
+                if (usedMozCapture) {
+                    // mozCaptureStreamUntilEnded diverts audio away from speakers,
+                    // so route it back via AudioContext to keep audio audible
+                    const audioContext = new AudioContext();
+                    const source = audioContext.createMediaStreamSource(audioStream);
+                    source.connect(audioContext.destination);
+                    this.audioContext = audioContext;
+                } else {
+                    // captureStream() captures at raw volume, independent of video.volume.
+                    // Apply video.volume via a GainNode so the recording level matches what the user hears.
+                    const audioContext = new AudioContext();
+                    const source = audioContext.createMediaStreamSource(audioStream);
+                    const gainNode = audioContext.createGain();
+                    gainNode.gain.value = this.video.muted ? 0 : this.video.volume;
+                    const destination = audioContext.createMediaStreamDestination();
+                    source.connect(gainNode);
+                    gainNode.connect(destination);
+
+                    const volumeChangeListener = () => {
+                        gainNode.gain.value = this.video.muted ? 0 : this.video.volume;
+                    };
+                    this.video.addEventListener('volumechange', volumeChangeListener);
+                    this.audioContext = audioContext;
+                    this.audioVolumeChangeListener = volumeChangeListener;
+                    recordingStream = destination.stream;
+                }
+
+                this.audioStream = recordingStream;
+                resolve(recordingStream);
             } catch (e) {
                 reject(e);
             }


### PR DESCRIPTION
From https://www.firefox.com/en-US/firefox/149.0beta/releasenotes/:

"Enabled the spec-compliant [HTMLMediaElement.captureStream()](https://w3c.github.io/mediacapture-fromelement/#html-media-element-media-capture-extensions) API."

Practically speaking this means that the new captureStream API is now independent of the video's volume, which means that we have to manually map the video's volume to the MediaStream using a gain node, and keep it up to date when the user adjusts the volume.