### PR TITLE
feat: restore last local file session with File System Access API

### DIFF
--- a/common/app/components/App.tsx
+++ b/common/app/components/App.tsx
@@ -51,6 +51,7 @@ import { useTranslation } from 'react-i18next';
 import { LocalizedError } from './localized-error';
 import { DisplaySubtitleModel } from './SubtitlePlayer';
 import { useCopyHistory } from '../hooks/use-copy-history';
+import { useFileSession } from '../hooks/use-file-session';
 import { useI18n } from '../hooks/use-i18n';
 import { useAppKeyBinder } from '../hooks/use-app-key-binder';
 import { useAnki } from '../hooks/use-anki';
@@ -60,6 +61,7 @@ import { useAppWebSocketClient } from '../hooks/use-app-web-socket-client';
 import { LoadSubtitlesCommand } from '../../web-socket-client';
 import { ExtensionBridgedCopyHistoryRepository } from '../services/extension-bridged-copy-history-repository';
 import { IndexedDBCopyHistoryRepository } from '../../copy-history';
+import { supportsFileSystemAccess, showFilePicker, requestPermissions, resolveFiles } from '../../file-system-access';
 import { isMobile } from 'react-device-detect';
 import { GlobalState } from '../../global-state';
 import mp3WorkerFactory from '../../audio-clip/mp3-encoder-worker.ts?worker';
@@ -75,9 +77,6 @@ import StatisticsOverlay, { StatisticsOverlayProps } from '../../components/Stat
 const latestExtensionVersion = '1.15.0';
 const extensionUrl =
     'https://chromewebstore.google.com/detail/asbplayer-language-learni/hkledmpjpaehamkiehglnbelcpdflcab';
