### PR TITLE
feat: add online subtitle source support

### DIFF
--- a/common/global-state/index.ts
+++ b/common/global-state/index.ts
@@ -9,16 +9,24 @@ export enum AnnotationTutorialState {
     hasSeen = 2,
 }
 
+export interface OnlineSubtitleSourceConfig {
+    jimakuApiKey: string;
+}
+
 export const initialGlobalState: GlobalState = {
     ftueHasSeenAnkiDialogQuickSelectV2: false,
     ftueHasSeenSubtitleTrackSelector: false,
     ftueAnnotation: AnnotationTutorialState.hasNotSeen,
+    onlineSubtitleSourceConfig: {
+        jimakuApiKey: '',
+    },
 };
 
 export interface GlobalState {
     ftueHasSeenAnkiDialogQuickSelectV2: boolean;
     ftueHasSeenSubtitleTrackSelector: boolean;
     ftueAnnotation: AnnotationTutorialState;
+    onlineSubtitleSourceConfig: OnlineSubtitleSourceConfig;
 }
 
 export interface GlobalStateProvider {

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "App update",
         "pwaUpdatePromptBody": "Click \"OK\" to complete update."
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "App update",
         "pwaUpdatePromptBody": "Click \"OK\" to complete update."
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "App update",
         "pwaUpdatePromptBody": "Click \"OK\" to complete update."
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "Sovelluspäivitys",
         "pwaUpdatePromptBody": "Napsauta \"OK\" suorittaaksesi päivityksen."
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "Mise à jour de l'application",
         "pwaUpdatePromptBody": "Cliquez sur \"OK\" pour terminer la mise à jour."
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "Pembaruan aplikasi",
         "pwaUpdatePromptBody": "Klik \"OK\" untuk menyelesaikan pembaruan."
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "アプリ更新",
         "pwaUpdatePromptBody": "「OK」をクリックすると更新が完了します。"
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "앱 업데이트",
         "pwaUpdatePromptBody": "‘OK’를 클릭하면 업데이트가 완료됩니다"
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "App update",
         "pwaUpdatePromptBody": "Click \"OK\" to complete update."
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "Atualização do aplicativo",
         "pwaUpdatePromptBody": "Clique em \"OK\" para concluir a atualização."
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "Обновление плеера",
         "pwaUpdatePromptBody": "Нажмите \"OK\", чтобы завершить обновление."
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -607,5 +607,15 @@
     "app": {
         "pwaUpdatePromptTitle": "应用版本更新",
         "pwaUpdatePromptBody": "点击“确定”以完成更新。"
+    },
+    "onlineSubtitleSources": {
+        "title": "Online subtitle sources",
+        "searchTerm": "Search term",
+        "jimakuApiKey": "Jimaku API key",
+        "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
+        "entries": "Entries",
+        "noEntries": "No entries",
+        "availableFiles": "Available files",
+        "noFiles": "No available files"
     }
 }

--- a/common/src/message.ts
+++ b/common/src/message.ts
@@ -9,7 +9,7 @@ import type {
     TokenState,
     TokenStatus,
 } from '../settings/settings';
-import type { GlobalState } from '../global-state';
+import type { GlobalState, OnlineSubtitleSourceConfig } from '../global-state';
 import type { DictionaryStatisticsSnapshot } from '../dictionary-statistics';
 import {
     RectModel,
@@ -517,6 +517,11 @@ export interface VideoDataUiBridgeConfirmMessage extends Message {
 export interface VideoDataUiBridgeOpenFileMessage extends Message {
     readonly command: 'openFile';
     readonly subtitles: SerializedSubtitleFile[];
+}
+
+export interface VideoDataUiBridgeSetOnlineSubtitleSourceConfigMessage extends Message {
+    readonly command: 'setOnlineSubtitleSourceConfig';
+    readonly state: Partial<OnlineSubtitleSourceConfig>;
 }
 
 export interface CropAndResizeMessage extends Message, ImageCaptureParams {

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -1,4 +1,5 @@
 import type { AnkiSettings, TokenState, TokenStatus } from '../settings/settings';
+import type { OnlineSubtitleSourceConfig } from '../global-state';
 
 type Profile = { name: string };
 
@@ -231,6 +232,7 @@ export interface VideoDataUiModel {
     openReason?: VideoDataUiOpenReason;
     openedFromAsbplayerId?: string;
     defaultCheckboxState?: boolean;
+    onlineSubtitleSourceConfig?: OnlineSubtitleSourceConfig;
     settings: VideoDataUiSettings;
     hasSeenFtue: boolean;
     hideRememberTrackPreferenceToggle: boolean;

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -8,6 +8,7 @@ import {
     VideoDataSubtitleTrack,
     VideoDataUiBridgeConfirmMessage,
     VideoDataUiBridgeOpenFileMessage,
+    VideoDataUiBridgeSetOnlineSubtitleSourceConfigMessage,
     VideoDataUiModel,
     VideoDataUiOpenReason,
     VideoToExtensionCommand,
@@ -200,8 +201,12 @@ export default class VideoDataSyncController {
         const themeType = await this._context.settings.getSingle('themeType');
         const profilesPromise = this._context.settings.profiles();
         const activeProfilePromise = this._context.settings.activeProfile();
-        const hasSeenFtue = (await globalStateProvider.get(['ftueHasSeenSubtitleTrackSelector']))
-            .ftueHasSeenSubtitleTrackSelector;
+        const globalState = await globalStateProvider.get([
+            'ftueHasSeenSubtitleTrackSelector',
+            'onlineSubtitleSourceConfig',
+        ]);
+        const hasSeenFtue = globalState.ftueHasSeenSubtitleTrackSelector;
+        const onlineSubtitleSourceConfig = globalState.onlineSubtitleSourceConfig;
         const hideRememberTrackPreferenceToggle = this._isTutorial || (await this._pageHidesTrackPrefToggle());
         return this._syncedData
             ? {
@@ -219,6 +224,7 @@ export default class VideoDataSyncController {
                   },
                   hasSeenFtue,
                   hideRememberTrackPreferenceToggle,
+                  onlineSubtitleSourceConfig,
                   ...additionalFields,
               }
             : {
@@ -237,6 +243,7 @@ export default class VideoDataSyncController {
                   },
                   hasSeenFtue,
                   hideRememberTrackPreferenceToggle,
+                  onlineSubtitleSourceConfig,
                   ...additionalFields,
               };
     }
@@ -364,6 +371,22 @@ export default class VideoDataSyncController {
 
                 if ('dismissFtue' === message.command) {
                     globalStateProvider.set({ ftueHasSeenSubtitleTrackSelector: true }).catch(console.error);
+                    return;
+                }
+
+                if ('setOnlineSubtitleSourceConfig' === message.command) {
+                    const setOnlineSubtitleSourceConfigMessage =
+                        message as VideoDataUiBridgeSetOnlineSubtitleSourceConfigMessage;
+                    const currentOnlineSubtitleSourceConfig = (
+                        await globalStateProvider.get(['onlineSubtitleSourceConfig'])
+                    ).onlineSubtitleSourceConfig;
+
+                    await globalStateProvider.set({
+                        onlineSubtitleSourceConfig: {
+                            ...currentOnlineSubtitleSourceConfig,
+                            ...setOnlineSubtitleSourceConfigMessage.state,
+                        },
+                    });
                     return;
                 }
 

--- a/extension/src/services/extension-global-state-provider.test.ts
+++ b/extension/src/services/extension-global-state-provider.test.ts
@@ -23,5 +23,8 @@ it('can retrieve all keys', async () => {
         ftueHasSeenAnkiDialogQuickSelectV2: false,
         ftueHasSeenSubtitleTrackSelector: false,
         ftueAnnotation: 0,
+        onlineSubtitleSourceConfig: {
+            jimakuApiKey: '',
+        },
     });
 });

--- a/extension/src/services/subtitle-sources.test.ts
+++ b/extension/src/services/subtitle-sources.test.ts
@@ -95,4 +95,3 @@ describe('JimakuClient', () => {
         await expect(client.getEntry(123)).rejects.toThrow('Jimaku request failed: expected a JSON response body');
     });
 });
-

--- a/extension/src/services/subtitle-sources.test.ts
+++ b/extension/src/services/subtitle-sources.test.ts
@@ -1,0 +1,98 @@
+import { JimakuClient } from './subtitle-sources';
+
+const createResponse = ({
+    ok = true,
+    status = 200,
+    statusText = 'OK',
+    jsonData,
+    textData,
+    headers = {},
+}: {
+    ok?: boolean;
+    status?: number;
+    statusText?: string;
+    jsonData?: unknown;
+    textData?: string;
+    headers?: Record<string, string>;
+}) => {
+    return {
+        ok,
+        status,
+        statusText,
+        headers: {
+            get: (key: string) => headers[key.toLowerCase()] ?? null,
+        },
+        text: async () => (textData !== undefined ? textData : JSON.stringify(jsonData)),
+    } as unknown as Response;
+};
+
+describe('JimakuClient', () => {
+    it('validates api key at construction', () => {
+        expect(() => new JimakuClient({ apiKey: '   ' })).toThrow('Jimaku API key cannot be empty or whitespace-only');
+    });
+
+    it('searches entries with authorization header', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(
+            createResponse({
+                jsonData: [{ id: 729, name: 'Sousou no Frieren' }],
+                headers: {
+                    'x-ratelimit-limit': '100',
+                    'x-ratelimit-remaining': '99',
+                    'x-ratelimit-reset-after': '1.5',
+                },
+            })
+        );
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        const response = await client.searchEntries('Sousou no Frieren');
+
+        expect(fetchMock).toHaveBeenCalledWith('https://jimaku.cc/api/entries/search?query=Sousou+no+Frieren', {
+            headers: { Authorization: 'test-key' },
+        });
+        expect(response.data).toHaveLength(1);
+        expect(response.data[0].id).toBe(729);
+        expect(response.rateLimit.limit).toBe(100);
+        expect(response.rateLimit.remaining).toBe(99);
+        expect(response.rateLimit.resetAfterSeconds).toBe(1.5);
+    });
+
+    it('requests files with optional filters', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ jsonData: [] }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        await client.getFiles(729, { episode: 1 });
+
+        expect(fetchMock).toHaveBeenCalledWith('https://jimaku.cc/api/entries/729/files?episode=1', {
+            headers: { Authorization: 'test-key' },
+        });
+    });
+
+    it('throws parsed error message on failed request', async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValue(createResponse({ ok: false, status: 401, jsonData: { error: 'Unauthorized' } }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        await expect(client.getEntry(123)).rejects.toThrow('Unauthorized');
+    });
+
+    it('falls back to status-based error when response is not json', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ ok: false, status: 503, textData: '<html/>' }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        await expect(client.getEntry(123)).rejects.toThrow('Jimaku request failed with status 503');
+    });
+
+    it('throws when successful response does not contain valid json', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ ok: true, status: 200, textData: '<html/>' }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        await expect(client.getEntry(123)).rejects.toThrow('Jimaku request failed: expected a JSON response body');
+    });
+});
+

