### PR TITLE
Add option to update all cards from the same subtitle line

### DIFF
--- a/common/anki/anki.ts
+++ b/common/anki/anki.ts
@@ -474,7 +474,7 @@ export class Anki {
         };
 
         const gui = mode === 'gui';
-        const updateLast = mode === 'updateLast';
+        const updateLast = mode === 'updateLast' || mode === 'updateLastForSameLine';
 
         if (this.settingsProvider.audioField && audioClip && audioClip.error === undefined) {
             const sanitizedName = this._sanitizeFileName(audioClip.name);
@@ -517,9 +517,10 @@ export class Anki {
         switch (mode) {
             case 'gui':
                 return (await this._executeAction('guiAddCards', params, ankiConnectUrl)).result;
+            case 'updateLastForSameLine':
             case 'updateLast':
                 const recentNotes = (
-                    await this._executeAction('findNotes', { query: 'added:1' }, ankiConnectUrl)
+                    await this._executeAction('findNotes', { query: 'added:2' }, ankiConnectUrl)
                 ).result.sort();
 
                 if (recentNotes.length === 0) {
@@ -546,6 +547,90 @@ export class Anki {
                             { notes: [lastNoteId], tags: tags.join(' ') },
                             ankiConnectUrl
                         );
+                    }
+
+                    // Update other recent cards from the same subtitle line with audio and image.
+                    // Walk backwards from the most recent note, stopping at the first note
+                    // whose sentence doesn't match. This handles cards created across Anki's
+                    // day boundary and avoids scanning the entire deck.
+                    if (mode === 'updateLastForSameLine' && text && this.settingsProvider.sentenceField) {
+                        const normalizedSubtitle = text.replace(/\n/g, ' ');
+                        const sentenceFieldName = this.settingsProvider.sentenceField;
+
+                        // Walk backwards through preceding notes (descending ID order)
+                        const precedingNoteIds = recentNotes
+                            .filter((id: number) => id !== lastNoteId)
+                            .reverse();
+
+                        if (precedingNoteIds.length > 0) {
+                            const precedingInfoResponse = await this._executeAction(
+                                'notesInfo',
+                                { notes: precedingNoteIds },
+                                ankiConnectUrl
+                            );
+
+                            for (const otherInfo of precedingInfoResponse.result) {
+                                const otherSentenceHtml = otherInfo.fields?.[sentenceFieldName]?.value;
+                                if (!otherSentenceHtml) break;
+
+                                const otherSentencePlain = otherSentenceHtml
+                                    .replace(/<br\s*\/?>/gi, ' ')
+                                    .replace(/<[^>]+>/g, '')
+                                    .replace(/&nbsp;/g, ' ')
+                                    .trim();
+
+                                if (
+                                    otherSentencePlain.length === 0 ||
+                                    (!normalizedSubtitle.includes(otherSentencePlain) &&
+                                        !otherSentencePlain.includes(normalizedSubtitle))
+                                ) {
+                                    break;
+                                }
+
+                                // Update asbplayer-provided fields (audio, image, source, url),
+                                // preserving card-specific fields (sentence, word, definition, etc.)
+                                const otherFields: { [key: string]: string } = {};
+
+                                if (this.settingsProvider.audioField && fields[this.settingsProvider.audioField]) {
+                                    otherFields[this.settingsProvider.audioField] =
+                                        fields[this.settingsProvider.audioField];
+                                }
+
+                                if (this.settingsProvider.imageField && fields[this.settingsProvider.imageField]) {
+                                    otherFields[this.settingsProvider.imageField] =
+                                        fields[this.settingsProvider.imageField];
+                                }
+
+                                if (this.settingsProvider.sourceField && fields[this.settingsProvider.sourceField]) {
+                                    otherFields[this.settingsProvider.sourceField] =
+                                        fields[this.settingsProvider.sourceField];
+                                }
+
+                                if (this.settingsProvider.urlField && fields[this.settingsProvider.urlField]) {
+                                    otherFields[this.settingsProvider.urlField] =
+                                        fields[this.settingsProvider.urlField];
+                                }
+
+                                if (Object.keys(otherFields).length === 0) continue;
+
+                                const otherParams = {
+                                    note: {
+                                        id: otherInfo.noteId,
+                                        fields: otherFields,
+                                    },
+                                };
+
+                                await this._executeAction('updateNoteFields', otherParams, ankiConnectUrl);
+
+                                if (tags.length > 0) {
+                                    await this._executeAction(
+                                        'addTags',
+                                        { notes: [otherInfo.noteId], tags: tags.join(' ') },
+                                        ankiConnectUrl
+                                    );
+                                }
+                            }
+                        }
                     }
 
                     if (!this.settingsProvider.wordField || !info.fields) {

--- a/common/anki/anki.ts
+++ b/common/anki/anki.ts
@@ -435,7 +435,7 @@ export class Anki {
         mode,
         ankiConnectUrl,
     }: ExportParams) {
-        const fields = {};
+        const fields: { [key: string]: string } = {};
 
         this._appendField(fields, this.settingsProvider.sentenceField, text, true);
         this._appendField(fields, this.settingsProvider.track1Field, track1, true);

--- a/common/components/MiningSettingsTab.tsx
+++ b/common/components/MiningSettingsTab.tsx
@@ -36,6 +36,7 @@ const MiningSettingsTab: React.FC<Props> = ({ settings, onSettingChanged }) => {
         recordWithAudioPlayback,
         preferMp3,
         copyToClipboardOnMine,
+        updateLastCardForSameSubtitle,
     } = settings;
     const [screenshotDelayInput, setScreenshotDelayInput] = useState(String(streamingScreenshotDelay));
 
@@ -155,6 +156,18 @@ const MiningSettingsTab: React.FC<Props> = ({ settings, onSettingChanged }) => {
                     />
                 }
                 label={t('settings.copyOnMine')}
+                labelPlacement="start"
+            />
+            <SwitchLabelWithHoverEffect
+                control={
+                    <Switch
+                        checked={updateLastCardForSameSubtitle}
+                        onChange={(event) =>
+                            onSettingChanged('updateLastCardForSameSubtitle', event.target.checked)
+                        }
+                    />
+                }
+                label={t('settings.updateLastCardForSameSubtitle')}
                 labelPlacement="start"
             />
             <SettingsSection>{t('settings.audio')}</SettingsSection>

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -357,6 +357,7 @@
         "fastForwardModePlaybackRate": "Fast-forward mode playback rate",
         "coloringStrategy": "Coloring strategy",
         "copyOnMine": "Copy mined subtitles to clipboard",
+        "updateLastCardForSameSubtitle": "Update all cards from the same subtitle line",
         "corsHelperText": "Ensure that {{origin}} is in the webCorsOriginList in your AnkiConnect settings as in this <0>video</0>.",
         "customCssField": "CSS: {{styleKey}}",
         "deck": "Deck",

--- a/common/settings/settings-import-export.ts
+++ b/common/settings/settings-import-export.ts
@@ -403,6 +403,9 @@ const settingsSchema = {
         copyToClipboardOnMine: {
             type: 'boolean',
         },
+        updateLastCardForSameSubtitle: {
+            type: 'boolean',
+        },
         rememberSubtitleOffset: {
             type: 'boolean',
         },

--- a/common/settings/settings-provider.ts
+++ b/common/settings/settings-provider.ts
@@ -167,6 +167,7 @@ export const defaultSettings: AsbplayerSettings = {
     miningHistoryStorageLimit: 25,
     clickToMineDefaultAction: PostMineAction.showAnkiDialog,
     postMiningPlaybackState: PostMinePlayback.remember,
+    updateLastCardForSameSubtitle: false,
     themeType: 'dark',
     copyToClipboardOnMine: false,
     rememberSubtitleOffset: true,

--- a/common/settings/settings.ts
+++ b/common/settings/settings.ts
@@ -26,6 +26,7 @@ export interface MiscSettings {
     readonly language: string;
     readonly clickToMineDefaultAction: PostMineAction;
     readonly postMiningPlaybackState: PostMinePlayback;
+    readonly updateLastCardForSameSubtitle: boolean;
     readonly lastSubtitleOffset: number;
     readonly lastSelectedAnkiExportMode: AnkiExportMode;
     readonly tabName: string;

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -122,7 +122,7 @@ export interface AudioModel {
     readonly error?: AudioErrorCode;
 }
 
-export type AnkiExportMode = 'gui' | 'updateLast' | 'default';
+export type AnkiExportMode = 'gui' | 'updateLast' | 'updateLastForSameLine' | 'default';
 
 export interface AnkiDialogSettings extends AnkiSettings {
     themeType: string;

--- a/extension/src/services/card-publisher.ts
+++ b/extension/src/services/card-publisher.ts
@@ -159,7 +159,8 @@ export class CardPublisher {
 
     private async _updateLastCard(card: CardModel, src: string | undefined, tabId: number) {
         const ankiSettings = (await this._settingsProvider.get(ankiSettingsKeys)) as AnkiSettings;
-        const cardName = await exportCard(card, ankiSettings, 'updateLast');
+        const updateSameLine = await this._settingsProvider.getSingle('updateLastCardForSameSubtitle');
+        const cardName = await exportCard(card, ankiSettings, updateSameLine ? 'updateLastForSameLine' : 'updateLast');
 
         const cardUpdatedCommand: ExtensionToVideoCommand<CardUpdatedMessage> = {
             sender: 'asbplayer-extension-to-video',


### PR DESCRIPTION
## Summary
- Adds a new toggle in Mining Settings: **"Update all cards from the same subtitle line"**
- When enabled, the "update last card" action also updates audio, image, source, and URL fields on other recently-created cards whose sentence matches the current subtitle line
- Useful when mining multiple words from the same subtitle — all cards get the same screenshot and audio, not just the last one

## Details
- New `updateLastCardForSameSubtitle` setting (default: off)
- New `updateLastForSameLine` export mode that extends `updateLast`
- Walks backwards through recent notes (last 2 days to handle Anki's day boundary), stops at the first note whose sentence doesn't match
- Only updates asbplayer-provided fields (audio, image, source, URL), preserving card-specific fields (word, definition, etc.)

## Test plan
- [ ] Enable the setting in Mining Settings
- [ ] Mine multiple words from the same subtitle line
- [ ] Use "update last card" — verify all cards from that line get updated with screenshot and audio
- [ ] Verify cards from different subtitle lines are not affected
- [ ] Verify the setting defaults to off and existing behavior is unchanged when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)