-
-const INPUT_ACCEPT_FILE_EXTENSIONS =
-    '.srt,.ass,.vtt,.sup,.mp3,.m4a,.aac,.flac,.ogg,.wav,.opus,.mkv,.mp4,.avi,.m4v,.webm';
 
 const useContentStyles = makeStyles<Theme, ContentProps>((theme) => ({
     content: {
@@ -97,6 +96,67 @@ const useContentStyles = makeStyles<Theme, ContentProps>((theme) => ({
     }),
 }));
 
+const videoExtensions = ['.mkv', '.mp4', '.m4v', '.avi', '.webm'] as const;
+const audioExtensions = ['.mp3', '.m4a', '.aac', '.flac', '.ogg', '.wav', '.opus', '.m4b'] as const;
+const subtitleExtensions = [
+    '.srt',
+    '.ass',
+    '.vtt',
+    '.sup',
+    '.nfvtt',
+    '.ytxml',
+    '.ytsrv3',
+    '.dfxp',
+    '.ttml2',
+    '.bbjson',
+] as const;
+const inputAcceptFileExtensions = [...subtitleExtensions, ...audioExtensions, ...videoExtensions].join(',');
+
+const VIDEO_EXT_SET = new Set<string>(videoExtensions);
+const AUDIO_EXT_SET = new Set<string>(audioExtensions);
+const SUBTITLE_EXT_SET = new Set<string>(subtitleExtensions);
+
+const getExtension = (fileName: string) => {
+    const index = fileName.lastIndexOf('.');
+    return index === -1 ? '' : fileName.substring(index).toLowerCase();
+};
+
+async function extractDropFileHandles(items: DataTransferItemList): Promise<FileSystemFileHandle[] | undefined> {
+    const handlePromises: Promise<any>[] = [];
+
+    for (let i = 0; i < items.length; ++i) {
+        const item = items[i];
+        if (item.kind !== 'file') {
+            continue;
+        }
+
+        // Persist dropped handles only when the browser exposes getAsFileSystemHandle.
+        const getAsFileSystemHandle = (item as any).getAsFileSystemHandle as (() => Promise<any>) | undefined;
+        if (typeof getAsFileSystemHandle !== 'function') {
+            return undefined;
+        }
+
+        // Capture handle promises synchronously before DataTransfer gets cleared.
+        handlePromises.push(getAsFileSystemHandle.call(item));
+    }
+
+    const handles: FileSystemFileHandle[] = [];
+    for (const handlePromise of handlePromises) {
+        try {
+            const handle = await handlePromise;
+            if (handle?.kind === 'file') {
+                handles.push(handle as FileSystemFileHandle);
+            }
+        } catch (e) {
+            // Best-effort only; if handle access fails, keep loading dropped files normally.
+            console.warn('Failed to read dropped file handle:', e);
+            return undefined;
+        }
+    }
+
+    return handles.length > 0 ? handles : undefined;
+}
+
 function extractSources(files: FileList | File[]): MediaSources {
     let subtitleFiles: File[] = [];
     let audioFile: File | undefined = undefined;
@@ -104,51 +164,28 @@ function extractSources(files: FileList | File[]): MediaSources {
 
     for (let i = 0; i < files.length; ++i) {
         const f = files[i];
-        const extensionStartIndex = f.name.lastIndexOf('.');
+        const extension = getExtension(f.name);
 
-        if (extensionStartIndex === -1) {
+        if (extension === '') {
             throw new LocalizedError('error.unknownExtension', { fileName: f.name });
         }
 
-        const extension = f.name.substring(extensionStartIndex + 1, f.name.length);
-        switch (extension) {
-            case 'ass':
-            case 'srt':
-            case 'vtt':
-            case 'nfvtt':
-            case 'sup':
-            case 'ytxml':
-            case 'ytsrv3':
-            case 'dfxp':
-            case 'ttml2':
-            case 'bbjson':
-                subtitleFiles.push(f);
-                break;
-            case 'mkv':
-            case 'mp4':
-            case 'm4v':
-            case 'avi':
-            case 'webm':
-                if (videoFile) {
-                    throw new LocalizedError('error.onlyOneVideoFile');
-                }
-                videoFile = f;
-                break;
-            case 'mp3':
-            case 'm4a':
-            case 'aac':
-            case 'flac':
-            case 'ogg':
-            case 'wav':
-            case 'opus':
-            case 'm4b':
-                if (videoFile) {
-                    throw new LocalizedError('error.onlyOneAudioFile');
-                }
-                videoFile = f;
-                break;
-            default:
-                throw new LocalizedError('error.unsupportedExtension', { extension });
+        if (SUBTITLE_EXT_SET.has(extension)) {
+            subtitleFiles.push(f);
+        } else if (VIDEO_EXT_SET.has(extension)) {
+            if (videoFile) {
+                throw new LocalizedError('error.onlyOneVideoFile');
+            }
+            videoFile = f;
+        } else if (AUDIO_EXT_SET.has(extension)) {
+            if (videoFile) {
+                throw new LocalizedError('error.onlyOneAudioFile');
+            }
+            videoFile = f;
+        } else {
+            throw new LocalizedError('error.unsupportedExtension', {
+                extension: extension.startsWith('.') ? extension.substring(1) : extension,
+            });
         }
     }
 
@@ -350,6 +387,7 @@ function App({
     const [isSidePanelOpen, setIsSidePanelOpen] = useState<boolean>(false);
     const [statisticsOverlayOpen, setStatisticsOverlayOpen] = useState<boolean>(false);
     const [statisticsOverlayDismissed, setStatisticsOverlayDismissed] = useState<boolean>(false);
+    const { canRestoreLastSession, saveSession: saveFileSession, fetchSession, clearSession } = useFileSession();
     const [lastError, setLastError] = useState<any>();
     const fileInputRef = useRef<HTMLInputElement>(null);
     const { subtitleFiles } = sources;
@@ -877,13 +915,12 @@ function App({
 
         return extension.subscribeTabs(onTabs);
     }, [availableTabs, tab, extension, handleError, t]);
-
     const handleTabSelected = useCallback((tab: VideoTabModel) => {
         setTab(tab);
     }, []);
 
     const handleFiles = useCallback(
-        ({ files, flattenSubtitleFiles }: { files: FileList | File[]; flattenSubtitleFiles?: boolean }) => {
+        ({ files, flattenSubtitleFiles }: { files: FileList | File[]; flattenSubtitleFiles?: boolean }): boolean => {
             try {
                 let { subtitleFiles, videoFile } = extractSources(files);
 
@@ -937,13 +974,74 @@ function App({
                     const subtitleFileName = subtitleFiles[0].name;
                     setFileName(subtitleFileName.substring(0, subtitleFileName.lastIndexOf('.')));
                 }
+                return true;
             } catch (e) {
                 console.error(e);
                 handleError(e);
+                return false;
             }
         },
         [handleError]
     );
+
+    const persistFileSessionHandles = useCallback(
+        (handles: FileSystemFileHandle[] | undefined) => {
+            if (!handles || handles.length === 0) {
+                return;
+            }
+
+            let videoHandle: FileSystemFileHandle | undefined;
+            const subtitleHandles: FileSystemFileHandle[] = [];
+            for (const handle of handles) {
+                const extension = getExtension(handle.name);
+                if (VIDEO_EXT_SET.has(extension) || AUDIO_EXT_SET.has(extension)) {
+                    videoHandle = handle;
+                } else if (SUBTITLE_EXT_SET.has(extension)) {
+                    subtitleHandles.push(handle);
+                }
+            }
+
+            if (!videoHandle && subtitleHandles.length === 0) {
+                return;
+            }
+
+            // Persist in background so session saving never blocks current file loading.
+            void saveFileSession({ videoHandle, subtitleHandles }).catch((e) => {
+                console.error('Failed to save file session:', e);
+                handleError(e);
+            });
+        },
+        [handleError, saveFileSession]
+    );
+
+    const handleRestoreLastSession = useCallback(async () => {
+        try {
+            const record = await fetchSession();
+            if (!record) return;
+
+            const allHandles = [...(record.videoHandle ? [record.videoHandle] : []), ...record.subtitleHandles];
+
+            const { granted, denied } = await requestPermissions(allHandles);
+            if (denied.length > 0) {
+                handleError(t('error.restoreSessionPermissionDenied'));
+                return;
+            }
+
+            const { files, errors } = await resolveFiles(granted);
+            if (errors.length > 0) {
+                handleError(t('error.restoreSessionFailed'));
+                await clearSession();
+                return;
+            }
+
+            if (!handleFiles({ files })) {
+                await clearSession();
+            }
+        } catch (e) {
+            console.error('Failed to restore last session:', e);
+            handleError(e);
+        }
+    }, [fetchSession, clearSession, handleFiles, handleError, t]);
 
     const handleDirectory = useCallback(
         async (items: DataTransferItemList) => {
@@ -1194,6 +1292,7 @@ function App({
 
             setDragging(false);
             dragEnterRef.current = null;
+            const dataTransfer = e.dataTransfer;
 
             function allDirectories(items: DataTransferItemList) {
                 for (let i = 0; i < items.length; ++i) {
@@ -1205,13 +1304,25 @@ function App({
                 return true;
             }
 
-            if (e.dataTransfer.items && e.dataTransfer.items.length > 0 && allDirectories(e.dataTransfer.items)) {
-                handleDirectory(e.dataTransfer.items);
-            } else if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-                handleFiles({ files: e.dataTransfer.files });
+            if (dataTransfer.items && dataTransfer.items.length > 0 && allDirectories(dataTransfer.items)) {
+                handleDirectory(dataTransfer.items);
+            } else if (dataTransfer.files && dataTransfer.files.length > 0) {
+                // Copy files synchronously; DataTransfer may be cleared after this handler returns.
+                const droppedFiles = Array.from(dataTransfer.files);
+                if (!handleFiles({ files: droppedFiles })) {
+                    return;
+                }
+
+                if (dataTransfer.items && dataTransfer.items.length > 0) {
+                    void extractDropFileHandles(dataTransfer.items)
+                        .then((fileHandles) => persistFileSessionHandles(fileHandles))
+                        .catch((e) => {
+                            console.warn('Failed to collect dropped file handles:', e);
+                        });
+                }
             }
         },
-        [inVideoPlayer, handleError, handleFiles, handleDirectory, ankiDialogOpen, t]
+        [inVideoPlayer, handleError, handleFiles, handleDirectory, ankiDialogOpen, t, persistFileSessionHandles]
     );
 
     const handleFileInputChange = useCallback(() => {
@@ -1223,7 +1334,28 @@ function App({
         }
     }, [handleFiles]);
 
-    const handleFileSelector = useCallback(() => fileInputRef.current?.click(), []);
+    const handleFileSelector = useCallback(async () => {
+        if (supportsFileSystemAccess()) {
+            try {
+                const handles = await showFilePicker({
+                    videoExtensions: [...videoExtensions],
+                    audioExtensions: [...audioExtensions],
+                    subtitleExtensions: [...subtitleExtensions],
+                });
+                if (!handles || handles.length === 0) return;
+                const { files } = await resolveFiles(handles);
+                if (files.length === 0) return;
+                if (handleFiles({ files })) {
+                    persistFileSessionHandles(handles);
+                }
+            } catch (e) {
+                console.error('Failed to pick files via File System Access API:', e);
+                handleError(e);
+            }
+        } else {
+            fileInputRef.current?.click();
+        }
+    }, [handleFiles, handleError, persistFileSessionHandles]);
 
     const handleVideoElementSelected = useCallback(
         async (videoElement: VideoTabModel) => {
@@ -1572,7 +1704,7 @@ function App({
                                 ref={fileInputRef}
                                 onChange={handleFileInputChange}
                                 type="file"
-                                accept={INPUT_ACCEPT_FILE_EXTENSIONS}
+                                accept={inputAcceptFileExtensions}
                                 multiple
                                 hidden
                             />
@@ -1587,8 +1719,10 @@ function App({
                                             dragging={dragging}
                                             appBarHidden={appBarHidden}
                                             videoElements={availableTabs ?? []}
+                                            canRestoreLastSession={canRestoreLastSession}
                                             onFileSelector={handleFileSelector}
                                             onVideoElementSelected={handleVideoElementSelected}
+                                            onRestoreLastSession={handleRestoreLastSession}
                                         />
                                     )}
                                     <DragOverlay

--- a/common/app/components/LandingPage.tsx
+++ b/common/app/components/LandingPage.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { makeStyles } from '@mui/styles';
 import gt from 'semver/functions/gt';
 import Fade from '@mui/material/Fade';
 import Paper from '@mui/material/Paper';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
 import ChromeExtension from '../services/chrome-extension';
 import { type Theme } from '@mui/material';
 import { useAppBarHeight } from '../../hooks/use-app-bar-height';
@@ -33,12 +34,15 @@ const useStyles = makeStyles<Theme, StylesProps>((theme) => ({
     browseLink: {
         cursor: 'pointer',
     },
-    videoElementSelectorContainer: {
+    actionsContainer: {
         position: 'absolute',
         bottom: 0,
         left: 0,
         padding: theme.spacing(2),
         width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing(1),
     },
 }));
 
@@ -50,10 +54,12 @@ interface Props {
     dragging: boolean;
     appBarHidden: boolean;
     videoElements: VideoTabModel[];
+    canRestoreLastSession: boolean;
     onFileSelector: React.MouseEventHandler<HTMLAnchorElement> &
         React.MouseEventHandler<HTMLSpanElement> &
         React.MouseEventHandler<HTMLLabelElement>;
     onVideoElementSelected: (videoElement: VideoTabModel) => void;
+    onRestoreLastSession: () => void;
 }
 
 export default function LandingPage({
@@ -64,9 +70,12 @@ export default function LandingPage({
     dragging,
     appBarHidden,
     videoElements,
+    canRestoreLastSession,
     onFileSelector,
     onVideoElementSelected,
+    onRestoreLastSession,
 }: Props) {
+    const { t } = useTranslation();
     const appBarHeight = useAppBarHeight();
     const classes = useStyles({ appBarHidden, appBarHeight });
     const extensionUpdateAvailable = extension.version && gt(latestExtensionVersion, extension.version);
@@ -108,12 +117,20 @@ export default function LandingPage({
                             </Trans>
                         )}
                     </Typography>
-                    {extension.supportsLandingPageStreamingVideoElementSelector && videoElements.length > 0 && (
-                        <div className={classes.videoElementSelectorContainer}>
-                            <VideoElementSelector
-                                videoElements={videoElements}
-                                onVideoElementSelected={onVideoElementSelected}
-                            />
+                    {(canRestoreLastSession ||
+                        (extension.supportsLandingPageStreamingVideoElementSelector && videoElements.length > 0)) && (
+                        <div className={classes.actionsContainer}>
+                            {canRestoreLastSession && (
+                                <Button variant="outlined" color="primary" onClick={onRestoreLastSession} fullWidth>
+                                    {t('landing.restoreLastSession')}
+                                </Button>
+                            )}
+                            {extension.supportsLandingPageStreamingVideoElementSelector && videoElements.length > 0 && (
+                                <VideoElementSelector
+                                    videoElements={videoElements}
+                                    onVideoElementSelected={onVideoElementSelected}
+                                />
+                            )}
                         </div>
                     )}
                 </div>

--- a/common/app/hooks/use-file-session.ts
+++ b/common/app/hooks/use-file-session.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from 'react';
+import { IndexedDBFileSessionRepository, supportsFileSystemAccess } from '../../file-system-access';
+
+let _repository: IndexedDBFileSessionRepository | undefined;
+const getRepository = () => {
+    if (_repository === undefined && supportsFileSystemAccess()) {
+        _repository = new IndexedDBFileSessionRepository();
+    }
+    return _repository;
+};
+
+export const useFileSession = () => {
+    const fileSessionRepository = getRepository();
+    const [canRestoreLastSession, setCanRestoreLastSession] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (!fileSessionRepository) return;
+        fileSessionRepository.fetch().then((record) => {
+            if (record && (record.videoHandle || record.subtitleHandles.length > 0)) {
+                setCanRestoreLastSession(true);
+            }
+        });
+    }, [fileSessionRepository]);
+
+    const saveSession = useCallback(
+        async ({
+            videoHandle,
+            subtitleHandles,
+        }: {
+            videoHandle?: FileSystemFileHandle;
+            subtitleHandles: FileSystemFileHandle[];
+        }) => {
+            if (!fileSessionRepository) return;
+
+            if (!videoHandle && subtitleHandles.length === 0) {
+                return;
+            }
+
+            await fileSessionRepository.merge({ videoHandle, subtitleHandles });
+            setCanRestoreLastSession(true);
+        },
+        [fileSessionRepository]
+    );
+
+    const fetchSession = useCallback(() => fileSessionRepository?.fetch(), [fileSessionRepository]);
+
+    const clearSession = useCallback(async () => {
+        await fileSessionRepository?.clear();
+        setCanRestoreLastSession(false);
+    }, [fileSessionRepository]);
+
+    return {
+        canRestoreLastSession,
+        saveSession,
+        fetchSession,
+        clearSession,
+    };
+};

--- a/common/file-system-access/file-system-access-repository.ts
+++ b/common/file-system-access/file-system-access-repository.ts
@@ -1,0 +1,52 @@
+import Dexie from 'dexie';
+
+export interface FileSessionRecord {
+    id: number;
+    videoHandle?: FileSystemFileHandle;
+    subtitleHandles: FileSystemFileHandle[];
+    timestamp: number;
+}
+
+class FileSessionDatabase extends Dexie {
+    sessions!: Dexie.Table<FileSessionRecord, number>;
+
+    constructor() {
+        super('FileSessionDatabase');
+        this.version(1).stores({
+            sessions: '++id,timestamp',
+        });
+    }
+}
+
+export interface FileSessionRepository {
+    fetch: () => Promise<FileSessionRecord | undefined>;
+    /** Merge new handles into the existing record, mirroring handleFiles' source-merge logic. */
+    merge: (incoming: Omit<FileSessionRecord, 'id' | 'timestamp'>) => Promise<void>;
+    clear: () => Promise<void>;
+}
+
+export class IndexedDBFileSessionRepository implements FileSessionRepository {
+    private readonly _db = new FileSessionDatabase();
+
+    async fetch(): Promise<FileSessionRecord | undefined> {
+        const records = await this._db.sessions.orderBy('timestamp').reverse().limit(1).toArray();
+        return records.length > 0 ? records[0] : undefined;
+    }
+
+    async merge(incoming: Omit<FileSessionRecord, 'id' | 'timestamp'>): Promise<void> {
+        const existing = await this.fetch();
+        // Keep previous handles when user picks only one side (e.g. subtitles without re-selecting video),
+        // so the saved session still represents the latest complete set.
+        const merged: Omit<FileSessionRecord, 'id' | 'timestamp'> = {
+            videoHandle: incoming.videoHandle ?? existing?.videoHandle,
+            subtitleHandles:
+                incoming.subtitleHandles.length > 0 ? incoming.subtitleHandles : (existing?.subtitleHandles ?? []),
+        };
+        await this._db.sessions.clear();
+        await this._db.sessions.add({ ...merged, id: 1, timestamp: Date.now() });
+    }
+
+    async clear(): Promise<void> {
+        await this._db.sessions.clear();
+    }
+}

--- a/common/file-system-access/file-system-access.ts
+++ b/common/file-system-access/file-system-access.ts
@@ -1,0 +1,90 @@
+/**
+ * File System Access API helpers (Chrome-only).
+ * Provides showOpenFilePicker-based file selection that returns FileSystemFileHandle objects,
+ * and utilities to re-acquire permissions and resolve handles back to File objects on revisit.
+ */
+
+export function supportsFileSystemAccess(): boolean {
+    return typeof window !== 'undefined' && 'showOpenFilePicker' in window;
+}
+
+export async function requestPermissions(
+    handles: FileSystemFileHandle[]
+): Promise<{ granted: FileSystemFileHandle[]; denied: FileSystemFileHandle[] }> {
+    const granted: FileSystemFileHandle[] = [];
+    const denied: FileSystemFileHandle[] = [];
+
+    for (const handle of handles) {
+        try {
+            const state = await (handle as any).queryPermission?.({ mode: 'read' });
+            if (state === 'granted') {
+                granted.push(handle);
+                continue;
+            }
+        } catch {
+            // queryPermission not supported, fall through to requestPermission
+        }
+
+        try {
+            const state = await (handle as any).requestPermission?.({ mode: 'read' });
+            if (state === 'granted') {
+                granted.push(handle);
+            } else {
+                denied.push(handle);
+            }
+        } catch {
+            denied.push(handle);
+        }
+    }
+
+    return { granted, denied };
+}
+
+export async function resolveFiles(
+    handles: FileSystemFileHandle[]
+): Promise<{ files: File[]; errors: FileSystemFileHandle[] }> {
+    const files: File[] = [];
+    const errors: FileSystemFileHandle[] = [];
+
+    for (const handle of handles) {
+        try {
+            files.push(await handle.getFile());
+        } catch {
+            errors.push(handle);
+        }
+    }
+
+    return { files, errors };
+}
+
+export async function showFilePicker(extensions: {
+    videoExtensions: string[];
+    audioExtensions: string[];
+    subtitleExtensions: string[];
+}): Promise<FileSystemFileHandle[] | undefined> {
+    if (!supportsFileSystemAccess()) {
+        return undefined;
+    }
+
+    try {
+        const handles = await (window as any).showOpenFilePicker({
+            multiple: true,
+            types: [
+                {
+                    description: 'Media and subtitle files',
+                    accept: {
+                        'video/*': extensions.videoExtensions,
+                        'audio/*': extensions.audioExtensions,
+                        'text/*': extensions.subtitleExtensions,
+                    },
+                },
+            ],
+        });
+        return handles as FileSystemFileHandle[];
+    } catch (e: any) {
+        if (e.name === 'AbortError') {
+            return undefined;
+        }
+        throw e;
+    }
+}

--- a/common/file-system-access/index.ts
+++ b/common/file-system-access/index.ts
@@ -1,0 +1,2 @@
+export * from './file-system-access-repository';
+export * from './file-system-access';

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "Subtitle file {{fileName}} is not open.",
         "unknownExtension": "Dateityp von {{fileName}} konnte nicht erkannt werden",
         "unsupportedExtension": "Nicht unterstützter Dateityp {{extension}}",
-        "videoPlayerDragAndDropNotAllowed": "Video player cannot receive dropped files. Drop outside of the video frame instead."
+        "videoPlayerDragAndDropNotAllowed": "Video player cannot receive dropped files. Drop outside of the video frame instead.",
+        "restoreSessionPermissionDenied": "Berechtigung verweigert. Letzte Sitzung kann nicht wiederhergestellt werden.",
+        "restoreSessionFailed": "Die letzte Sitzung konnte nicht wiederhergestellt werden. Die Dateien wurden möglicherweise verschoben oder gelöscht."
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "Ein <1>Update</1> ist verfügbar",
         "noSubtitles": "No subtitles",
         "videoElementsDetected": "Load subtitles onto a video to start using asbplayer.",
-        "noVideoElementsDetected": "No videos detected."
+        "noVideoElementsDetected": "No videos detected.",
+        "restoreLastSession": "Letzte Sitzung wiederherstellen"
     },
     "activeTabPermissionRequest": {
         "title": "Enable audio recording",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "Subtitle file {{fileName}} is not open.",
         "unknownExtension": "Unable to determine extension of {{fileName}}",
         "unsupportedExtension": "Unsupported extension {{extension}}",
-        "videoPlayerDragAndDropNotAllowed": "Video player cannot receive dropped files. Drop outside of the video frame instead."
+        "videoPlayerDragAndDropNotAllowed": "Video player cannot receive dropped files. Drop outside of the video frame instead.",
+        "restoreSessionPermissionDenied": "Permission denied. Unable to restore last session.",
+        "restoreSessionFailed": "Failed to restore last session. The files may have been moved or deleted."
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "An extension <1>update</1> is available.",
         "noSubtitles": "No subtitles",
         "videoElementsDetected": "Load subtitles onto a video to start using asbplayer.",
-        "noVideoElementsDetected": "No videos detected."
+        "noVideoElementsDetected": "No videos detected.",
+        "restoreLastSession": "Restore last session"
     },
     "activeTabPermissionRequest": {
         "title": "Enable audio recording",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "La pista de subtítulos {{fileName}} no está abierta",
         "unknownExtension": "No pudo determinarse la extensión de {{fileName}}",
         "unsupportedExtension": "Extensión no soportada {{extension}}",
-        "videoPlayerDragAndDropNotAllowed": "El reproductor de video no puede recibir archivos. Arrástralos fuera del cuadro de video."
+        "videoPlayerDragAndDropNotAllowed": "El reproductor de video no puede recibir archivos. Arrástralos fuera del cuadro de video.",
+        "restoreSessionPermissionDenied": "Permiso denegado. No se puede restaurar la última sesión.",
+        "restoreSessionFailed": "No se pudo restaurar la última sesión. Es posible que los archivos se hayan movido o eliminado."
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "Hay una <1>actualización</1> disponible para la extensión.",
         "noSubtitles": "No hay subtítulos",
         "videoElementsDetected": "Carga subtítulos a un video para comenzar a usar asbplayer",
-        "noVideoElementsDetected": "No se detectaron videos"
+        "noVideoElementsDetected": "No se detectaron videos",
+        "restoreLastSession": "Restaurar última sesión"
     },
     "activeTabPermissionRequest": {
         "title": "Habilitar grabación de audio",

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "Tekstitystiedosto {{fileName}} ei ole auki.",
         "unknownExtension": "{{fileName}} laajennusta ei voitu määrittää",
         "unsupportedExtension": "Tiedostoa ei tueta {{extension}}",
-        "videoPlayerDragAndDropNotAllowed": "Videosoitinta ei voi vastaanottaa pudotettuja tiedostoja. Pudota sen sijaan videoruudun ulkopuolelle."
+        "videoPlayerDragAndDropNotAllowed": "Videosoitinta ei voi vastaanottaa pudotettuja tiedostoja. Pudota sen sijaan videoruudun ulkopuolelle.",
+        "restoreSessionPermissionDenied": "Käyttöoikeus evätty. Viimeisintä istuntoa ei voitu palauttaa.",
+        "restoreSessionFailed": "Viimeisintä istuntoa ei voitu palauttaa. Tiedostot on ehkä siirretty tai poistettu."
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "Laajennus <1>päivitys</1> on saatavilla.",
         "noSubtitles": "Ei tekstityksiä",
         "videoElementsDetected": "Lataa tekstitys videon päälle aloittaaksesi asbplayerin käytön.",
-        "noVideoElementsDetected": "Ei havaittuja videoita."
+        "noVideoElementsDetected": "Ei havaittuja videoita.",
+        "restoreLastSession": "Palauta viimeisin istunto"
     },
     "activeTabPermissionRequest": {
         "title": "Ota äänentallennus käyttöön",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "Le fichier de sous-titres \"{{fileName}}\" n’est pas ouvert.",
         "unknownExtension": "Impossible de déterminer l’extension de \"{{fileName}} \"",
         "unsupportedExtension": "Extension \"{{extension}}\" non prise en charge.",
-        "videoPlayerDragAndDropNotAllowed": "Le lecteur vidéo ne peut pas recevoir de fichiers glissés. Déposez-les en dehors de la zone de la vidéo."
+        "videoPlayerDragAndDropNotAllowed": "Le lecteur vidéo ne peut pas recevoir de fichiers glissés. Déposez-les en dehors de la zone de la vidéo.",
+        "restoreSessionPermissionDenied": "Autorisation refusée. Impossible de restaurer la dernière session.",
+        "restoreSessionFailed": "Impossible de restaurer la dernière session. Les fichiers ont peut-être été déplacés ou supprimés."
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "Une <1>mise à jour</1> de l’extension est disponible.",
         "noSubtitles": "Pas de sous-titres",
         "videoElementsDetected": "Chargez des sous-titres sur une vidéo pour commencer à utiliser asbplayer.",
-        "noVideoElementsDetected": "Aucune vidéo détectée."
+        "noVideoElementsDetected": "Aucune vidéo détectée.",
+        "restoreLastSession": "Restaurer la dernière session"
     },
     "activeTabPermissionRequest": {
         "title": "Activer l'enregistrement audio",

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "Berkas takarir {{fileName}} belum dibuka.",
         "unknownExtension": "Tidak dapat mengenali ekstensi {{fileName}}",
         "unsupportedExtension": "Ekstensi {{extension}} tidak didukung",
-        "videoPlayerDragAndDropNotAllowed": "Pemutar video tidak dapat menerima berkas yang dijatuhkan langsung. Letakkan di luar bingkai video."
+        "videoPlayerDragAndDropNotAllowed": "Pemutar video tidak dapat menerima berkas yang dijatuhkan langsung. Letakkan di luar bingkai video.",
+        "restoreSessionPermissionDenied": "Izin ditolak. Tidak dapat memulihkan sesi terakhir.",
+        "restoreSessionFailed": "Gagal memulihkan sesi terakhir. File mungkin telah dipindahkan atau dihapus."
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "Tersedia <1>pembaruan</1> untuk ekstensi.",
         "noSubtitles": "Tidak ada takarir",
         "videoElementsDetected": "Muat takarir ke dalam video untuk mulai menggunakan asbplayer.",
-        "noVideoElementsDetected": "Tidak ada video yang terdeteksi."
+        "noVideoElementsDetected": "Tidak ada video yang terdeteksi.",
+        "restoreLastSession": "Pulihkan sesi terakhir"
     },
     "activeTabPermissionRequest": {
         "title": "Aktifkan perekaman audio",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "字幕ファイル「{{fileName}} 」が開いていません",
         "unknownExtension": "{{fileName}}の拡張子を確認できません",
         "unsupportedExtension": "対応していない拡張子です：{{extension}}",
-        "videoPlayerDragAndDropNotAllowed": "動画プレイヤーはドロップしたファイルを受け取れません。動画のフレーム外にファイルをドロップしてください。"
+        "videoPlayerDragAndDropNotAllowed": "動画プレイヤーはドロップしたファイルを受け取れません。動画のフレーム外にファイルをドロップしてください。",
+        "restoreSessionPermissionDenied": "権限が拒否されました。前回のセッションを復元できません。",
+        "restoreSessionFailed": "前回のセッションを復元できませんでした。ファイルが移動または削除された可能性があります。"
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "拡張機能の<1>アップデート</1>を公開しました。",
         "noSubtitles": "字幕はありません",
         "videoElementsDetected": "asbplayer を使用するには字幕をロードしてください。",
-        "noVideoElementsDetected": "動画を探知できませんでした。"
+        "noVideoElementsDetected": "動画を探知できませんでした。",
+        "restoreLastSession": "前回のセッションを復元"
     },
     "activeTabPermissionRequest": {
         "title": "音声記録を有効にしてください",

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "자막 파일 {{fileName}}이(가) 열려 있지 않습니다.",
         "unknownExtension": "{{fileName}}의 확장자를 확인할 수 없습니다.",
         "unsupportedExtension": "{{extension}} 확장자는 지원되지 않습니다.",
-        "videoPlayerDragAndDropNotAllowed": "동영상 프레임에는 파일을 드롭할 수 없습니다. 화면 밖 영역에 드롭해 주세요."
+        "videoPlayerDragAndDropNotAllowed": "동영상 프레임에는 파일을 드롭할 수 없습니다. 화면 밖 영역에 드롭해 주세요.",
+        "restoreSessionPermissionDenied": "권한이 거부되어 마지막 세션을 복원할 수 없습니다.",
+        "restoreSessionFailed": "마지막 세션을 복원하지 못했습니다. 파일이 이동되었거나 삭제되었을 수 있습니다."
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "새로운  <1>확장 프로그램 업데이트</1>가 있습니다.",
         "noSubtitles": "자막 없음",
         "videoElementsDetected": "asbplayer를 시작하려면 영상에 자막을 추가하세요.",
-        "noVideoElementsDetected": "감지된 영상이 없음"
+        "noVideoElementsDetected": "감지된 영상이 없음",
+        "restoreLastSession": "마지막 세션 복원"
     },
     "activeTabPermissionRequest": {
         "title": "오디오 녹음 활성화",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "Plik napisów {{fileName}} nie jest otwarty.",
         "unknownExtension": "Nie można rozpoznać rozszerzenia {{fileName}}",
         "unsupportedExtension": "Niewspierane rozszerzenie {{extension}}",
-        "videoPlayerDragAndDropNotAllowed": "Odtwarzacz wideo nie może przyjąć upuszczonych plików. Zamiast tego upuść poza ramką wideo."
+        "videoPlayerDragAndDropNotAllowed": "Odtwarzacz wideo nie może przyjąć upuszczonych plików. Zamiast tego upuść poza ramką wideo.",
+        "restoreSessionPermissionDenied": "Odmowa uprawnień. Nie można przywrócić ostatniej sesji.",
+        "restoreSessionFailed": "Nie udało się przywrócić ostatniej sesji. Pliki mogły zostać przeniesione lub usunięte."
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "Dostępna jest <1>aktualizacja</1> rozszerzenia.",
         "noSubtitles": "Brak napisów",
         "videoElementsDetected": "Załaduj napisy, aby rozpocząć korzystanie z asbplayera.",
-        "noVideoElementsDetected": "Nie wykryto żadnego wideo."
+        "noVideoElementsDetected": "Nie wykryto żadnego wideo.",
+        "restoreLastSession": "Przywróć ostatnią sesję"
     },
     "activeTabPermissionRequest": {
         "title": "Aktywuj nagrywanie audio",

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "Arquivo de legenda {{fileName}} não está aberto.",
         "unknownExtension": "Não é possível determinar a extensão de {{fileName}}",
         "unsupportedExtension": "Extensão não suportada: {{extension}}",
-        "videoPlayerDragAndDropNotAllowed": "O player de vídeo não pode receber arquivos arrastados. Solte-os fora do quadro do vídeo."
+        "videoPlayerDragAndDropNotAllowed": "O player de vídeo não pode receber arquivos arrastados. Solte-os fora do quadro do vídeo.",
+        "restoreSessionPermissionDenied": "Permissão negada. Não foi possível restaurar a última sessão.",
+        "restoreSessionFailed": "Não foi possível restaurar a última sessão. Os arquivos podem ter sido movidos ou excluídos."
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "Uma <1>atualização</1>  para a extensão está disponível.",
         "noSubtitles": "Sem legendas",
         "videoElementsDetected": "Carregar legendas em um vídeo para começar a usar o asbplayer.",
-        "noVideoElementsDetected": "Nenhum vídeo detectado."
+        "noVideoElementsDetected": "Nenhum vídeo detectado.",
+        "restoreLastSession": "Restaurar última sessão"
     },
     "activeTabPermissionRequest": {
         "title": "Habilitar gravação de áudio.",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "Файл субтитров {{fileName}} не открыт.",
         "unknownExtension": "Невозможно определить расширение файла {{fileName}}",
         "unsupportedExtension": "Неподдерживаемое расширение: {{extension}}",
-        "videoPlayerDragAndDropNotAllowed": "Нельзя перетаскивать файлы в сам видеоплеер. Перетащите и отпустите их вне рамки видео."
+        "videoPlayerDragAndDropNotAllowed": "Нельзя перетаскивать файлы в сам видеоплеер. Перетащите и отпустите их вне рамки видео.",
+        "restoreSessionPermissionDenied": "Доступ запрещён. Не удалось восстановить последнюю сессию.",
+        "restoreSessionFailed": "Не удалось восстановить последнюю сессию. Возможно, файлы были перемещены или удалены."
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "Доступно <1>обновление</1> для расширения.",
         "noSubtitles": "Субтитры отсутствуют",
         "videoElementsDetected": "Загрузите субтитры в видео, чтобы начать использовать asbplayer.",
-        "noVideoElementsDetected": "Видео не обнаружено."
+        "noVideoElementsDetected": "Видео не обнаружено.",
+        "restoreLastSession": "Восстановить последнюю сессию"
     },
     "activeTabPermissionRequest": {
         "title": "Разрешить запись аудио.",

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -200,7 +200,9 @@
         "subtitleFileNotOpen": "字幕文件 {{fileName}} 未打开。",
         "unknownExtension": "无法识别 {{fileName}} 的文件格式",
         "unsupportedExtension": "不支持该文件格式：{{extension}}",
-        "videoPlayerDragAndDropNotAllowed": "播放器无法接收拖放文件，请拖至视频画面外。"
+        "videoPlayerDragAndDropNotAllowed": "播放器无法接收拖放文件，请拖至视频画面外。",
+        "restoreSessionPermissionDenied": "权限被拒绝，无法恢复上次会话。",
+        "restoreSessionFailed": "恢复上次会话失败，文件可能已被移动或删除。"
     },
     "extension": {
         "settings": {
@@ -324,7 +326,8 @@
         "extensionUpdateAvailable": "发现新的 <1>扩展更新</1>。",
         "noSubtitles": "无字幕",
         "videoElementsDetected": "为视频加载字幕以开始使用。",
-        "noVideoElementsDetected": "未检测到视频元素。"
+        "noVideoElementsDetected": "未检测到视频元素。",
+        "restoreLastSession": "恢复上次会话"
     },
     "activeTabPermissionRequest": {
         "title": "开启录音权限",


### PR DESCRIPTION

## Summary

- Add a File System Access-based file loading path behind the existing `browse` entry to persist local `FileSystemFileHandle`s across reloads.
- Introduce an IndexedDB repository for a single latest file session record and merge partial selections (e.g., subtitles only) into that session.
- Add a landing-page action to restore the last session, including permission re-check and fallback error handling when files are moved or deleted.
- Normalize extension parsing to lowercase, centralize file input accept extensions in the new `file-system-access` module, and add missing localized copy for restore-related errors and actions.

Closes https://github.com/asbplayer/asbplayer/issues/975

## Implementation Notes

- New module `common/file-system-access` encapsulates:
  - capability detection (`supportsFileSystemAccess`)
  - picker invocation (`showFilePicker`)
  - permission flow (`requestPermissions`)
  - handle-to-file resolution (`resolveFiles`)
  - media/subtitle extension classification helpers
- `App` keeps the previous `<input type="file">` fallback for non-FSA environments.
- Session restoration is intentionally gated by explicit user action from the landing page, with a separate visibility check on mount (`canRestoreLastSession`).
- Repository initialization is done once per mount via lazy state initialization so identity is stable for effects/callbacks.

## Discussion Topics

1. **Why a new file loading path is necessary**
   - Standard `<input type="file">` and drag-and-drop can load files immediately, but they do not provide durable `FileSystemFileHandle`s.
   - Without handles, there is nothing to persist across reloads. Only the File System Access API (plus IndexedDB for handle serialization) makes one-click local session restoration possible.
   - This is the core reason we introduce a new loading path rather than extending the existing input flow.

2. **Extension classification moved to `file-system-access`**
   - The previous `INPUT_ACCEPT_FILE_EXTENSIONS` constant and the extension-to-type mapping were hard-coded in `App.tsx`.
   - With the addition of FSA-specific picker types, the extensions are now centralized in `common/file-system-access/file-system-access.ts`.
   - This means `App.tsx` imports `inputAcceptFileExtensions` rather than defining its own list. If we expect these lists to diverge (e.g., picker types vs. `<input accept>`), we may want to split them again.

3. **Restore action placement / UX weight**
   - Current placement is in the lower action area as an outlined button as suggested in https://github.com/asbplayer/asbplayer/issues/975#issuecomment-4348157600.
   - Alternative: move this trigger closer to the main CTA text (`Drag and drop... or browse`) and make it a lighter inline link-style action for reduced visual weight.


4. **`handleFileSelector` is now async / event handler returns `Promise<void>`**
   - `handleFileSelector` was changed from `() => void` to `async () => Promise<void>` to support the FSA picker flow.
   - React event handlers do not await async functions; if the component unmounts while the picker is open, a subsequent `setState` (e.g., `saveFileSession` → `setCanRestoreLastSession`) could warn about updates on an unmounted component.
   - Options: add an `isMounted` guard, move the async work into a `useEffect`-like pattern, or accept the low-probability warning given the current landing-page architecture.

## Optional Design Notes (For Deeper Review)

- **Merge design for partial selections**
  - `IndexedDBFileSessionRepository.merge` preserves the previous video handle when the user picks only subtitles, and vice versa, so the saved session always reflects the latest complete set.

- **Repository lifetime (`useState` lazy init vs. `useMemo`)**
  - The repository is created once per mount with lazy `useState` initialization instead of `useMemo`, making the one-per-mount lifecycle explicit and the reference stable for effects and callbacks.