--- a/extension/src/services/subtitle-sources.test.ts
+++ b/extension/src/services/subtitle-sources.test.ts
@@ -1,0 +1,167 @@
+import { JimakuClient, listAjattDirectoryFiles, searchAjatt } from './subtitle-sources';
+
+const createResponse = ({
+    ok = true,
+    status = 200,
+    statusText = 'OK',
+    jsonData,
+    textData,
+    headers = {},
+}: {
+    ok?: boolean;
+    status?: number;
+    statusText?: string;
+    jsonData?: unknown;
+    textData?: string;
+    headers?: Record<string, string>;
+}) => {
+    return {
+        ok,
+        status,
+        statusText,
+        headers: {
+            get: (key: string) => headers[key.toLowerCase()] ?? null,
+        },
+        text: async () => (textData !== undefined ? textData : JSON.stringify(jsonData)),
+    } as unknown as Response;
+};
+
+describe('JimakuClient', () => {
+    it('validates api key at construction', () => {
+        expect(() => new JimakuClient({ apiKey: '   ' })).toThrow('Jimaku API key cannot be empty or whitespace-only');
+    });
+
+    it('searches entries with authorization header', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(
+            createResponse({
+                jsonData: [{ id: 729, name: 'Sousou no Frieren' }],
+                headers: {
+                    'x-ratelimit-limit': '100',
+                    'x-ratelimit-remaining': '99',
+                    'x-ratelimit-reset-after': '1',
+                },
+            })
+        );
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        const response = await client.searchEntries('Sousou no Frieren');
+
+        expect(fetchMock).toHaveBeenCalledWith('https://jimaku.cc/api/entries/search?query=Sousou+no+Frieren', {
+            headers: { Authorization: 'test-key' },
+        });
+        expect(response.data).toHaveLength(1);
+        expect(response.data[0].id).toBe(729);
+        expect(response.rateLimit.limit).toBe(100);
+        expect(response.rateLimit.remaining).toBe(99);
+        expect(response.rateLimit.resetAfterSeconds).toBe(1);
+    });
+
+    it('requests files with optional filters', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ jsonData: [] }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        await client.getFiles(729, { episode: 1, language: 'ja' });
+
+        expect(fetchMock).toHaveBeenCalledWith('https://jimaku.cc/api/entries/729/files?episode=1&language=ja', {
+            headers: { Authorization: 'test-key' },
+        });
+    });
+
+    it('throws parsed error message on failed request', async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValue(createResponse({ ok: false, status: 401, jsonData: { error: 'Unauthorized' } }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        await expect(client.getEntry(123)).rejects.toThrow('Unauthorized');
+    });
+
+    it('falls back to status-based error when response is not json', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ ok: false, status: 503, textData: '<html/>' }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        await expect(client.getEntry(123)).rejects.toThrow('Jimaku request failed with status 503');
+    });
+});
+
+describe('AJATT subtitle source', () => {
+    it('searches homepage entries by multiple title fields', async () => {
+        const html = `
+            <table>
+                <tr>
+                    <th>#</th><th>Name</th><th>Type</th><th>English name</th><th>Japanese name</th><th>Last modified</th>
+                </tr>
+                <tr>
+                    <td>1</td>
+                    <td><a href="/Sousou%20no%20Frieren/">Sousou no Frieren</a></td>
+                    <td>Anime TV</td>
+                    <td>Frieren: Beyond Journey's End</td>
+                    <td>葬送のフリーレン</td>
+                    <td>2024-10-01</td>
+                </tr>
+                <tr>
+                    <td>2</td>
+                    <td><a href="/Another%20Title/">Another Title</a></td>
+                    <td>Anime TV</td>
+                    <td>Another English</td>
+                    <td>別のタイトル</td>
+                    <td>2024-09-01</td>
+                </tr>
+            </table>
+        `;
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ textData: html }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        const matches = await searchAjatt('frieren');
+
+        expect(fetchMock).toHaveBeenCalledWith('https://subtitles.ajatt.top/');
+        expect(matches).toHaveLength(1);
+        expect(matches[0]).toMatchObject({
+            name: 'Sousou no Frieren',
+            path: '/Sousou%20no%20Frieren/',
+            url: 'https://subtitles.ajatt.top/Sousou%20no%20Frieren/',
+        });
+    });
+
+    it('extracts subtitle files from an anime directory', async () => {
+        const html = `
+            <a href="../">../</a>
+            <a href="Sousou.no.Frieren.S01E01.srt">Sousou.no.Frieren.S01E01.srt</a>
+            <a href="Sousou.no.Frieren.S01E02.ass">Sousou.no.Frieren.S01E02.ass</a>
+            <a href="Sousou.no.Frieren.Batch.zip">Sousou.no.Frieren.Batch.zip</a>
+            <a href="notes.txt">notes.txt</a>
+        `;
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ textData: html }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        const files = await listAjattDirectoryFiles('/Sousou%20no%20Frieren/');
+
+        expect(fetchMock).toHaveBeenCalledWith('https://subtitles.ajatt.top/Sousou%20no%20Frieren/');
+        expect(files).toHaveLength(3);
+        expect(files[0].url).toBe('https://subtitles.ajatt.top/Sousou%20no%20Frieren/Sousou.no.Frieren.S01E01.srt');
+        expect(files[1].url).toBe('https://subtitles.ajatt.top/Sousou%20no%20Frieren/Sousou.no.Frieren.S01E02.ass');
+        expect(files[2].url).toBe('https://subtitles.ajatt.top/Sousou%20no%20Frieren/Sousou.no.Frieren.Batch.zip');
+    });
+
+    it('throws when ajatt search request fails', async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValue(createResponse({ ok: false, status: 500, statusText: 'Server Error', textData: '' }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        await expect(searchAjatt('frieren')).rejects.toThrow('AJATT search failed with status 500');
+    });
+
+    it('throws when ajatt directory listing request fails', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ ok: false, status: 404, textData: '' }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        await expect(listAjattDirectoryFiles('/missing/')).rejects.toThrow(
+            'AJATT directory listing failed with status 404'
+        );
+    });
+});

--- a/extension/src/services/subtitle-sources.test.ts
+++ b/extension/src/services/subtitle-sources.test.ts
@@ -86,6 +86,14 @@ describe('JimakuClient', () => {
 
         await expect(client.getEntry(123)).rejects.toThrow('Jimaku request failed with status 503');
     });
