### PR TITLE
Fix Disney+ subtitle sync via MSE SourceBuffer.timestampOffset interception

### DIFF
--- a/common/subtitle-reader/subtitle-reader.test.ts
+++ b/common/subtitle-reader/subtitle-reader.test.ts
@@ -1,0 +1,96 @@
+jest.mock('@qgustavor/srt-parser', () => {
+    return { default: class {} };
+});
+jest.mock('ass-compiler', () => {
+    return { compile: () => ({ dialogues: [] }) };
+});
+jest.mock('fast-xml-parser', () => {
+    return { XMLParser: class {} };
+});
+jest.mock('dompurify', () => ({
+    __esModule: true,
+    default: { sanitize: (html: string) => html },
+    sanitize: (html: string) => html,
+}));
+
+import SubtitleReader from './subtitle-reader';
+import { SubtitleHtml } from '@project/common';
+
+function makeVttFile(content: string, name: string = 'test.vtt'): File {
+    const file = new File([content], name, { type: 'text/plain' });
+    // jsdom does not implement Blob.prototype.text(), so polyfill it
+    if (typeof file.text !== 'function') {
+        (file as any).text = () =>
+            new Promise<string>((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = () => resolve(reader.result as string);
+                reader.onerror = () => reject(reader.error);
+                reader.readAsText(file);
+            });
+    }
+    return file;
+}
+
+describe('SubtitleReader VTT parsing', () => {
+    let reader: SubtitleReader;
+
+    beforeEach(() => {
+        reader = new SubtitleReader({
+            regexFilter: '',
+            regexFilterTextReplacement: '',
+            subtitleHtml: SubtitleHtml.render,
+            convertNetflixRuby: false,
+            pgsParserWorkerFactory: () => {
+                throw new Error('PGS not supported in test');
+            },
+        });
+    });
+
+    it('parses a simple VTT file', async () => {
+        const vtt = `WEBVTT
+
+00:00:01.000 --> 00:00:04.000
+Hello world
+
+00:00:05.000 --> 00:00:08.000
+Second subtitle
+`;
+        const files = [makeVttFile(vtt)];
+        const subtitles = await reader.subtitles(files);
+
+        expect(subtitles).toHaveLength(2);
+        expect(subtitles[0].start).toBe(1000);
+        expect(subtitles[0].end).toBe(4000);
+        expect(subtitles[0].text).toBe('Hello world');
+        expect(subtitles[1].start).toBe(5000);
+        expect(subtitles[1].end).toBe(8000);
+        expect(subtitles[1].text).toBe('Second subtitle');
+    });
+
+    it('flattens multiple VTT segments with absolute timestamps', async () => {
+        const segment1 = `WEBVTT
+
+00:00:01.000 --> 00:00:04.000
+First segment
+
+00:00:05.000 --> 00:00:08.000
+Still first segment
+`;
+        const segment2 = `WEBVTT
+
+00:05:01.000 --> 00:05:04.000
+Second segment
+
+00:05:05.000 --> 00:05:08.000
+Still second segment
+`;
+        const files = [makeVttFile(segment1, 'subs.vtt'), makeVttFile(segment2, 'subs.vtt')];
+        const subtitles = await reader.subtitles(files, true);
+
+        expect(subtitles).toHaveLength(4);
+        expect(subtitles[0].start).toBe(1000);
+        expect(subtitles[0].text).toBe('First segment');
+        expect(subtitles[2].start).toBe(301000);
+        expect(subtitles[2].text).toBe('Second segment');
+    });
+});

