### PR TITLE
add filter for 1 Unknown and 2+ Unknown in sentence stats

### DIFF
--- a/common/components/Statistics.tsx
+++ b/common/components/Statistics.tsx
@@ -22,7 +22,7 @@ import {
     sentenceComprehensionPointLabel,
     sentenceComprehensionXAxisLabels,
     sentenceDialogBucketData,
-    uncollectedSentenceBucketLabel,
+    statusSentenceBucketLabel,
 } from '@project/common/dictionary-statistics';
 import { AsbplayerSettings, dictionaryTrackEnabled, TokenStatus } from '@project/common/settings';
 import StatisticsSentenceDetailsDialog from '@project/common/components/StatisticsSentenceDetailsDialog';
@@ -108,6 +108,7 @@ const emptySentenceBuckets: DictionaryStatisticsSentenceBuckets = {
         entries: [],
     },
     uncollected: [],
+    unknown: [],
 };
 const distributionBarHeight = 6;
 const sentenceComprehensionGraphHeight = 120;
@@ -447,6 +448,7 @@ interface SentenceStatsPanelProps {
     totalSentences: number;
     sentenceBuckets: DictionaryStatisticsSentenceBuckets;
     uncollectedLabel: string;
+    unknownLabel: string;
     uniqueWordsPerSentenceLabel: string;
     uniqueWordsPerSentence: number;
     knownWordsPerSentenceLabel: string;
@@ -527,6 +529,7 @@ function SentenceStatsPanel({
     totalSentences,
     sentenceBuckets,
     uncollectedLabel,
+    unknownLabel,
     uniqueWordsPerSentenceLabel,
     uniqueWordsPerSentence,
     knownWordsPerSentenceLabel,
@@ -547,11 +550,21 @@ function SentenceStatsPanel({
         () =>
             sentenceBuckets.uncollected.map((bucket, groupIndex) => ({
                 bucket: { kind: 'uncollected', groupIndex } as const,
-                label: uncollectedSentenceBucketLabel(bucket, uncollectedLabel),
+                label: statusSentenceBucketLabel(bucket, uncollectedLabel),
                 count: bucket.count,
                 entries: bucket.entries,
             })),
         [sentenceBuckets, uncollectedLabel]
+    );
+    const unknownSentenceBuckets = useMemo(
+        () =>
+            sentenceBuckets.unknown.map((bucket, groupIndex) => ({
+                bucket: { kind: 'unknown', groupIndex } as const,
+                label: statusSentenceBucketLabel(bucket, unknownLabel),
+                count: bucket.count,
+                entries: bucket.entries,
+            })),
+        [sentenceBuckets, unknownLabel]
     );
 
     const renderSentenceBucketRow = useCallback(
@@ -641,9 +654,18 @@ function SentenceStatsPanel({
                             sentenceBuckets.allKnown.count,
                             sentenceBuckets.allKnown.entries
                         )}
-                        {uncollectedSentenceBuckets.map(({ bucket, label, count, entries }) =>
-                            renderSentenceBucketRow(bucket, label, count, entries)
-                        )}
+                        {uncollectedSentenceBuckets.map(({ bucket, label, count, entries }, index) => (
+                            <Box key={label} sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                                {renderSentenceBucketRow(bucket, label, count, entries)}
+                                {unknownSentenceBuckets[index] !== undefined &&
+                                    renderSentenceBucketRow(
+                                        unknownSentenceBuckets[index].bucket,
+                                        unknownSentenceBuckets[index].label,
+                                        unknownSentenceBuckets[index].count,
+                                        unknownSentenceBuckets[index].entries
+                                    )}
+                            </Box>
+                        ))}
                     </>
                 )}
             </Box>
@@ -898,6 +920,7 @@ function TrackSnapshot({
     const uniqueWordsPerSentenceLabel = t('statistics.uniqueWordsPerSentence');
     const knownWordsPerSentenceLabel = t('statistics.knownWordsPerSentence');
     const uncollectedLabel = statusLabels[TokenStatus.UNCOLLECTED];
+    const unknownLabel = statusLabels[TokenStatus.UNKNOWN];
     const currentWatchTitle = t('statistics.currentWatch');
     const ankiStatisticsTitle = t('statistics.anki.ankiStatistics');
     const ankiStatisticsInfoLines = useMemo(() => [t('statistics.anki.info.ankiStatistics')], [t]);
@@ -1115,6 +1138,7 @@ function TrackSnapshot({
                         totalSentences={totalSentences}
                         sentenceBuckets={trackSnapshot.sentenceBuckets}
                         uncollectedLabel={uncollectedLabel}
+                        unknownLabel={unknownLabel}
                         uniqueWordsPerSentenceLabel={uniqueWordsPerSentenceLabel}
                         uniqueWordsPerSentence={trackSnapshot.averageWordsPerSentence}
                         knownWordsPerSentenceLabel={knownWordsPerSentenceLabel}
@@ -1131,6 +1155,7 @@ function TrackSnapshot({
                             const bucketData = sentenceDialogBucketData(bucket, trackSnapshot.sentenceBuckets, {
                                 knownSentencesLabel: t('statistics.knownSentences'),
                                 uncollectedLabel,
+                                unknownLabel,
                             });
                             if (!bucketData) return;
                             onSentenceDialogState({
@@ -1149,6 +1174,7 @@ function TrackSnapshot({
                         totalSentences={totalSentences}
                         sentenceBuckets={projectedSentenceBuckets}
                         uncollectedLabel={uncollectedLabel}
+                        unknownLabel={unknownLabel}
                         uniqueWordsPerSentenceLabel={uniqueWordsPerSentenceLabel}
                         uniqueWordsPerSentence={projectedAverageWordsPerSentence}
                         knownWordsPerSentenceLabel={knownWordsPerSentenceLabel}
@@ -1191,6 +1217,7 @@ function TrackSnapshot({
                                 {
                                     knownSentencesLabel: t('statistics.knownSentences'),
                                     uncollectedLabel,
+                                    unknownLabel,
                                 }
                             );
                             if (!bucketData) return;

--- a/common/dictionary-statistics/dictionary-statistics-view.ts
+++ b/common/dictionary-statistics/dictionary-statistics-view.ts
@@ -62,6 +62,10 @@ export type DictionaryStatisticsSentenceDialogBucket =
     | {
           kind: 'uncollected';
           groupIndex: number;
+      }
+    | {
+          kind: 'unknown';
+          groupIndex: number;
       };
 
 export interface DictionaryStatisticsTokenStatusCount {
@@ -126,12 +130,19 @@ export interface DictionaryStatisticsSentenceUncollectedBucket {
     entries: DictionaryStatisticsSentenceBucketEntry[];
 }
 
+export interface DictionaryStatisticsSentenceUnknownBucket {
+    tokenCount: number;
+    count: number;
+    entries: DictionaryStatisticsSentenceBucketEntry[];
+}
+
 export interface DictionaryStatisticsSentenceBuckets {
     allKnown: {
         count: number;
         entries: DictionaryStatisticsSentenceBucketEntry[];
     };
     uncollected: DictionaryStatisticsSentenceUncollectedBucket[];
+    unknown: DictionaryStatisticsSentenceUnknownBucket[];
 }
 
 export interface DictionaryStatisticsRewatchSnapshot {
@@ -221,6 +232,7 @@ interface EvaluatedSentenceSnapshot {
     statusCounts: DictionaryStatisticsTokenStatusCounts;
     consideredTokenKeys: string[];
     uncollectedTokenKeys: string[];
+    unknownTokenKeys: string[];
 }
 
 interface DictionaryStatisticsDictionaryCounts {
@@ -396,11 +408,31 @@ function emptySentenceBuckets(): DictionaryStatisticsSentenceBuckets {
                 entries: [],
             },
         ],
+        unknown: [
+            {
+                tokenCount: 1,
+                count: 0,
+                entries: [],
+            },
+            {
+                tokenCount: 2,
+                count: 0,
+                entries: [],
+            },
+        ],
     };
 }
 
 function uncollectedSentenceBucketForCount(
     sentenceBuckets: DictionaryStatisticsSentenceUncollectedBucket[],
+    tokenCount: number
+) {
+    if (tokenCount <= 0) return;
+    return tokenCount === 1 ? sentenceBuckets[0] : sentenceBuckets[1];
+}
+
+function unknownSentenceBucketForCount(
+    sentenceBuckets: DictionaryStatisticsSentenceUnknownBucket[],
     tokenCount: number
 ) {
     if (tokenCount <= 0) return;
@@ -458,6 +490,7 @@ function evaluateSentenceSnapshot(
     let numUncollectedTokens = 0;
     const consideredTokenKeys: string[] = [];
     const uncollectedTokenKeys: string[] = [];
+    const unknownTokenKeys: string[] = [];
 
     for (const [tokenKey, token] of sentenceSnapshot.tokens.entries()) {
         if (token.ignored) continue;
@@ -475,6 +508,7 @@ function evaluateSentenceSnapshot(
         }
         if (status === TokenStatus.UNKNOWN) {
             numUnknownTokens += 1;
+            unknownTokenKeys.push(tokenKey);
             continue;
         }
         if (status === TokenStatus.UNCOLLECTED) {
@@ -492,6 +526,7 @@ function evaluateSentenceSnapshot(
         statusCounts,
         consideredTokenKeys,
         uncollectedTokenKeys,
+        unknownTokenKeys,
     };
 }
 
@@ -585,12 +620,20 @@ function buildSentenceBucketData(
             sentenceBuckets.uncollected,
             sentenceSnapshot.numUncollectedTokens
         );
-        if (!uncollectedBucket) continue;
+        if (uncollectedBucket) {
+            uncollectedBucket.count += 1;
+            uncollectedBucket.entries.push(
+                sentenceBucketEntry(sentenceSnapshot, sentenceSnapshot.uncollectedTokenKeys, tokens)
+            );
 
-        uncollectedBucket.count += 1;
-        uncollectedBucket.entries.push(
-            sentenceBucketEntry(sentenceSnapshot, sentenceSnapshot.uncollectedTokenKeys, tokens)
-        );
+            continue;
+        }
+
+        const unknownBucket = unknownSentenceBucketForCount(sentenceBuckets.unknown, sentenceSnapshot.numUnknownTokens);
+        if (!unknownBucket) continue;
+
+        unknownBucket.count += 1;
+        unknownBucket.entries.push(sentenceBucketEntry(sentenceSnapshot, sentenceSnapshot.unknownTokenKeys, tokens));
     }
 
     return sentenceBuckets;
@@ -926,7 +969,7 @@ export function nextDictionaryStatisticsSentenceSortDirection(
     return { sort: current.sort, direction: nextDirection };
 }
 
-export function uncollectedSentenceBucketLabel(
+export function statusSentenceBucketLabel(
     bucket: DictionaryStatisticsSentenceUncollectedBucket,
     uncollectedLabel: string
 ) {
@@ -940,6 +983,7 @@ export function sentenceDialogBucketData(
     labels: {
         knownSentencesLabel: string;
         uncollectedLabel: string;
+        unknownLabel: string;
     }
 ) {
     if (bucket.kind === 'allKnown') {
@@ -948,11 +992,21 @@ export function sentenceDialogBucketData(
             entries: sentenceBuckets.allKnown.entries,
         };
     }
-    const uncollectedBucket = sentenceBuckets.uncollected[bucket.groupIndex];
-    if (!uncollectedBucket) return;
+
+    if (bucket.kind === 'uncollected') {
+        const uncollectedBucket = sentenceBuckets.uncollected[bucket.groupIndex];
+        if (!uncollectedBucket) return;
+        return {
+            label: statusSentenceBucketLabel(uncollectedBucket, labels.uncollectedLabel),
+            entries: uncollectedBucket.entries,
+        };
+    }
+
+    const unknownBucket = sentenceBuckets.unknown[bucket.groupIndex];
+    if (!unknownBucket) return;
     return {
-        label: uncollectedSentenceBucketLabel(uncollectedBucket, labels.uncollectedLabel),
-        entries: uncollectedBucket.entries,
+        label: statusSentenceBucketLabel(unknownBucket, labels.unknownLabel),
+        entries: unknownBucket.entries,
     };
 }
 


### PR DESCRIPTION
fixes #974

This adds a filtered view for `1 Unknown` and `2+ Unknown` for the sentence stats. These views will not contain any uncollected tokens.

Assisted-by: Copilot:GPT-5.4
- [x] I have read the [contribution guidelines](https://github.com/killergerbah/asbplayer/blob/main/CONTRIBUTING.md).