+
+    it('throws when successful response does not contain valid json', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ ok: true, status: 200, textData: '<html/>' }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        await expect(client.getEntry(123)).rejects.toThrow('Jimaku request failed: expected a JSON response body');
+    });
 });
 
 describe('AJATT subtitle source', () => {
@@ -141,10 +149,9 @@ describe('AJATT subtitle source', () => {
         const files = await listAjattDirectoryFiles('/Sousou%20no%20Frieren/');
 
         expect(fetchMock).toHaveBeenCalledWith('https://subtitles.ajatt.top/Sousou%20no%20Frieren/');
-        expect(files).toHaveLength(3);
+        expect(files).toHaveLength(2);
         expect(files[0].url).toBe('https://subtitles.ajatt.top/Sousou%20no%20Frieren/Sousou.no.Frieren.S01E01.srt');
         expect(files[1].url).toBe('https://subtitles.ajatt.top/Sousou%20no%20Frieren/Sousou.no.Frieren.S01E02.ass');
-        expect(files[2].url).toBe('https://subtitles.ajatt.top/Sousou%20no%20Frieren/Sousou.no.Frieren.Batch.zip');
     });
 
     it('throws when ajatt search request fails', async () => {

--- a/extension/src/services/subtitle-sources.ts
+++ b/extension/src/services/subtitle-sources.ts
@@ -112,7 +112,6 @@ const parseOptionalFloat = (value: string | null): number | undefined => {
     return Number.isFinite(parsed) ? parsed : undefined;
 };
 
-
 export interface JimakuClientOptions {
     apiKey: string;
     baseUrl?: string;
@@ -225,4 +224,3 @@ export class JimakuClient {
         }
     }
 }
-

--- a/extension/src/services/subtitle-sources.ts
+++ b/extension/src/services/subtitle-sources.ts
@@ -1,0 +1,228 @@
+export interface JimakuEntry {
+    id: number;
+    anilist_id?: number;
+    name: string;
+    japanese_name?: string;
+    english_name?: string;
+    created_at?: string;
+    last_updated_at?: string;
+    flags?: number;
+}
+
+export interface JimakuFile {
+    id: number;
+    name: string;
+    url: string;
+    created_at?: string;
+    size?: number;
+}
+
+export interface JimakuRateLimit {
+    limit?: number;
+    remaining?: number;
+    resetAfterSeconds?: number;
+}
+
+export interface JimakuResponse<T> {
+    data: T;
+    rateLimit: JimakuRateLimit;
+}
+
+interface JimakuErrorPayload {
+    error?: string;
+    message?: string;
+}
+
+const parseJsonSafely = (text: string): unknown | undefined => {
+    if (text.length === 0) {
+        return undefined;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return undefined;
+    }
+};
+
+const defaultJimakuBaseUrl = 'https://jimaku.cc/api';
+
+type TrustedHtmlPolicyLike = {
+    createHTML: (value: string) => string | TrustedHTML;
+};
+
+let trustedHtmlPolicy: TrustedHtmlPolicyLike | undefined;
+
+const createTrustedHtml = (html: string): string | TrustedHTML => {
+    const trustedTypesApi = (
+        globalThis as typeof globalThis & {
+            trustedTypes?: {
+                createPolicy: (
+                    name: string,
+                    policy: { createHTML: (value: string) => string }
+                ) => TrustedHtmlPolicyLike;
+                getPolicy?: (name: string) => TrustedHtmlPolicyLike | null;
+            };
+        }
+    ).trustedTypes;
+
+    if (!trustedTypesApi) {
+        return html;
+    }
+
+    if (!trustedHtmlPolicy) {
+        try {
+            trustedHtmlPolicy = trustedTypesApi.createPolicy('asbplayer-subtitle-sources', {
+                createHTML: (value) => value,
+            });
+        } catch (error) {
+            trustedHtmlPolicy = trustedTypesApi.getPolicy?.('asbplayer-subtitle-sources') ?? undefined;
+        }
+    }
+
+    return trustedHtmlPolicy ? trustedHtmlPolicy.createHTML(html) : html;
+};
+
+const parseHtmlDocument = (html: string) => {
+    const trustedHtml = createTrustedHtml(html);
+    return new DOMParser().parseFromString(trustedHtml as string, 'text/html');
+};
+
+const parseRateLimit = (headers: Headers): JimakuRateLimit => ({
+    limit: parseOptionalInt(headers.get('x-ratelimit-limit')),
+    remaining: parseOptionalInt(headers.get('x-ratelimit-remaining')),
+    resetAfterSeconds: parseOptionalFloat(headers.get('x-ratelimit-reset-after')),
+});
+
+const parseOptionalInt = (value: string | null): number | undefined => {
+    if (value === null) {
+        return undefined;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const parseOptionalFloat = (value: string | null): number | undefined => {
+    if (value === null) {
+        return undefined;
+    }
+
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+
+export interface JimakuClientOptions {
+    apiKey: string;
+    baseUrl?: string;
+    minRequestIntervalMs?: number;
+}
+
+export class JimakuClient {
+    private readonly _apiKey: string;
+    private readonly _baseUrl: string;
+    private readonly _minRequestIntervalMs: number;
+    private _lastRequestTimestampMs?: number;
+    private _lastRateLimit?: JimakuRateLimit;
+
+    constructor({ apiKey, baseUrl = defaultJimakuBaseUrl, minRequestIntervalMs = 1000 }: JimakuClientOptions) {
+        const trimmedApiKey = apiKey.trim();
+
+        if (trimmedApiKey.length === 0) {
+            throw new Error('Jimaku API key cannot be empty or whitespace-only');
+        }
+
+        this._apiKey = trimmedApiKey;
+        this._baseUrl = baseUrl;
+        this._minRequestIntervalMs = minRequestIntervalMs;
+    }
+
+    async searchEntries(query: string): Promise<JimakuResponse<JimakuEntry[]>> {
+        const searchParams = new URLSearchParams();
+        searchParams.set('query', query);
+        return await this._request<JimakuEntry[]>(`entries/search?${searchParams.toString()}`);
+    }
+
+    async getEntry(id: number): Promise<JimakuResponse<JimakuEntry>> {
+        return await this._request<JimakuEntry>(`entries/${id}`);
+    }
+
+    async getFiles(
+        id: number,
+        options?: {
+            episode?: number;
+        }
+    ): Promise<JimakuResponse<JimakuFile[]>> {
+        const searchParams = new URLSearchParams();
+
+        if (options?.episode !== undefined) {
+            searchParams.set('episode', `${options.episode}`);
+        }
+
+        const query = searchParams.toString();
+        const endpoint = query.length > 0 ? `entries/${id}/files?${query}` : `entries/${id}/files`;
+        return await this._request<JimakuFile[]>(endpoint);
+    }
+
+    private async _request<T>(endpoint: string): Promise<JimakuResponse<T>> {
+        await this._waitIfNeeded();
+        const response = await fetch(new URL(endpoint, `${this._baseUrl}/`).toString(), {
+            headers: {
+                Authorization: this._apiKey,
+            },
+        });
+        this._lastRequestTimestampMs = Date.now();
+
+        const rateLimit = parseRateLimit(response.headers);
+        this._lastRateLimit = rateLimit;
+        const bodyText = await response.text();
+        const parsedBody = parseJsonSafely(bodyText) as T | JimakuErrorPayload | undefined;
+
+        if (!response.ok) {
+            const errorMessage =
+                (parsedBody as JimakuErrorPayload | undefined)?.error ??
+                (parsedBody as JimakuErrorPayload | undefined)?.message ??
+                `Jimaku request failed with status ${response.status}`;
+            throw new Error(errorMessage);
+        }
+
+        if (parsedBody === undefined) {
+            throw new Error('Jimaku request failed: expected a JSON response body');
+        }
+
+        return {
+            data: parsedBody as T,
+            rateLimit,
+        };
+    }
+
+    private async _waitIfNeeded() {
+        // Prioritize server-reported rate limit data over hard-coded interval
+        if (this._lastRateLimit !== undefined) {
+            const { remaining, resetAfterSeconds } = this._lastRateLimit;
+
+            if (remaining !== undefined && remaining <= 0 && resetAfterSeconds !== undefined && resetAfterSeconds > 0) {
+                await new Promise((resolve) => setTimeout(resolve, resetAfterSeconds * 1000));
+                return;
+            }
+
+            // If we still have quota remaining, skip the hard-coded wait
+            if (remaining !== undefined && remaining > 0) {
+                return;
+            }
+        }
+
+        if (this._lastRequestTimestampMs === undefined || this._minRequestIntervalMs <= 0) {
+            return;
+        }
+
+        const elapsedMs = Date.now() - this._lastRequestTimestampMs;
+        const remainingMs = this._minRequestIntervalMs - elapsedMs;
+
+        if (remainingMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, remainingMs));
+        }
+    }
+}
+

--- a/extension/src/services/subtitle-sources.ts
+++ b/extension/src/services/subtitle-sources.ts
@@ -1,0 +1,342 @@
+export interface JimakuEntry {
+    id: number;
+    anilist_id?: number;
+    name: string;
+    japanese_name?: string;
+    english_name?: string;
+    created_at?: string;
+    last_updated_at?: string;
+    flags?: number;
+}
+
+export interface JimakuFile {
+    id: number;
+    name: string;
+    url: string;
+    created_at?: string;
+    size?: number;
+}
+
+export interface JimakuRateLimit {
+    limit?: number;
+    remaining?: number;
+    resetAfterSeconds?: number;
+}
+
+export interface JimakuResponse<T> {
+    data: T;
+    rateLimit: JimakuRateLimit;
+}
+
+interface JimakuErrorPayload {
+    error?: string;
+    message?: string;
+}
+
+const parseJsonSafely = (text: string): unknown | undefined => {
+    if (text.length === 0) {
+        return undefined;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return undefined;
+    }
+};
+
+const defaultJimakuBaseUrl = 'https://jimaku.cc/api';
+const defaultAjattBaseUrl = 'https://subtitles.ajatt.top';
+
+type TrustedHtmlPolicyLike = {
+    createHTML: (value: string) => string | TrustedHTML;
+};
+
+let trustedHtmlPolicy: TrustedHtmlPolicyLike | undefined;
+
+const createTrustedHtml = (html: string): string | TrustedHTML => {
+    const trustedTypesApi = (
+        globalThis as typeof globalThis & {
+            trustedTypes?: {
+                createPolicy: (
+                    name: string,
+                    policy: { createHTML: (value: string) => string }
+                ) => TrustedHtmlPolicyLike;
+                getPolicy?: (name: string) => TrustedHtmlPolicyLike | null;
+            };
+        }
+    ).trustedTypes;
+
+    if (!trustedTypesApi) {
+        return html;
+    }
+
+    if (!trustedHtmlPolicy) {
+        try {
+            trustedHtmlPolicy = trustedTypesApi.createPolicy('asbplayer-subtitle-sources', {
+                createHTML: (value) => value,
+            });
+        } catch (error) {
+            trustedHtmlPolicy = trustedTypesApi.getPolicy?.('asbplayer-subtitle-sources') ?? undefined;
+        }
+    }
+
+    return trustedHtmlPolicy ? trustedHtmlPolicy.createHTML(html) : html;
+};
+
+const parseHtmlDocument = (html: string) => {
+    const trustedHtml = createTrustedHtml(html);
+    return new DOMParser().parseFromString(trustedHtml as string, 'text/html');
+};
+
+const parseRateLimit = (headers: Headers): JimakuRateLimit => ({
+    limit: parseOptionalInt(headers.get('x-ratelimit-limit')),
+    remaining: parseOptionalInt(headers.get('x-ratelimit-remaining')),
+    resetAfterSeconds: parseOptionalInt(headers.get('x-ratelimit-reset-after')),
+});
+
+const parseOptionalInt = (value: string | null): number | undefined => {
+    if (value === null) {
+        return undefined;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const trimLeadingSlash = (path: string) => {
+    if (path.startsWith('/')) {
+        return path.substring(1);
+    }
+
+    return path;
+};
+
+const buildAjattDirectoryUrl = (animePath: string, baseUrl: string = defaultAjattBaseUrl) => {
+    return new URL(trimLeadingSlash(animePath), `${baseUrl}/`).toString();
+};
+
+export interface JimakuClientOptions {
+    apiKey: string;
+    baseUrl?: string;
+    minRequestIntervalMs?: number;
+}
+
+export class JimakuClient {
+    private readonly _apiKey: string;
+    private readonly _baseUrl: string;
+    private readonly _minRequestIntervalMs: number;
+    private _lastRequestTimestampMs?: number;
+
+    constructor({ apiKey, baseUrl = defaultJimakuBaseUrl, minRequestIntervalMs = 1000 }: JimakuClientOptions) {
+        const trimmedApiKey = apiKey.trim();
+
+        if (trimmedApiKey.length === 0) {
+            throw new Error('Jimaku API key cannot be empty or whitespace-only');
+        }
+
+        this._apiKey = trimmedApiKey;
+        this._baseUrl = baseUrl;
+        this._minRequestIntervalMs = minRequestIntervalMs;
+    }
+
+    async searchEntries(query: string): Promise<JimakuResponse<JimakuEntry[]>> {
+        const searchParams = new URLSearchParams();
+        searchParams.set('query', query);
+        return await this._request<JimakuEntry[]>(`entries/search?${searchParams.toString()}`);
+    }
+
+    async getEntry(id: number): Promise<JimakuResponse<JimakuEntry>> {
+        return await this._request<JimakuEntry>(`entries/${id}`);
+    }
+
+    async getFiles(
+        id: number,
+        options?: {
+            episode?: number;
+            language?: string;
+        }
+    ): Promise<JimakuResponse<JimakuFile[]>> {
+        const searchParams = new URLSearchParams();
+
+        if (options?.episode !== undefined) {
+            searchParams.set('episode', `${options.episode}`);
+        }
+
+        if (options?.language) {
+            searchParams.set('language', options.language);
+        }
+
+        const query = searchParams.toString();
+        const endpoint = query.length > 0 ? `entries/${id}/files?${query}` : `entries/${id}/files`;
+        return await this._request<JimakuFile[]>(endpoint);
+    }
+
+    private async _request<T>(endpoint: string): Promise<JimakuResponse<T>> {
+        await this._waitIfNeeded();
+        const response = await fetch(new URL(endpoint, `${this._baseUrl}/`).toString(), {
+            headers: {
+                Authorization: this._apiKey,
+            },
+        });
+        this._lastRequestTimestampMs = Date.now();
+
+        const rateLimit = parseRateLimit(response.headers);
+        const bodyText = await response.text();
+        const parsedBody = parseJsonSafely(bodyText) as T | JimakuErrorPayload | undefined;
+
+        if (!response.ok) {
+            const errorMessage =
+                (parsedBody as JimakuErrorPayload | undefined)?.error ??
+                (parsedBody as JimakuErrorPayload | undefined)?.message ??
+                `Jimaku request failed with status ${response.status}`;
+            throw new Error(errorMessage);
+        }
+
+        return {
+            data: parsedBody as T,
+            rateLimit,
+        };
+    }
+
+    private async _waitIfNeeded() {
+        if (this._lastRequestTimestampMs === undefined || this._minRequestIntervalMs <= 0) {
+            return;
+        }
+
+        const elapsedMs = Date.now() - this._lastRequestTimestampMs;
+        const remainingMs = this._minRequestIntervalMs - elapsedMs;
+
+        if (remainingMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, remainingMs));
+        }
+    }
+}
+
+export interface AjattAnimeSearchResult {
+    name: string;
+    type?: string;
+    englishName?: string;
+    japaneseName?: string;
+    lastModified?: string;
+    path: string;
+    url: string;
+}
+
+export interface AjattDirectoryFile {
+    name: string;
+    url: string;
+}
+
+// Homepage table columns:
+// 0: row number, 1: linked title, 2: type, 3: english name, 4: japanese name, 5: last modified
+const ajattColumns = {
+    linkedTitle: 1,
+    type: 2,
+    englishName: 3,
+    japaneseName: 4,
+    lastModified: 5,
+} as const;
+
+export const searchAjatt = async (
+    query: string,
+    baseUrl: string = defaultAjattBaseUrl
+): Promise<AjattAnimeSearchResult[]> => {
+    const response = await fetch(`${baseUrl}/`);
+    if (!response.ok) {
+        throw new Error(`AJATT search failed with status ${response.status}`);
+    }
+
+    const html = await response.text();
+    const document = parseHtmlDocument(html);
+    const rows = document.querySelectorAll('table tr');
+    const normalizedQuery = query.trim().toLowerCase();
+    const matches: AjattAnimeSearchResult[] = [];
+
+    for (const row of rows) {
+        const cells = row.querySelectorAll('td');
+
+        if (cells.length === 0) {
+            continue;
+        }
+
+        const linkedCell = cells[ajattColumns.linkedTitle];
+        const anchor = linkedCell?.querySelector('a[href]');
+        const path = anchor?.getAttribute('href')?.trim();
+
+        if (!path) {
+            continue;
+        }
+
+        const name = linkedCell.textContent?.trim() ?? '';
+        const type = cells[ajattColumns.type]?.textContent?.trim() || undefined;
+        const englishName = cells[ajattColumns.englishName]?.textContent?.trim() || undefined;
+        const japaneseName = cells[ajattColumns.japaneseName]?.textContent?.trim() || undefined;
+        const lastModified = cells[ajattColumns.lastModified]?.textContent?.trim() || undefined;
+
+        if (
+            normalizedQuery.length > 0 &&
+            ![name, englishName, japaneseName].some((v) => v?.toLowerCase().includes(normalizedQuery))
+        ) {
+            continue;
+        }
+
+        matches.push({
+            name,
+            type,
+            englishName,
+            japaneseName,
+            lastModified,
+            path,
+            url: buildAjattDirectoryUrl(path, baseUrl),
+        });
+    }
+
+    return matches;
+};
+
+const subtitleExtensions = ['.srt', '.ass', '.zip'];
+
+const isSubtitleLink = (href: string) => {
+    const lower = href.toLowerCase();
+    return subtitleExtensions.some((extension) => lower.endsWith(extension));
+};
+
+export const listAjattDirectoryFiles = async (
+    animePath: string,
+    baseUrl: string = defaultAjattBaseUrl
+): Promise<AjattDirectoryFile[]> => {
+    const directoryUrl = buildAjattDirectoryUrl(animePath, baseUrl);
+    const response = await fetch(directoryUrl);
+    if (!response.ok) {
+        throw new Error(`AJATT directory listing failed with status ${response.status}`);
+    }
+
+    const html = await response.text();
+    const document = parseHtmlDocument(html);
+    const links = document.querySelectorAll('a[href]');
+    const files: AjattDirectoryFile[] = [];
+    const seenUrls = new Set<string>();
+
+    for (const link of links) {
+        const href = link.getAttribute('href')?.trim();
+
+        if (!href || !isSubtitleLink(href)) {
+            continue;
+        }
+
+        const url = new URL(href, directoryUrl).toString();
+
+        if (seenUrls.has(url)) {
+            continue;
+        }
+
+        seenUrls.add(url);
+        files.push({
+            name: link.textContent?.trim() || href,
+            url,
+        });
+    }
+
+    return files;
+};

--- a/extension/src/services/subtitle-sources.ts
+++ b/extension/src/services/subtitle-sources.ts
@@ -193,6 +193,10 @@ export class JimakuClient {
             throw new Error(errorMessage);
         }
 
+        if (parsedBody === undefined) {
+            throw new Error('Jimaku request failed: expected a JSON response body');
+        }
+
         return {
             data: parsedBody as T,
             rateLimit,
@@ -295,7 +299,7 @@ export const searchAjatt = async (
     return matches;
 };
 
-const subtitleExtensions = ['.srt', '.ass', '.zip'];
+const subtitleExtensions = ['.srt', '.ass'];
 
 const isSubtitleLink = (href: string) => {
     const lower = href.toLowerCase();

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -1,22 +1,25 @@
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
+import SearchIcon from '@mui/icons-material/Search';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
 import Link from '@mui/material/Link';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
+import CloseIcon from '@mui/icons-material/Close';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { JimakuClient } from '@/services/subtitle-sources';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import Toolbar from '@mui/material/Toolbar';
 
 interface OnlineSubtitleImportCandidate {
     name: string;
@@ -31,11 +34,6 @@ interface Props {
     jimakuApiKey: string;
     onJimakuApiKeyChange: (jimakuApiKey: string) => void;
 }
-
-const emptyStateText = {
-    entries: 'No entries',
-    files: 'No files',
-};
 
 const SUPPORTED_JIMAKU_EXTENSIONS = ['.srt', '.ass'];
 
@@ -73,15 +71,13 @@ export default function OnlineSubtitleSourceDialog({
     const [jimakuEntries, setJimakuEntries] = useState<{ id: number; name: string }[]>([]);
     const [jimakuSelectedEntryId, setJimakuSelectedEntryId] = useState<number>();
     const [jimakuFiles, setJimakuFiles] = useState<OnlineSubtitleImportCandidate[]>([]);
+    const [searchFocused, setSearchFocused] = useState<boolean>(false);
 
     const selectedFiles = jimakuFiles;
     const normalizedDetectedTitleHint = useMemo(
         () => normalizeDetectedTitleHint(detectedTitleHint),
         [detectedTitleHint]
     );
-    const showDetectedTitleHint =
-        normalizedDetectedTitleHint.length > 0 &&
-        normalizedDetectedTitleHint.toLowerCase() !== query.trim().toLowerCase();
     const isSearchDisabled = loading || query.trim().length === 0 || jimakuApiKey.trim().length === 0;
 
     const resetState = useCallback(() => {
@@ -95,8 +91,10 @@ export default function OnlineSubtitleSourceDialog({
     useEffect(() => {
         if (open) {
             resetState();
+            setQuery(normalizedDetectedTitleHint);
         }
-    }, [open, resetState]);
+        setSearchFocused(false);
+    }, [open, normalizedDetectedTitleHint, resetState]);
 
     const handleSearchJimaku = useCallback(async () => {
         setError(undefined);
@@ -154,80 +152,84 @@ export default function OnlineSubtitleSourceDialog({
         [onClose, onImport]
     );
 
-    const handleApplyDetectedTitleHint = useCallback(() => {
-        setQuery(normalizedDetectedTitleHint);
-    }, [normalizedDetectedTitleHint]);
-
     const handleSearch = handleSearchJimaku;
 
     return (
         <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-            <DialogTitle>
-                {t('extension.videoDataSync.onlineSubtitleSources', { defaultValue: 'Online subtitle sources' })}
-            </DialogTitle>
+            <Toolbar>
+                <Typography variant="h6" sx={{ flexGrow: 1 }}>
+                    {t('extension.videoDataSync.onlineSubtitleSources')}
+                </Typography>
+                <IconButton onClick={onClose} edge="end">
+                    <CloseIcon />
+                </IconButton>
+            </Toolbar>
             <DialogContent>
                 <Stack spacing={2}>
                     {error && <Alert severity="error">{error}</Alert>}
-
-                    {showDetectedTitleHint && (
-                        <Alert
-                            severity="info"
-                            action={
-                                <Button onClick={handleApplyDetectedTitleHint} size="small">
-                                    {t('extension.videoDataSync.fillDetectedTitle', {
-                                        defaultValue: 'Use title',
-                                    })}
-                                </Button>
-                            }
-                        >
-                            {t('extension.videoDataSync.detectedTitleHint', {
-                                defaultValue: 'Detected from current page: {{title}}',
-                                title: normalizedDetectedTitleHint,
-                            })}
-                        </Alert>
-                    )}
-
                     <Box sx={{ display: 'flex', gap: 1 }}>
                         <TextField
-                            label={t('extension.videoDataSync.animeTitle', { defaultValue: 'Anime title' })}
+                            autoFocus
+                            margin="dense"
+                            label={t('extension.videoDataSync.searchTerm')}
                             value={query}
                             onChange={(e) => setQuery(e.target.value)}
+                            onFocus={(e) => {
+                                e.target.select();
+                                setSearchFocused(true);
+                            }}
+                            onBlur={() => setSearchFocused(false)}
+                            onKeyDown={(evt) => {
+                                if (evt.key === 'Enter') {
+                                    handleSearch();
+                                }
+                            }}
                             fullWidth
+                            slotProps={{
+                                input: {
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <IconButton
+                                                loading={loading}
+                                                onClick={handleSearch}
+                                                disabled={isSearchDisabled}
+                                            >
+                                                <SearchIcon fontSize="small" />
+                                            </IconButton>
+                                        </InputAdornment>
+                                    ),
+                                },
+                            }}
                         />
-                        <Button variant="contained" onClick={handleSearch} disabled={isSearchDisabled}>
-                            {t('extension.videoDataSync.search', { defaultValue: 'Search' })}
-                        </Button>
                     </Box>
 
                     <TextField
-                        label={t('extension.videoDataSync.jimakuApiKey', { defaultValue: 'Jimaku API Key' })}
+                        label={t('extension.videoDataSync.jimakuApiKey')}
                         value={jimakuApiKey}
                         onChange={(e) => onJimakuApiKeyChange(e.target.value)}
                         helperText={
-                            <>
-                                {t('extension.videoDataSync.jimakuApiKeyAutosaveHint', {
-                                    defaultValue: 'Saved automatically after typing.',
-                                })}{' '}
-                                <Link
-                                    href="https://jimaku.cc/account"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    underline="hover"
-                                >
-                                    {t('extension.videoDataSync.jimakuApiKeyGetHere', {
-                                        defaultValue: 'Get your API key here.',
-                                    })}
-                                </Link>
-                            </>
+                            <Trans
+                                i18nKey="extension.videoDataSync.jimakuApiKeyAutosaveHint"
+                                components={{
+                                    0: (
+                                        <Link
+                                            href="https://jimaku.cc/account"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            underline="hover"
+                                        >
+                                            here
+                                        </Link>
+                                    ),
+                                }}
+                            />
                         }
                         fullWidth
                     />
 
-                    <Box sx={{ display: 'flex', gap: 2 }}>
+                    <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2 }}>
                         <Stack spacing={1} sx={{ flex: 1, minWidth: 0 }}>
-                            <Typography variant="subtitle2">
-                                {t('extension.videoDataSync.entries', { defaultValue: 'Entries' })}
-                            </Typography>
+                            <Typography variant="subtitle2">{t('extension.videoDataSync.entries')}</Typography>
                             <List
                                 dense
                                 sx={{ maxHeight: 220, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}
@@ -243,20 +245,14 @@ export default function OnlineSubtitleSourceDialog({
                                 ))}
                                 {jimakuEntries.length === 0 && (
                                     <ListItem>
-                                        <ListItemText
-                                            primary={t('extension.videoDataSync.noEntries', {
-                                                defaultValue: emptyStateText.entries,
-                                            })}
-                                        />
+                                        <ListItemText primary={t('extension.videoDataSync.noEntries')} />
                                     </ListItem>
                                 )}
                             </List>
                         </Stack>
 
                         <Stack spacing={1} sx={{ flex: 1, minWidth: 0 }}>
-                            <Typography variant="subtitle2">
-                                {t('extension.videoDataSync.availableFiles', { defaultValue: 'Available files' })}
-                            </Typography>
+                            <Typography variant="subtitle2">{t('extension.videoDataSync.availableFiles')}</Typography>
                             <List
                                 dense
                                 sx={{ maxHeight: 220, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}
@@ -268,21 +264,12 @@ export default function OnlineSubtitleSourceDialog({
                                 ))}
                                 {selectedFiles.length === 0 && (
                                     <ListItem>
-                                        <ListItemText
-                                            primary={t('extension.videoDataSync.noFiles', {
-                                                defaultValue: emptyStateText.files,
-                                            })}
-                                        />
+                                        <ListItemText primary={t('extension.videoDataSync.noFiles')} />
                                     </ListItem>
                                 )}
                             </List>
                         </Stack>
                     </Box>
-                    {loading && (
-                        <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
-                            <CircularProgress size={22} />
-                        </Box>
-                    )}
                 </Stack>
             </DialogContent>
             <DialogActions>

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -82,8 +82,7 @@ export default function OnlineSubtitleSourceDialog({
     const showDetectedTitleHint =
         normalizedDetectedTitleHint.length > 0 &&
         normalizedDetectedTitleHint.toLowerCase() !== query.trim().toLowerCase();
-    const isSearchDisabled =
-        loading || query.trim().length === 0 || jimakuApiKey.trim().length === 0;
+    const isSearchDisabled = loading || query.trim().length === 0 || jimakuApiKey.trim().length === 0;
 
     const resetState = useCallback(() => {
         setLoading(false);
@@ -162,13 +161,7 @@ export default function OnlineSubtitleSourceDialog({
     const handleSearch = handleSearchJimaku;
 
     return (
-        <Dialog
-            open={open}
-            onClose={onClose}
-            fullWidth
-            maxWidth="md"
-
-        >
+        <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
             <DialogTitle>
                 {t('extension.videoDataSync.onlineSubtitleSources', { defaultValue: 'Online subtitle sources' })}
             </DialogTitle>
@@ -214,8 +207,7 @@ export default function OnlineSubtitleSourceDialog({
                             <>
                                 {t('extension.videoDataSync.jimakuApiKeyAutosaveHint', {
                                     defaultValue: 'Saved automatically after typing.',
-                                })}
-                                {' '}
+                                })}{' '}
                                 <Link
                                     href="https://jimaku.cc/account"
                                     target="_blank"
@@ -265,7 +257,10 @@ export default function OnlineSubtitleSourceDialog({
                             <Typography variant="subtitle2">
                                 {t('extension.videoDataSync.availableFiles', { defaultValue: 'Available files' })}
                             </Typography>
-                            <List dense sx={{ maxHeight: 220, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}>
+                            <List
+                                dense
+                                sx={{ maxHeight: 220, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}
+                            >
                                 {selectedFiles.map((file) => (
                                     <ListItemButton key={file.url} onClick={() => handleImport(file)}>
                                         <ListItemText primary={file.name} secondary={file.url} />
@@ -274,7 +269,9 @@ export default function OnlineSubtitleSourceDialog({
                                 {selectedFiles.length === 0 && (
                                     <ListItem>
                                         <ListItemText
-                                            primary={t('extension.videoDataSync.noFiles', { defaultValue: emptyStateText.files })}
+                                            primary={t('extension.videoDataSync.noFiles', {
+                                                defaultValue: emptyStateText.files,
+                                            })}
                                         />
                                     </ListItem>
                                 )}

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -158,7 +158,7 @@ export default function OnlineSubtitleSourceDialog({
         <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
             <Toolbar>
                 <Typography variant="h6" sx={{ flexGrow: 1 }}>
-                    {t('extension.videoDataSync.onlineSubtitleSources')}
+                    {t('onlineSubtitleSources.title')}
                 </Typography>
                 <IconButton onClick={onClose} edge="end">
                     <CloseIcon />
@@ -171,7 +171,7 @@ export default function OnlineSubtitleSourceDialog({
                         <TextField
                             autoFocus
                             margin="dense"
-                            label={t('extension.videoDataSync.searchTerm')}
+                            label={t('onlineSubtitleSources.searchTerm')}
                             value={query}
                             onChange={(e) => setQuery(e.target.value)}
                             onFocus={(e) => {
@@ -204,24 +204,23 @@ export default function OnlineSubtitleSourceDialog({
                     </Box>
 
                     <TextField
-                        label={t('extension.videoDataSync.jimakuApiKey')}
+                        label={t('onlineSubtitleSources.jimakuApiKey')}
                         value={jimakuApiKey}
                         onChange={(e) => onJimakuApiKeyChange(e.target.value)}
                         helperText={
                             <Trans
-                                i18nKey="extension.videoDataSync.jimakuApiKeyAutosaveHint"
-                                components={{
-                                    0: (
-                                        <Link
-                                            href="https://jimaku.cc/account"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            underline="hover"
-                                        >
-                                            here
-                                        </Link>
-                                    ),
-                                }}
+                                i18nKey="onlineSubtitleSources.jimakuApiKeyAutosaveHint"
+                                components={[
+                                    <Link
+                                        key={0}
+                                        href="https://jimaku.cc/account"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        underline="hover"
+                                    >
+                                        here
+                                    </Link>,
+                                ]}
                             />
                         }
                         fullWidth
@@ -229,7 +228,7 @@ export default function OnlineSubtitleSourceDialog({
 
                     <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2 }}>
                         <Stack spacing={1} sx={{ flex: 1, minWidth: 0 }}>
-                            <Typography variant="subtitle2">{t('extension.videoDataSync.entries')}</Typography>
+                            <Typography variant="subtitle2">{t('onlineSubtitleSources.entries')}</Typography>
                             <List
                                 dense
                                 sx={{ maxHeight: 220, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}
@@ -245,14 +244,14 @@ export default function OnlineSubtitleSourceDialog({
                                 ))}
                                 {jimakuEntries.length === 0 && (
                                     <ListItem>
-                                        <ListItemText primary={t('extension.videoDataSync.noEntries')} />
+                                        <ListItemText primary={t('onlineSubtitleSources.noEntries')} />
                                     </ListItem>
                                 )}
                             </List>
                         </Stack>
 
                         <Stack spacing={1} sx={{ flex: 1, minWidth: 0 }}>
-                            <Typography variant="subtitle2">{t('extension.videoDataSync.availableFiles')}</Typography>
+                            <Typography variant="subtitle2">{t('onlineSubtitleSources.availableFiles')}</Typography>
                             <List
                                 dense
                                 sx={{ maxHeight: 220, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}
@@ -264,7 +263,7 @@ export default function OnlineSubtitleSourceDialog({
                                 ))}
                                 {selectedFiles.length === 0 && (
                                     <ListItem>
-                                        <ListItemText primary={t('extension.videoDataSync.noFiles')} />
+                                        <ListItemText primary={t('onlineSubtitleSources.noFiles')} />
                                     </ListItem>
                                 )}
                             </List>

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -1,0 +1,296 @@
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Link from '@mui/material/Link';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { JimakuClient } from '@/services/subtitle-sources';
+
+interface OnlineSubtitleImportCandidate {
+    name: string;
+    url: string;
+}
+
+interface Props {
+    open: boolean;
+    onClose: () => void;
+    onImport: (file: OnlineSubtitleImportCandidate) => Promise<void>;
+    detectedTitleHint?: string;
+    jimakuApiKey: string;
+    onJimakuApiKeyChange: (jimakuApiKey: string) => void;
+}
+
+const emptyStateText = {
+    entries: 'No entries',
+    files: 'No files',
+};
+
+const SUPPORTED_JIMAKU_EXTENSIONS = ['.srt', '.ass'];
+
+const isSupportedSubtitleFile = (name: string) =>
+    SUPPORTED_JIMAKU_EXTENSIONS.some((ext) => name.toLowerCase().endsWith(ext));
+
+const normalizeDetectedTitleHint = (hint?: string) => {
+    const trimmedHint = hint?.trim() ?? '';
+
+    if (trimmedHint.length === 0) {
+        return '';
+    }
+
+    const suffixSplit = trimmedHint.split(' - ');
+    if (suffixSplit.length > 1) {
+        return suffixSplit[0].trim();
+    }
+
+    return trimmedHint;
+};
+
+export default function OnlineSubtitleSourceDialog({
+    open,
+    onClose,
+    onImport,
+    detectedTitleHint,
+    jimakuApiKey,
+    onJimakuApiKeyChange,
+}: Props) {
+    const { t } = useTranslation();
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string>();
+
+    const [query, setQuery] = useState('');
+    const [jimakuEntries, setJimakuEntries] = useState<{ id: number; name: string }[]>([]);
+    const [jimakuSelectedEntryId, setJimakuSelectedEntryId] = useState<number>();
+    const [jimakuFiles, setJimakuFiles] = useState<OnlineSubtitleImportCandidate[]>([]);
+
+    const selectedFiles = jimakuFiles;
+    const normalizedDetectedTitleHint = useMemo(
+        () => normalizeDetectedTitleHint(detectedTitleHint),
+        [detectedTitleHint]
+    );
+    const showDetectedTitleHint =
+        normalizedDetectedTitleHint.length > 0 &&
+        normalizedDetectedTitleHint.toLowerCase() !== query.trim().toLowerCase();
+    const isSearchDisabled =
+        loading || query.trim().length === 0 || jimakuApiKey.trim().length === 0;
+
+    const resetState = useCallback(() => {
+        setLoading(false);
+        setError(undefined);
+        setJimakuEntries([]);
+        setJimakuSelectedEntryId(undefined);
+        setJimakuFiles([]);
+    }, []);
+
+    useEffect(() => {
+        if (open) {
+            resetState();
+        }
+    }, [open, resetState]);
+
+    const handleSearchJimaku = useCallback(async () => {
+        setError(undefined);
+        setLoading(true);
+
+        try {
+            const client = new JimakuClient({ apiKey: jimakuApiKey });
+            const entries = (await client.searchEntries(query)).data;
+            setJimakuEntries(entries.map((entry) => ({ id: entry.id, name: entry.name })));
+            setJimakuSelectedEntryId(undefined);
+            setJimakuFiles([]);
+        } catch (e) {
+            setError((e as Error).message);
+        } finally {
+            setLoading(false);
+        }
+    }, [jimakuApiKey, query]);
+
+    const handleLoadJimakuFiles = useCallback(
+        async (entryId: number) => {
+            setError(undefined);
+            setLoading(true);
+            setJimakuSelectedEntryId(entryId);
+
+            try {
+                const client = new JimakuClient({ apiKey: jimakuApiKey });
+                const files = (await client.getFiles(entryId)).data
+                    .filter((file) => isSupportedSubtitleFile(file.name))
+                    .map((file) => ({ name: file.name, url: file.url }));
+                setJimakuFiles(files);
+            } catch (e) {
+                setError((e as Error).message);
+                setJimakuFiles([]);
+            } finally {
+                setLoading(false);
+            }
+        },
+        [jimakuApiKey]
+    );
+
+    const handleImport = useCallback(
+        async (file: OnlineSubtitleImportCandidate) => {
+            setError(undefined);
+            setLoading(true);
+
+            try {
+                await onImport(file);
+                onClose();
+            } catch (e) {
+                setError((e as Error).message);
+            } finally {
+                setLoading(false);
+            }
+        },
+        [onClose, onImport]
+    );
+
+    const handleApplyDetectedTitleHint = useCallback(() => {
+        setQuery(normalizedDetectedTitleHint);
+    }, [normalizedDetectedTitleHint]);
+
+    const handleSearch = handleSearchJimaku;
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            fullWidth
+            maxWidth="md"
+
+        >
+            <DialogTitle>
+                {t('extension.videoDataSync.onlineSubtitleSources', { defaultValue: 'Online subtitle sources' })}
+            </DialogTitle>
+            <DialogContent>
+                <Stack spacing={2}>
+                    {error && <Alert severity="error">{error}</Alert>}
+
+                    {showDetectedTitleHint && (
+                        <Alert
+                            severity="info"
+                            action={
+                                <Button onClick={handleApplyDetectedTitleHint} size="small">
+                                    {t('extension.videoDataSync.fillDetectedTitle', {
+                                        defaultValue: 'Use title',
+                                    })}
+                                </Button>
+                            }
+                        >
+                            {t('extension.videoDataSync.detectedTitleHint', {
+                                defaultValue: 'Detected from current page: {{title}}',
+                                title: normalizedDetectedTitleHint,
+                            })}
+                        </Alert>
+                    )}
+
+                    <Box sx={{ display: 'flex', gap: 1 }}>
+                        <TextField
+                            label={t('extension.videoDataSync.animeTitle', { defaultValue: 'Anime title' })}
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            fullWidth
+                        />
+                        <Button variant="contained" onClick={handleSearch} disabled={isSearchDisabled}>
+                            {t('extension.videoDataSync.search', { defaultValue: 'Search' })}
+                        </Button>
+                    </Box>
+
+                    <TextField
+                        label={t('extension.videoDataSync.jimakuApiKey', { defaultValue: 'Jimaku API Key' })}
+                        value={jimakuApiKey}
+                        onChange={(e) => onJimakuApiKeyChange(e.target.value)}
+                        helperText={
+                            <>
+                                {t('extension.videoDataSync.jimakuApiKeyAutosaveHint', {
+                                    defaultValue: 'Saved automatically after typing.',
+                                })}
+                                {' '}
+                                <Link
+                                    href="https://jimaku.cc/account"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    underline="hover"
+                                >
+                                    {t('extension.videoDataSync.jimakuApiKeyGetHere', {
+                                        defaultValue: 'Get your API key here.',
+                                    })}
+                                </Link>
+                            </>
+                        }
+                        fullWidth
+                    />
+
+                    <Box sx={{ display: 'flex', gap: 2 }}>
+                        <Stack spacing={1} sx={{ flex: 1, minWidth: 0 }}>
+                            <Typography variant="subtitle2">
+                                {t('extension.videoDataSync.entries', { defaultValue: 'Entries' })}
+                            </Typography>
+                            <List
+                                dense
+                                sx={{ maxHeight: 220, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}
+                            >
+                                {jimakuEntries.map((entry) => (
+                                    <ListItemButton
+                                        key={entry.id}
+                                        onClick={() => handleLoadJimakuFiles(entry.id)}
+                                        selected={jimakuSelectedEntryId === entry.id}
+                                    >
+                                        <ListItemText primary={entry.name} />
+                                    </ListItemButton>
+                                ))}
+                                {jimakuEntries.length === 0 && (
+                                    <ListItem>
+                                        <ListItemText
+                                            primary={t('extension.videoDataSync.noEntries', {
+                                                defaultValue: emptyStateText.entries,
+                                            })}
+                                        />
+                                    </ListItem>
+                                )}
+                            </List>
+                        </Stack>
+
+                        <Stack spacing={1} sx={{ flex: 1, minWidth: 0 }}>
+                            <Typography variant="subtitle2">
+                                {t('extension.videoDataSync.availableFiles', { defaultValue: 'Available files' })}
+                            </Typography>
+                            <List dense sx={{ maxHeight: 220, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}>
+                                {selectedFiles.map((file) => (
+                                    <ListItemButton key={file.url} onClick={() => handleImport(file)}>
+                                        <ListItemText primary={file.name} secondary={file.url} />
+                                    </ListItemButton>
+                                ))}
+                                {selectedFiles.length === 0 && (
+                                    <ListItem>
+                                        <ListItemText
+                                            primary={t('extension.videoDataSync.noFiles', { defaultValue: emptyStateText.files })}
+                                        />
+                                    </ListItem>
+                                )}
+                            </List>
+                        </Stack>
+                    </Box>
+                    {loading && (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
+                            <CircularProgress size={22} />
+                        </Box>
+                    )}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>{t('action.cancel')}</Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -7,6 +7,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import Stack from '@mui/material/Stack';
@@ -400,12 +401,13 @@ export default function OnlineSubtitleSourceDialog({ open, onClose, onImport, de
                                     </ListItemButton>
                                 ))}
                                 {jimakuEntries.length === 0 && (
-                                    <ListItemText
-                                        sx={{ px: 2, py: 1 }}
-                                        primary={t('extension.videoDataSync.noEntries', {
-                                            defaultValue: emptyStateText.entries,
-                                        })}
-                                    />
+                                    <ListItem>
+                                        <ListItemText
+                                            primary={t('extension.videoDataSync.noEntries', {
+                                                defaultValue: emptyStateText.entries,
+                                            })}
+                                        />
+                                    </ListItem>
                                 )}
                             </List>
                         </Stack>
@@ -430,12 +432,13 @@ export default function OnlineSubtitleSourceDialog({ open, onClose, onImport, de
                                     </ListItemButton>
                                 ))}
                                 {ajattEntries.length === 0 && (
-                                    <ListItemText
-                                        sx={{ px: 2, py: 1 }}
-                                        primary={t('extension.videoDataSync.noDirectories', {
-                                            defaultValue: emptyStateText.directories,
-                                        })}
-                                    />
+                                    <ListItem>
+                                        <ListItemText
+                                            primary={t('extension.videoDataSync.noDirectories', {
+                                                defaultValue: emptyStateText.directories,
+                                            })}
+                                        />
+                                    </ListItem>
                                 )}
                             </List>
                         </Stack>
@@ -451,10 +454,11 @@ export default function OnlineSubtitleSourceDialog({ open, onClose, onImport, de
                             </ListItemButton>
                         ))}
                         {selectedFiles.length === 0 && (
-                            <ListItemText
-                                sx={{ px: 2, py: 1 }}
-                                primary={t('extension.videoDataSync.noFiles', { defaultValue: emptyStateText.files })}
-                            />
+                            <ListItem>
+                                <ListItemText
+                                    primary={t('extension.videoDataSync.noFiles', { defaultValue: emptyStateText.files })}
+                                />
+                            </ListItem>
                         )}
                     </List>
                     {loading && (

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -1,0 +1,472 @@
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Stack from '@mui/material/Stack';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { JimakuClient, listAjattDirectoryFiles, searchAjatt } from '@/services/subtitle-sources';
+
+interface OnlineSubtitleImportCandidate {
+    name: string;
+    url: string;
+}
+
+interface Props {
+    open: boolean;
+    onClose: () => void;
+    onImport: (file: OnlineSubtitleImportCandidate) => Promise<void>;
+    detectedTitleHint?: string;
+}
+
+type Source = 'jimaku' | 'ajatt';
+const emptyStateText = {
+    entries: 'No entries',
+    directories: 'No directories',
+    files: 'No files',
+};
+
+const jimakuApiKeyStorageKey = 'jimakuApiKey';
+
+type ExtensionStorageAreaLike = {
+    get: (
+        keys?: string | string[] | Record<string, unknown> | null,
+        callback?: (items: Record<string, unknown>) => void
+    ) => Promise<Record<string, unknown>> | void;
+    set: (items: Record<string, unknown>, callback?: () => void) => Promise<void> | void;
+};
+
+const getExtensionStorage = () => {
+    const globalWithStorage = globalThis as typeof globalThis & {
+        browser?: { storage?: { local?: chrome.storage.StorageArea } };
+        chrome?: { storage?: { local?: chrome.storage.StorageArea } };
+    };
+
+    return (
+        (globalWithStorage.browser?.storage?.local as ExtensionStorageAreaLike | undefined) ??
+        (globalWithStorage.chrome?.storage?.local as ExtensionStorageAreaLike | undefined)
+    );
+};
+
+const getChromeRuntimeLastError = () => {
+    const globalWithChrome = globalThis as typeof globalThis & {
+        chrome?: { runtime?: { lastError?: { message?: string } } };
+    };
+
+    return globalWithChrome.chrome?.runtime?.lastError?.message;
+};
+
+const setExtensionStorageValue = async (extensionStorage: ExtensionStorageAreaLike, key: string, value: string) => {
+    if (extensionStorage.set.length >= 2) {
+        await new Promise<void>((resolve, reject) => {
+            extensionStorage.set({ [key]: value }, () => {
+                const lastErrorMessage = getChromeRuntimeLastError();
+                if (lastErrorMessage) {
+                    reject(new Error(lastErrorMessage));
+                    return;
+                }
+
+                resolve();
+            });
+        });
+
+        return;
+    }
+
+    await extensionStorage.set({ [key]: value });
+};
+
+const getExtensionStorageValue = async (extensionStorage: ExtensionStorageAreaLike, key: string) => {
+    if (extensionStorage.get.length >= 2) {
+        return await new Promise<string | undefined>((resolve, reject) => {
+            extensionStorage.get(key, (result) => {
+                const lastErrorMessage = getChromeRuntimeLastError();
+                if (lastErrorMessage) {
+                    reject(new Error(lastErrorMessage));
+                    return;
+                }
+
+                resolve(typeof result?.[key] === 'string' ? (result[key] as string) : undefined);
+            });
+        });
+    }
+
+    const result = await extensionStorage.get(key);
+    if (!result) {
+        return undefined;
+    }
+
+    return typeof result[key] === 'string' ? (result[key] as string) : undefined;
+};
+
+const saveJimakuApiKeyToStorage = async (apiKey: string) => {
+    const extensionStorage = getExtensionStorage();
+
+    if (extensionStorage) {
+        try {
+            await setExtensionStorageValue(extensionStorage, jimakuApiKeyStorageKey, apiKey);
+        } catch {
+            // Ignore extension storage failures and fall back to localStorage.
+        }
+    }
+
+    try {
+        window.localStorage.setItem(jimakuApiKeyStorageKey, apiKey);
+    } catch {
+        // Ignore environments that disallow storage access.
+    }
+};
+
+const loadJimakuApiKeyFromStorage = async () => {
+    const extensionStorage = getExtensionStorage();
+
+    if (extensionStorage) {
+        try {
+            const value = await getExtensionStorageValue(extensionStorage, jimakuApiKeyStorageKey);
+            if (value !== undefined) {
+                return value;
+            }
+        } catch {
+            // Ignore extension storage failures and fall back to localStorage.
+        }
+    }
+
+    try {
+        return window.localStorage.getItem(jimakuApiKeyStorageKey) ?? '';
+    } catch {
+        return '';
+    }
+};
+
+const normalizeDetectedTitleHint = (hint?: string) => {
+    const trimmedHint = hint?.trim() ?? '';
+
+    if (trimmedHint.length === 0) {
+        return '';
+    }
+
+    const suffixSplit = trimmedHint.split(' - ');
+    if (suffixSplit.length > 1) {
+        return suffixSplit[0].trim();
+    }
+
+    return trimmedHint;
+};
+
+export default function OnlineSubtitleSourceDialog({ open, onClose, onImport, detectedTitleHint }: Props) {
+    const { t } = useTranslation();
+    const [source, setSource] = useState<Source>('jimaku');
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string>();
+
+    const [jimakuApiKey, setJimakuApiKey] = useState('');
+    const [query, setQuery] = useState('');
+    const [didLoadJimakuApiKey, setDidLoadJimakuApiKey] = useState(false);
+    const [jimakuEntries, setJimakuEntries] = useState<{ id: number; name: string }[]>([]);
+    const [jimakuSelectedEntryId, setJimakuSelectedEntryId] = useState<number>();
+    const [jimakuFiles, setJimakuFiles] = useState<OnlineSubtitleImportCandidate[]>([]);
+
+    const [ajattEntries, setAjattEntries] = useState<{ path: string; name: string }[]>([]);
+    const [ajattSelectedPath, setAjattSelectedPath] = useState<string>();
+    const [ajattFiles, setAjattFiles] = useState<OnlineSubtitleImportCandidate[]>([]);
+
+    const selectedFiles = useMemo(
+        () => (source === 'jimaku' ? jimakuFiles : ajattFiles),
+        [source, jimakuFiles, ajattFiles]
+    );
+    const normalizedDetectedTitleHint = useMemo(
+        () => normalizeDetectedTitleHint(detectedTitleHint),
+        [detectedTitleHint]
+    );
+    const showDetectedTitleHint =
+        normalizedDetectedTitleHint.length > 0 &&
+        normalizedDetectedTitleHint.toLowerCase() !== query.trim().toLowerCase();
+    const isSearchDisabled =
+        loading || query.trim().length === 0 || (source === 'jimaku' && jimakuApiKey.trim().length === 0);
+
+    const loadJimakuApiKey = useCallback(async () => {
+        setJimakuApiKey(await loadJimakuApiKeyFromStorage());
+        setDidLoadJimakuApiKey(true);
+    }, []);
+
+    const resetState = useCallback(() => {
+        setLoading(false);
+        setError(undefined);
+        setJimakuEntries([]);
+        setJimakuSelectedEntryId(undefined);
+        setJimakuFiles([]);
+        setAjattEntries([]);
+        setAjattSelectedPath(undefined);
+        setAjattFiles([]);
+    }, []);
+
+    const handleDialogEntered = useCallback(async () => {
+        await loadJimakuApiKey();
+        resetState();
+    }, [loadJimakuApiKey, resetState]);
+
+    const handleSearchJimaku = useCallback(async () => {
+        setError(undefined);
+        setLoading(true);
+
+        try {
+            const client = new JimakuClient({ apiKey: jimakuApiKey });
+            const entries = (await client.searchEntries(query)).data;
+            setJimakuEntries(entries.map((entry) => ({ id: entry.id, name: entry.name })));
+            setJimakuSelectedEntryId(undefined);
+            setJimakuFiles([]);
+        } catch (e) {
+            setError((e as Error).message);
+        } finally {
+            setLoading(false);
+        }
+    }, [jimakuApiKey, query]);
+
+    const handleLoadJimakuFiles = useCallback(
+        async (entryId: number) => {
+            setError(undefined);
+            setLoading(true);
+            setJimakuSelectedEntryId(entryId);
+
+            try {
+                const client = new JimakuClient({ apiKey: jimakuApiKey });
+                const files = (await client.getFiles(entryId)).data.map((file) => ({ name: file.name, url: file.url }));
+                setJimakuFiles(files);
+            } catch (e) {
+                setError((e as Error).message);
+                setJimakuFiles([]);
+            } finally {
+                setLoading(false);
+            }
+        },
+        [jimakuApiKey]
+    );
+
+    const handleSearchAjatt = useCallback(async () => {
+        setError(undefined);
+        setLoading(true);
+
+        try {
+            const entries = await searchAjatt(query);
+            setAjattEntries(entries.map((entry) => ({ path: entry.path, name: entry.name })));
+            setAjattSelectedPath(undefined);
+            setAjattFiles([]);
+        } catch (e) {
+            setError((e as Error).message);
+        } finally {
+            setLoading(false);
+        }
+    }, [query]);
+
+    const handleLoadAjattFiles = useCallback(async (path: string) => {
+        setError(undefined);
+        setLoading(true);
+        setAjattSelectedPath(path);
+
+        try {
+            const files = await listAjattDirectoryFiles(path);
+            setAjattFiles(files);
+        } catch (e) {
+            setError((e as Error).message);
+            setAjattFiles([]);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    const handleImport = useCallback(
+        async (file: OnlineSubtitleImportCandidate) => {
+            setError(undefined);
+            setLoading(true);
+
+            try {
+                await onImport(file);
+                onClose();
+            } catch (e) {
+                setError((e as Error).message);
+            } finally {
+                setLoading(false);
+            }
+        },
+        [onClose, onImport]
+    );
+
+    const handleApplyDetectedTitleHint = useCallback(() => {
+        setQuery(normalizedDetectedTitleHint);
+    }, [normalizedDetectedTitleHint]);
+
+    const handleSearch = useCallback(async () => {
+        if (source === 'jimaku') {
+            await handleSearchJimaku();
+            return;
+        }
+
+        await handleSearchAjatt();
+    }, [handleSearchAjatt, handleSearchJimaku, source]);
+
+    useEffect(() => {
+        if (!open || !didLoadJimakuApiKey) {
+            return;
+        }
+
+        void saveJimakuApiKeyToStorage(jimakuApiKey);
+    }, [didLoadJimakuApiKey, jimakuApiKey, open]);
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            fullWidth
+            maxWidth="md"
+            TransitionProps={{ onEntered: handleDialogEntered }}
+        >
+            <DialogTitle>
+                {t('extension.videoDataSync.onlineSubtitleSources', { defaultValue: 'Online subtitle sources' })}
+            </DialogTitle>
+            <DialogContent>
+                <Stack spacing={2}>
+                    <Tabs value={source} onChange={(_, value: Source) => setSource(value)}>
+                        <Tab value="jimaku" label="jimaku.cc" />
+                        <Tab value="ajatt" label="subtitles.ajatt.top" />
+                    </Tabs>
+                    {error && <Alert severity="error">{error}</Alert>}
+
+                    {showDetectedTitleHint && (
+                        <Alert
+                            severity="info"
+                            action={
+                                <Button onClick={handleApplyDetectedTitleHint} size="small">
+                                    {t('extension.videoDataSync.fillDetectedTitle', {
+                                        defaultValue: 'Use title',
+                                    })}
+                                </Button>
+                            }
+                        >
+                            {t('extension.videoDataSync.detectedTitleHint', {
+                                defaultValue: 'Detected from current page: {{title}}',
+                                title: normalizedDetectedTitleHint,
+                            })}
+                        </Alert>
+                    )}
+
+                    <Box sx={{ display: 'flex', gap: 1 }}>
+                        <TextField
+                            label={t('extension.videoDataSync.animeTitle', { defaultValue: 'Anime title' })}
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            fullWidth
+                        />
+                        <Button variant="contained" onClick={handleSearch} disabled={isSearchDisabled}>
+                            {t('extension.videoDataSync.search', { defaultValue: 'Search' })}
+                        </Button>
+                    </Box>
+
+                    {source === 'jimaku' && (
+                        <Stack spacing={2}>
+                            <TextField
+                                label={t('extension.videoDataSync.jimakuApiKey', { defaultValue: 'Jimaku API Key' })}
+                                value={jimakuApiKey}
+                                onChange={(e) => setJimakuApiKey(e.target.value)}
+                                helperText={t('extension.videoDataSync.jimakuApiKeyAutosaveHint', {
+                                    defaultValue: 'Only used for jimaku.cc. Saved automatically after typing.',
+                                })}
+                                fullWidth
+                            />
+                            <Typography variant="subtitle2">
+                                {t('extension.videoDataSync.entries', { defaultValue: 'Entries' })}
+                            </Typography>
+                            <List
+                                dense
+                                sx={{ maxHeight: 180, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}
+                            >
+                                {jimakuEntries.map((entry) => (
+                                    <ListItemButton
+                                        key={entry.id}
+                                        onClick={() => handleLoadJimakuFiles(entry.id)}
+                                        selected={jimakuSelectedEntryId === entry.id}
+                                    >
+                                        <ListItemText primary={entry.name} />
+                                    </ListItemButton>
+                                ))}
+                                {jimakuEntries.length === 0 && (
+                                    <ListItemText
+                                        sx={{ px: 2, py: 1 }}
+                                        primary={t('extension.videoDataSync.noEntries', {
+                                            defaultValue: emptyStateText.entries,
+                                        })}
+                                    />
+                                )}
+                            </List>
+                        </Stack>
+                    )}
+
+                    {source === 'ajatt' && (
+                        <Stack spacing={2}>
+                            <Typography variant="subtitle2">
+                                {t('extension.videoDataSync.directories', { defaultValue: 'Directories' })}
+                            </Typography>
+                            <List
+                                dense
+                                sx={{ maxHeight: 180, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}
+                            >
+                                {ajattEntries.map((entry) => (
+                                    <ListItemButton
+                                        key={entry.path}
+                                        onClick={() => handleLoadAjattFiles(entry.path)}
+                                        selected={ajattSelectedPath === entry.path}
+                                    >
+                                        <ListItemText primary={entry.name} />
+                                    </ListItemButton>
+                                ))}
+                                {ajattEntries.length === 0 && (
+                                    <ListItemText
+                                        sx={{ px: 2, py: 1 }}
+                                        primary={t('extension.videoDataSync.noDirectories', {
+                                            defaultValue: emptyStateText.directories,
+                                        })}
+                                    />
+                                )}
+                            </List>
+                        </Stack>
+                    )}
+
+                    <Typography variant="subtitle2">
+                        {t('extension.videoDataSync.availableFiles', { defaultValue: 'Available files' })}
+                    </Typography>
+                    <List dense sx={{ maxHeight: 220, overflow: 'auto', border: '1px solid', borderColor: 'divider' }}>
+                        {selectedFiles.map((file) => (
+                            <ListItemButton key={file.url} onClick={() => handleImport(file)}>
+                                <ListItemText primary={file.name} secondary={file.url} />
+                            </ListItemButton>
+                        ))}
+                        {selectedFiles.length === 0 && (
+                            <ListItemText
+                                sx={{ px: 2, py: 1 }}
+                                primary={t('extension.videoDataSync.noFiles', { defaultValue: emptyStateText.files })}
+                            />
+                        )}
+                    </List>
+                    {loading && (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
+                            <CircularProgress size={22} />
+                        </Box>
+                    )}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>{t('action.cancel')}</Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/extension/src/ui/components/VideoDataSyncDialog.tsx
+++ b/extension/src/ui/components/VideoDataSyncDialog.tsx
@@ -70,6 +70,7 @@ interface Props {
     hideRememberTrackPreferenceToggle?: boolean;
     onCancel: () => void;
     onOpenFile: (track?: number) => void;
+    onOpenOnline: (track?: number) => void;
     onOpenSettings: () => void;
     onConfirm: (track: ConfirmedVideoDataSubtitleTrack[], shouldRememberTrackChoices: boolean) => void;
     onSetActiveProfile: (profile: string | undefined) => void;
@@ -93,6 +94,7 @@ export default function VideoDataSyncDialog({
     hideRememberTrackPreferenceToggle,
     onCancel,
     onOpenFile,
+    onOpenOnline,
     onOpenSettings,
     onConfirm,
     onSetActiveProfile,
@@ -219,6 +221,11 @@ export default function VideoDataSyncDialog({
                                 </MenuItem>
                             ))}
                             <MenuItem onClick={() => onOpenFile(i)}>{t('action.openFiles')}</MenuItem>
+                            <MenuItem onClick={() => onOpenOnline(i)}>
+                                {t('extension.videoDataSync.searchOnlineSubtitles', {
+                                    defaultValue: 'Search online subtitles',
+                                })}
+                            </MenuItem>
                         </TextField>
                         {isLoading && (
                             <span className={classes.spinner}>
@@ -328,6 +335,9 @@ export default function VideoDataSyncDialog({
             <DialogActions>
                 <Button disabled={disabled} onClick={() => onOpenFile()}>
                     {t('action.openFiles')}
+                </Button>
+                <Button disabled={disabled} onClick={() => onOpenOnline()}>
+                    {t('extension.videoDataSync.onlineSources', { defaultValue: 'Online sources' })}
                 </Button>
                 <Button action={okActionRef} disabled={!trimmedName || disabled} onClick={handleOkButtonClick}>
                     {t('action.ok')}

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -238,7 +238,10 @@ export default function VideoDataSyncUi({ bridge }: Props) {
         // Revoke tracked blob URLs once they are no longer referenced by subtitle tracks.
         const currentLocalObjectUrls = new Set(
             subtitles
-                .filter((track) => track.localFile === true && typeof track.url === 'string' && track.url.startsWith('blob:'))
+                .filter(
+                    (track) =>
+                        track.localFile === true && typeof track.url === 'string' && track.url.startsWith('blob:')
+                )
                 .map((track) => track.url as string)
         );
 
@@ -436,9 +439,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                     onImport={handleImportOnlineFile}
                     detectedTitleHint={detectedTitleHint}
                     jimakuApiKey={onlineSubtitleSourceConfig.jimakuApiKey}
-                    onJimakuApiKeyChange={(jimakuApiKey) =>
-                        handleOnlineSubtitleSourceConfigChanged({ jimakuApiKey })
-                    }
+                    onJimakuApiKeyChange={(jimakuApiKey) => handleOnlineSubtitleSourceConfigChanged({ jimakuApiKey })}
                 />
                 <input
                     ref={fileInputRef}

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -12,22 +12,81 @@ import {
     VideoDataSubtitleTrack,
     VideoDataUiBridgeConfirmMessage,
     VideoDataUiBridgeOpenFileMessage,
+    VideoDataUiBridgeSetOnlineSubtitleSourceConfigMessage,
     VideoDataUiModel,
     VideoDataUiOpenReason,
     ActiveProfileMessage,
 } from '@project/common';
+import type { OnlineSubtitleSourceConfig } from '@project/common/global-state';
 import { createTheme } from '@project/common/theme';
 import { type PaletteMode } from '@mui/material/styles';
 import { bufferToBase64 } from '@project/common/base64';
 import { useTranslation } from 'react-i18next';
 import type { Profile } from '@project/common/settings';
 import { StyledEngineProvider } from '@mui/material/styles';
+import OnlineSubtitleSourceDialog from './OnlineSubtitleSourceDialog';
 
 interface Props {
     bridge: Bridge;
 }
 
 const initialTrackIds = ['-', '-', '-'];
+
+const normalizeOnlineSubtitleFileName = (name: string, sourceUrl: string) => {
+    const trimmedName = name.trim();
+    const defaultExtension = 'srt';
+    const sourceUrlPath = (() => {
+        try {
+            return new URL(sourceUrl).pathname;
+        } catch {
+            return sourceUrl;
+        }
+    })();
+    const sourceUrlFileName = sourceUrlPath.split('/').pop() ?? '';
+    const sourceUrlLastDotIndex = sourceUrlFileName.lastIndexOf('.');
+    const sourceUrlExtension =
+        sourceUrlLastDotIndex > 0 && sourceUrlLastDotIndex < sourceUrlFileName.length - 1
+            ? sourceUrlFileName.substring(sourceUrlLastDotIndex + 1)
+            : undefined;
+
+    if (trimmedName.length === 0) {
+        // Handle incomplete source metadata (empty display name) deterministically.
+        const fallbackExtension = sourceUrlExtension ?? defaultExtension;
+        return {
+            normalizedName: `subtitle.${fallbackExtension}`,
+            extension: fallbackExtension,
+        };
+    }
+
+    const lastDotIndex = trimmedName.lastIndexOf('.');
+    if (lastDotIndex > 0 && lastDotIndex < trimmedName.length - 1) {
+        return {
+            normalizedName: trimmedName,
+            extension: trimmedName.substring(lastDotIndex + 1),
+        };
+    }
+
+    // Keep name/extension consistent when display name has no extension but URL still has one.
+    const fallbackExtension = sourceUrlExtension ?? defaultExtension;
+    return {
+        normalizedName: `${trimmedName}.${fallbackExtension}`,
+        extension: fallbackExtension,
+    };
+};
+
+const detectOnlineSubtitleTitleHint = (suggestedName: string) => {
+    const normalizedSuggestedName = suggestedName.trim();
+
+    if (normalizedSuggestedName.length > 0) {
+        return normalizedSuggestedName;
+    }
+
+    if (typeof document === 'undefined') {
+        return '';
+    }
+
+    return document.title.trim();
+};
 
 export default function VideoDataSyncUi({ bridge }: Props) {
     const { t } = useTranslation();
@@ -50,6 +109,16 @@ export default function VideoDataSyncUi({ bridge }: Props) {
     const [fileInputTrackNumber, setFileInputTrackNumber] = useState<number>();
     const [hasSeenFtue, setHasSeenFtue] = useState<boolean>();
     const [hideRememberTrackPreferenceToggle, setHideRememberTrackPreferenceToggle] = useState<boolean>();
+    const [onlineSubtitleSourceConfig, setOnlineSubtitleSourceConfig] = useState<OnlineSubtitleSourceConfig>({
+        jimakuApiKey: '',
+    });
+    const [onlineDialogOpen, setOnlineDialogOpen] = useState(false);
+    const [onlineDialogTrackNumber, setOnlineDialogTrackNumber] = useState<number>();
+    const detectedTitleHint = useMemo(() => detectOnlineSubtitleTitleHint(suggestedName), [suggestedName]);
+    // Tracks blob URLs created here so we only revoke URLs owned by this component.
+    const trackedLocalObjectUrlsRef = useRef(new Set<string>());
+    // Previous render's local blob URLs to detect removed/replaced tracks.
+    const previousLocalObjectUrlsRef = useRef(new Set<string>());
 
     const theme = useMemo(() => createTheme((themeType || 'dark') as PaletteMode), [themeType]);
 
@@ -156,10 +225,45 @@ export default function VideoDataSyncUi({ bridge }: Props) {
             if (model.hideRememberTrackPreferenceToggle !== undefined) {
                 setHideRememberTrackPreferenceToggle(model.hideRememberTrackPreferenceToggle);
             }
+
+            if (model.onlineSubtitleSourceConfig !== undefined) {
+                setOnlineSubtitleSourceConfig(model.onlineSubtitleSourceConfig);
+            }
         });
     }, [bridge, t]);
 
     useEffect(() => bridge.serverIsReady(), [bridge]);
+
+    useEffect(() => {
+        // Revoke tracked blob URLs once they are no longer referenced by subtitle tracks.
+        const currentLocalObjectUrls = new Set(
+            subtitles
+                .filter((track) => track.localFile === true && typeof track.url === 'string' && track.url.startsWith('blob:'))
+                .map((track) => track.url as string)
+        );
+
+        for (const trackedUrl of previousLocalObjectUrlsRef.current) {
+            if (!currentLocalObjectUrls.has(trackedUrl) && trackedLocalObjectUrlsRef.current.has(trackedUrl)) {
+                URL.revokeObjectURL(trackedUrl);
+                trackedLocalObjectUrlsRef.current.delete(trackedUrl);
+            }
+        }
+
+        previousLocalObjectUrlsRef.current = currentLocalObjectUrls;
+    }, [subtitles]);
+
+    useEffect(
+        () => () => {
+            // Safety net for cancel/close/navigation paths where sync never consumes these URLs.
+            for (const url of trackedLocalObjectUrlsRef.current) {
+                URL.revokeObjectURL(url);
+            }
+
+            trackedLocalObjectUrlsRef.current.clear();
+            previousLocalObjectUrlsRef.current.clear();
+        },
+        []
+    );
 
     const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -189,6 +293,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                 } else {
                     const fileTracks: VideoDataSubtitleTrack[] = [...files].map((f) => {
                         const url = URL.createObjectURL(f);
+                        trackedLocalObjectUrlsRef.current.add(url);
                         const extension = f.name.substring(f.name.lastIndexOf('.') + 1, f.name.length);
                         return {
                             label: f.name,
@@ -223,6 +328,57 @@ export default function VideoDataSyncUi({ bridge }: Props) {
         fileInputRef.current?.click();
     }, []);
 
+    const handleOpenOnline = useCallback((track?: number) => {
+        setOnlineDialogTrackNumber(track);
+        setOnlineDialogOpen(true);
+    }, []);
+
+    const handleOnlineDialogClose = useCallback(() => {
+        setOnlineDialogOpen(false);
+    }, []);
+
+    const handleImportOnlineFile = useCallback(
+        async ({ name, url }: { name: string; url: string }) => {
+            const response = await fetch(url);
+
+            if (!response.ok) {
+                throw new Error(`Subtitle retrieval failed with status ${response.status} (${response.statusText}).`);
+            }
+
+            const blob = await response.blob();
+            const { normalizedName, extension } = normalizeOnlineSubtitleFileName(name, url);
+            const file = new File([blob], normalizedName);
+            const objectUrl = URL.createObjectURL(file);
+            trackedLocalObjectUrlsRef.current.add(objectUrl);
+            const track = {
+                label: normalizedName,
+                id: objectUrl,
+                url: objectUrl,
+                extension,
+                localFile: true,
+            };
+
+            setSubtitles((s) => [...s, track]);
+            setSelectedSubtitleTrackIds((s) => {
+                const next = [...s];
+
+                if (onlineDialogTrackNumber !== undefined) {
+                    next[onlineDialogTrackNumber] = track.id;
+                } else {
+                    const firstEmptyIndex = next.findIndex((id) => id === '-');
+                    if (firstEmptyIndex >= 0) {
+                        next[firstEmptyIndex] = track.id;
+                    } else {
+                        next[0] = track.id;
+                    }
+                }
+
+                return next;
+            });
+        },
+        [onlineDialogTrackNumber]
+    );
+
     const handleSetActiveProfile = useCallback(
         (profile: string | undefined) => {
             const message: ActiveProfileMessage = { command: 'activeProfile', profile: profile };
@@ -235,6 +391,17 @@ export default function VideoDataSyncUi({ bridge }: Props) {
         setHasSeenFtue(true);
         bridge.sendMessageFromServer({ command: 'dismissFtue' });
     }, [bridge]);
+    const handleOnlineSubtitleSourceConfigChanged = useCallback(
+        (state: Partial<OnlineSubtitleSourceConfig>) => {
+            setOnlineSubtitleSourceConfig((current) => ({ ...current, ...state }));
+            const message: VideoDataUiBridgeSetOnlineSubtitleSourceConfigMessage = {
+                command: 'setOnlineSubtitleSourceConfig',
+                state,
+            };
+            bridge.sendMessageFromServer(message);
+        },
+        [bridge]
+    );
 
     return (
         <StyledEngineProvider injectFirst>
@@ -257,10 +424,21 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                     hideRememberTrackPreferenceToggle={hideRememberTrackPreferenceToggle}
                     onCancel={handleCancel}
                     onOpenFile={handleOpenFile}
+                    onOpenOnline={handleOpenOnline}
                     onOpenSettings={handleOpenSettings}
                     onConfirm={handleConfirm}
                     onSetActiveProfile={handleSetActiveProfile}
                     onDismissFtue={handleDismissFtue}
+                />
+                <OnlineSubtitleSourceDialog
+                    open={onlineDialogOpen}
+                    onClose={handleOnlineDialogClose}
+                    onImport={handleImportOnlineFile}
+                    detectedTitleHint={detectedTitleHint}
+                    jimakuApiKey={onlineSubtitleSourceConfig.jimakuApiKey}
+                    onJimakuApiKeyChange={(jimakuApiKey) =>
+                        handleOnlineSubtitleSourceConfigChanged({ jimakuApiKey })
+                    }
                 />
                 <input
                     ref={fileInputRef}

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -22,12 +22,27 @@ import { bufferToBase64 } from '@project/common/base64';
 import { useTranslation } from 'react-i18next';
 import type { Profile } from '@project/common/settings';
 import { StyledEngineProvider } from '@mui/material/styles';
+import OnlineSubtitleSourceDialog from './OnlineSubtitleSourceDialog';
 
 interface Props {
     bridge: Bridge;
 }
 
 const initialTrackIds = ['-', '-', '-'];
+
+const detectOnlineSubtitleTitleHint = (suggestedName: string) => {
+    const normalizedSuggestedName = suggestedName.trim();
+
+    if (normalizedSuggestedName.length > 0) {
+        return normalizedSuggestedName;
+    }
+
+    if (typeof document === 'undefined') {
+        return '';
+    }
+
+    return document.title.trim();
+};
 
 export default function VideoDataSyncUi({ bridge }: Props) {
     const { t } = useTranslation();
@@ -50,6 +65,9 @@ export default function VideoDataSyncUi({ bridge }: Props) {
     const [fileInputTrackNumber, setFileInputTrackNumber] = useState<number>();
     const [hasSeenFtue, setHasSeenFtue] = useState<boolean>();
     const [hideRememberTrackPreferenceToggle, setHideRememberTrackPreferenceToggle] = useState<boolean>();
+    const [onlineDialogOpen, setOnlineDialogOpen] = useState(false);
+    const [onlineDialogTrackNumber, setOnlineDialogTrackNumber] = useState<number>();
+    const detectedTitleHint = useMemo(() => detectOnlineSubtitleTitleHint(suggestedName), [suggestedName]);
 
     const theme = useMemo(() => createTheme((themeType || 'dark') as PaletteMode), [themeType]);
 
@@ -223,6 +241,56 @@ export default function VideoDataSyncUi({ bridge }: Props) {
         fileInputRef.current?.click();
     }, []);
 
+    const handleOpenOnline = useCallback((track?: number) => {
+        setOnlineDialogTrackNumber(track);
+        setOnlineDialogOpen(true);
+    }, []);
+
+    const handleOnlineDialogClose = useCallback(() => {
+        setOnlineDialogOpen(false);
+    }, []);
+
+    const handleImportOnlineFile = useCallback(
+        async ({ name, url }: { name: string; url: string }) => {
+            const response = await fetch(url);
+
+            if (!response.ok) {
+                throw new Error(`Subtitle retrieval failed with status ${response.status} (${response.statusText}).`);
+            }
+
+            const blob = await response.blob();
+            const file = new File([blob], name);
+            const extension = name.includes('.') ? name.substring(name.lastIndexOf('.') + 1) : 'srt';
+            const objectUrl = URL.createObjectURL(file);
+            const track = {
+                label: name,
+                id: objectUrl,
+                url: objectUrl,
+                extension,
+                localFile: true,
+            };
+
+            setSubtitles((s) => [...s, track]);
+            setSelectedSubtitleTrackIds((s) => {
+                const next = [...s];
+
+                if (onlineDialogTrackNumber !== undefined) {
+                    next[onlineDialogTrackNumber] = track.id;
+                } else {
+                    const firstEmptyIndex = next.findIndex((id) => id === '-');
+                    if (firstEmptyIndex >= 0) {
+                        next[firstEmptyIndex] = track.id;
+                    } else {
+                        next[0] = track.id;
+                    }
+                }
+
+                return next;
+            });
+        },
+        [onlineDialogTrackNumber]
+    );
+
     const handleSetActiveProfile = useCallback(
         (profile: string | undefined) => {
             const message: ActiveProfileMessage = { command: 'activeProfile', profile: profile };
@@ -257,10 +325,17 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                     hideRememberTrackPreferenceToggle={hideRememberTrackPreferenceToggle}
                     onCancel={handleCancel}
                     onOpenFile={handleOpenFile}
+                    onOpenOnline={handleOpenOnline}
                     onOpenSettings={handleOpenSettings}
                     onConfirm={handleConfirm}
                     onSetActiveProfile={handleSetActiveProfile}
                     onDismissFtue={handleDismissFtue}
+                />
+                <OnlineSubtitleSourceDialog
+                    open={onlineDialogOpen}
+                    onClose={handleOnlineDialogClose}
+                    onImport={handleImportOnlineFile}
+                    detectedTitleHint={detectedTitleHint}
                 />
                 <input
                     ref={fileInputRef}

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -30,6 +30,48 @@ interface Props {
 
 const initialTrackIds = ['-', '-', '-'];
 
+const normalizeOnlineSubtitleFileName = (name: string, sourceUrl: string) => {
+    const trimmedName = name.trim();
+    const defaultExtension = 'srt';
+    const sourceUrlPath = (() => {
+        try {
+            return new URL(sourceUrl).pathname;
+        } catch {
+            return sourceUrl;
+        }
+    })();
+    const sourceUrlFileName = sourceUrlPath.split('/').pop() ?? '';
+    const sourceUrlLastDotIndex = sourceUrlFileName.lastIndexOf('.');
+    const sourceUrlExtension =
+        sourceUrlLastDotIndex > 0 && sourceUrlLastDotIndex < sourceUrlFileName.length - 1
+            ? sourceUrlFileName.substring(sourceUrlLastDotIndex + 1)
+            : undefined;
+
+    if (trimmedName.length === 0) {
+        // Handle incomplete source metadata (empty display name) deterministically.
+        const fallbackExtension = sourceUrlExtension ?? defaultExtension;
+        return {
+            normalizedName: `subtitle.${fallbackExtension}`,
+            extension: fallbackExtension,
+        };
+    }
+
+    const lastDotIndex = trimmedName.lastIndexOf('.');
+    if (lastDotIndex > 0 && lastDotIndex < trimmedName.length - 1) {
+        return {
+            normalizedName: trimmedName,
+            extension: trimmedName.substring(lastDotIndex + 1),
+        };
+    }
+
+    // Keep name/extension consistent when display name has no extension but URL still has one.
+    const fallbackExtension = sourceUrlExtension ?? defaultExtension;
+    return {
+        normalizedName: `${trimmedName}.${fallbackExtension}`,
+        extension: fallbackExtension,
+    };
+};
+
 const detectOnlineSubtitleTitleHint = (suggestedName: string) => {
     const normalizedSuggestedName = suggestedName.trim();
 
@@ -68,6 +110,10 @@ export default function VideoDataSyncUi({ bridge }: Props) {
     const [onlineDialogOpen, setOnlineDialogOpen] = useState(false);
     const [onlineDialogTrackNumber, setOnlineDialogTrackNumber] = useState<number>();
     const detectedTitleHint = useMemo(() => detectOnlineSubtitleTitleHint(suggestedName), [suggestedName]);
+    // Tracks blob URLs created here so we only revoke URLs owned by this component.
+    const trackedLocalObjectUrlsRef = useRef(new Set<string>());
+    // Previous render's local blob URLs to detect removed/replaced tracks.
+    const previousLocalObjectUrlsRef = useRef(new Set<string>());
 
     const theme = useMemo(() => createTheme((themeType || 'dark') as PaletteMode), [themeType]);
 
@@ -179,6 +225,37 @@ export default function VideoDataSyncUi({ bridge }: Props) {
 
     useEffect(() => bridge.serverIsReady(), [bridge]);
 
+    useEffect(() => {
+        // Revoke tracked blob URLs once they are no longer referenced by subtitle tracks.
+        const currentLocalObjectUrls = new Set(
+            subtitles
+                .filter((track) => track.localFile === true && typeof track.url === 'string' && track.url.startsWith('blob:'))
+                .map((track) => track.url as string)
+        );
+
+        for (const trackedUrl of previousLocalObjectUrlsRef.current) {
+            if (!currentLocalObjectUrls.has(trackedUrl) && trackedLocalObjectUrlsRef.current.has(trackedUrl)) {
+                URL.revokeObjectURL(trackedUrl);
+                trackedLocalObjectUrlsRef.current.delete(trackedUrl);
+            }
+        }
+
+        previousLocalObjectUrlsRef.current = currentLocalObjectUrls;
+    }, [subtitles]);
+
+    useEffect(
+        () => () => {
+            // Safety net for cancel/close/navigation paths where sync never consumes these URLs.
+            for (const url of trackedLocalObjectUrlsRef.current) {
+                URL.revokeObjectURL(url);
+            }
+
+            trackedLocalObjectUrlsRef.current.clear();
+            previousLocalObjectUrlsRef.current.clear();
+        },
+        []
+    );
+
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const handleFileInputChange = useCallback(async () => {
@@ -207,6 +284,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                 } else {
                     const fileTracks: VideoDataSubtitleTrack[] = [...files].map((f) => {
                         const url = URL.createObjectURL(f);
+                        trackedLocalObjectUrlsRef.current.add(url);
                         const extension = f.name.substring(f.name.lastIndexOf('.') + 1, f.name.length);
                         return {
                             label: f.name,
@@ -259,11 +337,12 @@ export default function VideoDataSyncUi({ bridge }: Props) {
             }
 
             const blob = await response.blob();
-            const file = new File([blob], name);
-            const extension = name.includes('.') ? name.substring(name.lastIndexOf('.') + 1) : 'srt';
+            const { normalizedName, extension } = normalizeOnlineSubtitleFileName(name, url);
+            const file = new File([blob], normalizedName);
             const objectUrl = URL.createObjectURL(file);
+            trackedLocalObjectUrlsRef.current.add(objectUrl);
             const track = {
-                label: name,
+                label: normalizedName,
                 id: objectUrl,
                 url: objectUrl,
                 extension,


### PR DESCRIPTION
 ### Summary

This PR adds support for importing subtitles from online sources in the Video Data Sync flow.

### What’s included

- Added a new Online subtitle sources dialog in Video Data Sync.
- Added support for:
    - jimaku.cc (API key based search and file listing)
    - subtitles.ajatt.top (directory/table parsing and file listing)
- Added entry points to open online sources from:
    - Track selector menu (Search online subtitles)
    - Dialog actions (Online sources)
- Imported online subtitle files are converted into local tracks and selected automatically for the target slot.
- Jimaku API key persistence is handled in extension storage (with localStorage fallback).
- Improved error handling for online requests:
    - safer JSON parsing for Jimaku responses
    - explicit HTTP status checks for AJATT requests
- Added/updated tests for service behaviors and failure paths.

### Screenshots
<img width="428" height="231" alt="image" src="https://github.com/user-attachments/assets/4c70716b-da0c-4dda-884d-124844ea66f7" />
<img width="721" height="834" alt="image" src="https://github.com/user-attachments/assets/1040f3a5-9a42-45f1-a1e2-2bd570a6cda5" />

### Validation

- yarn workspace @project/extension run test extension/src/services/subtitle-sources.test.ts
- yarn workspace @project/extension run compile
- yarn workspace @project/extension run zip

All pass locally.

---

 I may still have missed details, so feedback is very welcome and I will actively revise this PR.

  I’m also not fully sure whether shipping subtitles.ajatt.top as a source has any policy/compliance concerns in this project. If
  this source should be removed, I can remove it immediately and keep the rest of the implementation.