--- a/extension/src/controllers/subtitle-controller.ts
+++ b/extension/src/controllers/subtitle-controller.ts
@@ -104,6 +104,7 @@ export default class SubtitleController {
     dictionaryTrackSettings?: DictionaryTrack[];
 
     readonly autoPauseContext: AutoPauseContext = new AutoPauseContext();
+    mseBaseOffsetMs: number = 0;
 
     onNextToShow?: (subtitle: SubtitleModel) => void;
     onSlice?: (subtitle: SubtitleSlice<IndexedSubtitleModel>) => void;
@@ -657,7 +658,7 @@ export default class SubtitleController {
 
         this.settings.getSingle('rememberSubtitleOffset').then((rememberSubtitleOffset) => {
             if (rememberSubtitleOffset) {
-                this.settings.set({ lastSubtitleOffset: offset });
+                this.settings.set({ lastSubtitleOffset: offset - this.mseBaseOffsetMs });
             }
         });
     }

--- a/extension/src/entrypoints/disney-plus-page.ts
+++ b/extension/src/entrypoints/disney-plus-page.ts
@@ -2,6 +2,169 @@ import { inferTracks } from '@/pages/util';
 import { subtitleTrackSegmentsFromM3U8 } from '@/pages/m3u8-util';
 
 export default defineUnlistedScript(() => {
+    const requestMseOffsetEventName = 'asbplayer-get-disney-plus-mse-offset';
+    const mseOffsetEventName = 'asbplayer-disney-plus-mse-offset';
+
+    interface MediaSourceOffsetState {
+        blobUrl?: string;
+        audioOffsetSeconds?: number;
+        videoOffsetSeconds?: number;
+        updatedAt: number;
+        notifiedOffsetMs?: number;
+    }
+
+    const stateByMediaSource = new WeakMap<MediaSource, MediaSourceOffsetState>();
+    const stateByBlobUrl = new Map<string, MediaSourceOffsetState>();
+    const mediaSourceBySourceBuffer = new WeakMap<SourceBuffer, MediaSource>();
+    const mimeTypeBySourceBuffer = new WeakMap<SourceBuffer, string>();
+
+    const ensureState = (mediaSource: MediaSource) => {
+        let state = stateByMediaSource.get(mediaSource);
+
+        if (state === undefined) {
+            state = { updatedAt: 0 };
+            stateByMediaSource.set(mediaSource, state);
+        }
+
+        return state;
+    };
+
+    const validOffsetSeconds = (offsetSeconds: number) =>
+        Number.isFinite(offsetSeconds) && Math.abs(offsetSeconds) < 86400;
+
+    const stateOffsetMs = (state: MediaSourceOffsetState | undefined) => {
+        if (state === undefined) {
+            return undefined;
+        }
+
+        const offsetSeconds = state.videoOffsetSeconds ?? state.audioOffsetSeconds;
+
+        if (offsetSeconds === undefined || !validOffsetSeconds(offsetSeconds)) {
+            return undefined;
+        }
+
+        return Math.round(offsetSeconds * 1000);
+    };
+
+    const currentOffsetDetail = () => {
+        const candidateVideos = [...document.querySelectorAll('video')].filter((video) => video.src.startsWith('blob:'));
+        const currentBlobUrl = candidateVideos[candidateVideos.length - 1]?.src;
+        const currentState = currentBlobUrl ? stateByBlobUrl.get(currentBlobUrl) : undefined;
+        const offsetMs = stateOffsetMs(currentState);
+
+        if (offsetMs !== undefined) {
+            return {
+                blobUrl: currentBlobUrl,
+                mseBaseOffsetMs: offsetMs,
+            };
+        }
+
+        let latestBlobUrl: string | undefined = undefined;
+        let latestState: MediaSourceOffsetState | undefined = undefined;
+
+        for (const [blobUrl, state] of stateByBlobUrl.entries()) {
+            if (latestState === undefined || state.updatedAt > latestState.updatedAt) {
+                latestBlobUrl = blobUrl;
+                latestState = state;
+            }
+        }
+
+        const latestOffsetMs = stateOffsetMs(latestState);
+
+        if (latestOffsetMs !== undefined) {
+            return {
+                blobUrl: latestBlobUrl,
+                mseBaseOffsetMs: latestOffsetMs,
+            };
+        }
+
+        return undefined;
+    };
+
+    const dispatchOffset = (state: MediaSourceOffsetState) => {
+        const offsetMs = stateOffsetMs(state);
+
+        if (offsetMs === undefined || state.notifiedOffsetMs === offsetMs) {
+            return;
+        }
+
+        state.notifiedOffsetMs = offsetMs;
+        document.dispatchEvent(
+            new CustomEvent(mseOffsetEventName, {
+                detail: {
+                    blobUrl: state.blobUrl,
+                    mseBaseOffsetMs: offsetMs,
+                },
+            })
+        );
+    };
+
+    const captureOffset = (sourceBuffer: SourceBuffer, offsetSeconds: number) => {
+        const mediaSource = mediaSourceBySourceBuffer.get(sourceBuffer);
+
+        if (mediaSource === undefined || !validOffsetSeconds(offsetSeconds)) {
+            return;
+        }
+
+        const state = ensureState(mediaSource);
+        state.updatedAt = Date.now();
+
+        if (mimeTypeBySourceBuffer.get(sourceBuffer)?.startsWith('video/')) {
+            state.videoOffsetSeconds = offsetSeconds;
+        } else {
+            state.audioOffsetSeconds = offsetSeconds;
+        }
+
+        dispatchOffset(state);
+    };
+
+    const originalCreateObjectURL = URL.createObjectURL.bind(URL);
+    URL.createObjectURL = function (object: Blob | MediaSource) {
+        const blobUrl = originalCreateObjectURL(object);
+
+        if (object instanceof MediaSource) {
+            const state = ensureState(object);
+            state.blobUrl = blobUrl;
+            state.updatedAt = Date.now();
+            stateByBlobUrl.set(blobUrl, state);
+            dispatchOffset(state);
+        }
+
+        return blobUrl;
+    };
+
+    const originalAddSourceBuffer = MediaSource.prototype.addSourceBuffer;
+    MediaSource.prototype.addSourceBuffer = function (mimeType: string) {
+        const sourceBuffer = originalAddSourceBuffer.call(this, mimeType);
+        mediaSourceBySourceBuffer.set(sourceBuffer, this);
+        mimeTypeBySourceBuffer.set(sourceBuffer, mimeType);
+        return sourceBuffer;
+    };
+
+    const timestampOffsetDescriptor = Object.getOwnPropertyDescriptor(SourceBuffer.prototype, 'timestampOffset');
+
+    if (timestampOffsetDescriptor?.set && timestampOffsetDescriptor.get) {
+        Object.defineProperty(SourceBuffer.prototype, 'timestampOffset', {
+            configurable: timestampOffsetDescriptor.configurable ?? true,
+            enumerable: timestampOffsetDescriptor.enumerable ?? false,
+            get() {
+                return timestampOffsetDescriptor.get!.call(this);
+            },
+            set(value: number) {
+                timestampOffsetDescriptor.set!.call(this, value);
+                captureOffset(this, value);
+            },
+        });
+    }
+
+    document.addEventListener(requestMseOffsetEventName, () => {
+        const detail = currentOffsetDetail();
+
+        if (detail !== undefined) {
+            document.dispatchEvent(new CustomEvent(mseOffsetEventName, { detail }));
+        }
+    });
+
     setTimeout(() => {
         let lastM3U8Url: string | undefined = undefined;
         let lastBasename: string | undefined = undefined;

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -97,6 +97,9 @@ document.addEventListener('asbplayer-netflix-enabled', (e) => {
 document.dispatchEvent(new CustomEvent('asbplayer-query-netflix'));
 
 const youtube = /(m|www)\.youtube\.com/.test(window.location.host);
+const disneyPlus = window.location.host === 'www.disneyplus.com';
+const requestDisneyPlusMseOffsetEventName = 'asbplayer-get-disney-plus-mse-offset';
+const disneyPlusMseOffsetEventName = 'asbplayer-disney-plus-mse-offset';
 
 enum RecordingState {
     requested,
@@ -185,6 +188,7 @@ export default class Binding {
     private videoChangeListener?: EventListener;
     private canPlayListener?: EventListener;
     private mouseMoveListener?: (event: MouseEvent) => void;
+    private disneyPlusMseOffsetListener?: EventListener;
     private listener?: (
         message: any,
         sender: Browser.runtime.MessageSender,
@@ -201,6 +205,7 @@ export default class Binding {
 
     private readonly frameId?: string;
     private _mseBaseOffsetMs: number = 0;
+    private _pageScriptMseBaseOffsetMs?: number;
 
     constructor(video: HTMLMediaElement, hasPageScript: boolean, frameId?: string) {
         this.video = video;
@@ -482,6 +487,7 @@ export default class Binding {
     }
 
     _bind() {
+        this._installDisneyPlusMseOffsetListener();
         this._notifyReady();
         this._mseBaseOffsetMs = this._detectMseBaseOffset();
         this.subtitleController.mseBaseOffsetMs = this._mseBaseOffsetMs;
@@ -1119,6 +1125,11 @@ export default class Binding {
             this.mouseMoveListener = undefined;
         }
 
+        if (this.disneyPlusMseOffsetListener) {
+            document.removeEventListener(disneyPlusMseOffsetEventName, this.disneyPlusMseOffsetListener);
+            this.disneyPlusMseOffsetListener = undefined;
+        }
+
         if (this.heartbeatInterval) {
             clearInterval(this.heartbeatInterval);
             this.heartbeatInterval = undefined;
@@ -1600,7 +1611,50 @@ export default class Binding {
         this.mobileVideoOverlayController.disposeOverlay();
     }
 
+    private _installDisneyPlusMseOffsetListener() {
+        if (!disneyPlus || !this.hasPageScript || this.disneyPlusMseOffsetListener !== undefined) {
+            return;
+        }
+
+        this.disneyPlusMseOffsetListener = (event) => {
+            const offsetMs = (event as CustomEvent).detail?.mseBaseOffsetMs;
+
+            if (typeof offsetMs !== 'number' || !Number.isFinite(offsetMs)) {
+                return;
+            }
+
+            const previousMseBaseOffsetMs = this._mseBaseOffsetMs;
+            this._pageScriptMseBaseOffsetMs = offsetMs;
+            this._mseBaseOffsetMs = offsetMs;
+            this.subtitleController.mseBaseOffsetMs = offsetMs;
+
+            const subtitles = this.subtitleController.subtitles;
+
+            if (subtitles.length > 0) {
+                const currentOffset = subtitles[0].start - subtitles[0].originalStart;
+                const userOffset = currentOffset - previousMseBaseOffsetMs;
+                this.subtitleController.offset(userOffset + offsetMs, true);
+            }
+        };
+        document.addEventListener(disneyPlusMseOffsetEventName, this.disneyPlusMseOffsetListener);
+    }
+
+    private _requestDisneyPlusMseBaseOffset() {
+        if (!disneyPlus || !this.hasPageScript) {
+            return this._pageScriptMseBaseOffsetMs;
+        }
+
+        document.dispatchEvent(new CustomEvent(requestDisneyPlusMseOffsetEventName));
+        return this._pageScriptMseBaseOffsetMs;
+    }
+
     private _detectMseBaseOffset(): number {
+        const pageScriptOffsetMs = this._requestDisneyPlusMseBaseOffset();
+
+        if (pageScriptOffsetMs !== undefined) {
+            return pageScriptOffsetMs;
+        }
+
         if (!this.video.src.startsWith('blob:') || (isFinite(this.video.duration) && !isNaN(this.video.duration))) {
             return 0;
         }

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -88,6 +88,7 @@ import { pgsParserWorkerFactory } from './pgs-parser-worker-factory';
 import { DictionaryProvider } from '@project/common/dictionary-db/dictionary-provider';
 import { ExtensionDictionaryStorage } from './extension-dictionary-storage';
 import { HoveredToken } from '@project/common/subtitle-coloring';
+import { createVideoChangeHandler } from './video-change-handler';
 
 let netflix = false;
 document.addEventListener('asbplayer-netflix-enabled', (e) => {
@@ -199,6 +200,7 @@ export default class Binding {
     private currentAudioRecordingRequestId?: string;
 
     private readonly frameId?: string;
+    private _mseBaseOffsetMs: number = 0;
 
     constructor(video: HTMLMediaElement, hasPageScript: boolean, frameId?: string) {
         this.video = video;
@@ -481,6 +483,8 @@ export default class Binding {
 
     _bind() {
         this._notifyReady();
+        this._mseBaseOffsetMs = this._detectMseBaseOffset();
+        this.subtitleController.mseBaseOffsetMs = this._mseBaseOffsetMs;
         this._subscribe();
         this._refreshSettings().then(() => {
             this.videoDataSyncController.requestSubtitles();
@@ -641,10 +645,12 @@ export default class Binding {
         this.subtitleController.onMouseOut = (mouseEvent: MouseEvent) => this.hoveredToken.handleMouseOut(mouseEvent);
 
         if (this.hasPageScript) {
-            this.videoChangeListener = () => {
+            this.videoChangeListener = createVideoChangeHandler(this.video, () => {
+                this._mseBaseOffsetMs = this._detectMseBaseOffset();
+                this.subtitleController.mseBaseOffsetMs = this._mseBaseOffsetMs;
                 this.videoDataSyncController.requestSubtitles();
                 this._resetSubtitles();
-            };
+            });
             this.video.addEventListener('loadedmetadata', this.videoChangeListener);
         }
 
@@ -1505,7 +1511,8 @@ export default class Binding {
                     convertNetflixRuby: convertNetflixRuby,
                     pgsParserWorkerFactory: pgsParserWorkerFactory,
                 });
-                const offset = rememberSubtitleOffset ? lastSubtitleOffset : 0;
+                const userOffset = rememberSubtitleOffset ? lastSubtitleOffset : 0;
+                const offset = userOffset + this._mseBaseOffsetMs;
                 const subtitles = await reader.subtitles(files, flatten);
 
                 // Order is important: sync with tab first, then update our subtitle controller
@@ -1591,6 +1598,20 @@ export default class Binding {
         this._synced = false;
         this._syncedTimestamp = undefined;
         this.mobileVideoOverlayController.disposeOverlay();
+    }
+
+    private _detectMseBaseOffset(): number {
+        if (!this.video.src.startsWith('blob:') || (isFinite(this.video.duration) && !isNaN(this.video.duration))) {
+            return 0;
+        }
+        if (this.video.seekable.length === 0) {
+            return 0;
+        }
+        const offsetSeconds = this.video.currentTime - this.video.seekable.start(0);
+        if (offsetSeconds > 0.5 && offsetSeconds < 86400) {
+            return Math.round(offsetSeconds * 1000);
+        }
+        return 0;
     }
 
     private _captureStream(): Promise<MediaStream> {

--- a/extension/src/services/video-change-handler.test.ts
+++ b/extension/src/services/video-change-handler.test.ts
@@ -1,0 +1,82 @@
+import { createVideoChangeHandler } from './video-change-handler';
+
+describe('createVideoChangeHandler', () => {
+    let video: HTMLVideoElement;
+    let onVideoChange: jest.Mock;
+    let handler: () => void;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        video = document.createElement('video');
+        Object.defineProperty(video, 'src', { value: 'https://cdn.example.com/stream1.mpd', writable: true });
+        onVideoChange = jest.fn();
+        handler = createVideoChangeHandler(video, onVideoChange);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('does not call onVideoChange when video.src has not changed', () => {
+        handler();
+        jest.advanceTimersByTime(2000);
+        expect(onVideoChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call onVideoChange when video.src has not changed across multiple firings', () => {
+        handler();
+        handler();
+        handler();
+        jest.advanceTimersByTime(2000);
+        expect(onVideoChange).not.toHaveBeenCalled();
+    });
+
+    it('calls onVideoChange after debounce when video.src changes', () => {
+        (video as any).src = 'https://cdn.example.com/stream2.mpd';
+        handler();
+        expect(onVideoChange).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1000);
+        expect(onVideoChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('debounces rapid src changes to a single call', () => {
+        (video as any).src = 'https://cdn.example.com/stream2.mpd';
+        handler();
+        jest.advanceTimersByTime(500);
+
+        (video as any).src = 'https://cdn.example.com/stream3.mpd';
+        handler();
+        jest.advanceTimersByTime(500);
+
+        // First timer was cleared, only 500ms since last change
+        expect(onVideoChange).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(500);
+        expect(onVideoChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores loadedmetadata firings after src change settles', () => {
+        (video as any).src = 'https://cdn.example.com/stream2.mpd';
+        handler();
+        jest.advanceTimersByTime(1000);
+        expect(onVideoChange).toHaveBeenCalledTimes(1);
+
+        // Same src, should be ignored
+        handler();
+        handler();
+        jest.advanceTimersByTime(2000);
+        expect(onVideoChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles multiple distinct src changes over time', () => {
+        (video as any).src = 'https://cdn.example.com/stream2.mpd';
+        handler();
+        jest.advanceTimersByTime(1000);
+        expect(onVideoChange).toHaveBeenCalledTimes(1);
+
+        (video as any).src = 'https://cdn.example.com/stream3.mpd';
+        handler();
+        jest.advanceTimersByTime(1000);
+        expect(onVideoChange).toHaveBeenCalledTimes(2);
+    });
+});

--- a/extension/src/services/video-change-handler.ts
+++ b/extension/src/services/video-change-handler.ts
@@ -1,0 +1,23 @@
+const videoChangeDebounceMs = 1000;
+
+export function createVideoChangeHandler(
+    video: HTMLMediaElement,
+    onVideoChange: () => void
+): () => void {
+    let lastVideoSrc: string | undefined = video.src;
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    return () => {
+        if (video.src === lastVideoSrc) {
+            return;
+        }
+        lastVideoSrc = video.src;
+        if (debounceTimer !== undefined) {
+            clearTimeout(debounceTimer);
+        }
+        debounceTimer = setTimeout(() => {
+            debounceTimer = undefined;
+            onVideoChange();
+        }, videoChangeDebounceMs);
+    };
+}


### PR DESCRIPTION
## Summary

- **Auto-detect MSE base time offset** for streaming services where `video.currentTime` does not start at 0 due to MPEG-TS PTS values. Detected via `currentTime - seekable.start(0)` when the video source is a blob URL with infinite duration.
- **Intercept `SourceBuffer.timestampOffset`** on Disney+ to capture the exact content-time offset set by the player SDK. This enables correct subtitle alignment even after seek operations that recreate the MediaSource.
- **Debounce `loadedmetadata` handler** with src-change gating to prevent spurious subtitle resets during stream quality changes.
- **Separate MSE offset from user offset** in persistence to prevent double-application across sessions.

### Background

Disney+ uses MSE (Media Source Extensions) where `video.currentTime` starts at a non-zero PTS base (~20s) and resets on every seek (new MediaSource created with a new blob URL). VTT subtitle timestamps use absolute content time (0:00-based). Without offset correction, subtitles are misaligned by tens of seconds.

The `SourceBuffer.timestampOffset` property (set by Disney+ to negative values like -276s, -666s) provides the exact mapping from MPEG-TS time to media timeline, enabling the formula: `contentPosition = currentTime - timestampOffset`.

### Changed files

| File | Change |
|------|--------|
| `extension/src/entrypoints/disney-plus-page.ts` | Intercept `URL.createObjectURL`, `MediaSource.addSourceBuffer`, and `SourceBuffer.timestampOffset` to capture MSE offset and communicate via custom DOM events |
| `extension/src/services/binding.ts` | MSE offset detection (generic + Disney+ page-script), apply to subtitle timestamps, debounced loadedmetadata handler |
| `extension/src/controllers/subtitle-controller.ts` | `mseBaseOffsetMs` field to exclude MSE offset from persisted user offset |
| `extension/src/services/video-change-handler.ts` | Extracted loadedmetadata handler with src-change check and debounce |
| `extension/src/services/video-change-handler.test.ts` | Unit tests for debounce and src-change gating |
| `common/subtitle-reader/subtitle-reader.test.ts` | Unit tests for VTT parsing |

## Test plan

- [x] Unit tests pass (`yarn workspace @project/extension run test`, `yarn workspace @project/common run test`)
- [x] Disney+: subtitles align correctly on initial playback
- [x] Disney+: subtitles align correctly after seek / skip recap
- [x] Disney+: side panel subtitle list follows playback position
- [ ] Verify no regression on YouTube, Netflix, or local file playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)