### PR TITLE
watch common folder for changes

### DIFF
--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -31,6 +31,16 @@ const extName = 'asbplayer';
 export default defineConfig({
     modules: ['@wxt-dev/module-react'],
     srcDir: 'src',
+    vite: () => ({
+        plugins: [
+            {
+                name: 'watch-common',
+                configureServer(server) {
+                    server.watcher.add(path.resolve(__dirname, '../common'));
+                },
+            },
+        ],
+    }),
     zip: {
         sourcesRoot: '..',
         includeSources: ['.yarn/patches/**'],


### PR DESCRIPTION
Noticed when working on common files that the server didn't always reload when changes were made (especially when switching branches). This seems to fix it since I think by default the src folder is the only one being directly watched.