### PR TITLE
fix: search jimaku dramas entries alongside anime entries

### DIFF
--- a/common/global-state/index.ts
+++ b/common/global-state/index.ts
@@ -11,7 +11,7 @@ export enum AnnotationTutorialState {
 
 export interface OnlineSubtitleSourceConfig {
     jimakuApiKey: string;
-    jimakuSearchCategory: 'anime' | 'drama' | 'both';
+    jimakuSearchCategory: 'anime' | 'drama';
 }
 
 export const initialGlobalState: GlobalState = {
@@ -20,7 +20,7 @@ export const initialGlobalState: GlobalState = {
     ftueAnnotation: AnnotationTutorialState.hasNotSeen,
     onlineSubtitleSourceConfig: {
         jimakuApiKey: '',
-        jimakuSearchCategory: 'both',
+        jimakuSearchCategory: 'anime',
     },
 };
 

--- a/common/global-state/index.ts
+++ b/common/global-state/index.ts
@@ -11,6 +11,7 @@ export enum AnnotationTutorialState {
 
 export interface OnlineSubtitleSourceConfig {
     jimakuApiKey: string;
+    jimakuSearchCategory: 'anime' | 'drama' | 'both';
 }
 
 export const initialGlobalState: GlobalState = {
@@ -19,6 +20,7 @@ export const initialGlobalState: GlobalState = {
     ftueAnnotation: AnnotationTutorialState.hasNotSeen,
     onlineSubtitleSourceConfig: {
         jimakuApiKey: '',
+        jimakuSearchCategory: 'both',
     },
 };
 

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -669,6 +669,10 @@
         "entries": "Search results",
         "noEntries": "No search results",
         "availableFiles": "Files",
-        "noFiles": "No files"
+        "noFiles": "No files",
+        "searchCategory": "Search category",
+        "categoryAnime": "Anime",
+        "categoryDrama": "Drama",
+        "categoryBoth": "Both"
     }
 }

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -672,7 +672,6 @@
         "noFiles": "No files",
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
-        "categoryDrama": "Drama",
-        "categoryBoth": "Both"
+        "categoryDrama": "Drama"
     }
 }

--- a/extension/src/services/extension-global-state-provider.test.ts
+++ b/extension/src/services/extension-global-state-provider.test.ts
@@ -25,6 +25,7 @@ it('can retrieve all keys', async () => {
         ftueAnnotation: 0,
         onlineSubtitleSourceConfig: {
             jimakuApiKey: '',
+            jimakuSearchCategory: 'both',
         },
     });
 });

--- a/extension/src/services/extension-global-state-provider.test.ts
+++ b/extension/src/services/extension-global-state-provider.test.ts
@@ -25,7 +25,7 @@ it('can retrieve all keys', async () => {
         ftueAnnotation: 0,
         onlineSubtitleSourceConfig: {
             jimakuApiKey: '',
-            jimakuSearchCategory: 'both',
+            jimakuSearchCategory: 'anime',
         },
     });
 });

--- a/extension/src/services/subtitle-sources.test.ts
+++ b/extension/src/services/subtitle-sources.test.ts
@@ -57,6 +57,28 @@ describe('JimakuClient', () => {
         expect(response.rateLimit.resetAfterSeconds).toBe(1.5);
     });
 
+    it('searches entries with anime parameter', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(
+            createResponse({
+                jsonData: [{ id: 999, name: 'Some Drama', flags: 2 }],
+                headers: {
+                    'x-ratelimit-limit': '100',
+                    'x-ratelimit-remaining': '98',
+                    'x-ratelimit-reset-after': '1.0',
+                },
+            })
+        );
+        global.fetch = fetchMock as unknown as typeof fetch;
+        const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
+
+        const response = await client.searchEntries('Some Drama', false);
+
+        expect(fetchMock).toHaveBeenCalledWith('https://jimaku.cc/api/entries/search?query=Some+Drama&anime=false', {
+            headers: { Authorization: 'test-key' },
+        });
+        expect(response.data[0].name).toBe('Some Drama');
+    });
+
     it('requests files with optional filters', async () => {
         const fetchMock = jest.fn().mockResolvedValue(createResponse({ jsonData: [] }));
         global.fetch = fetchMock as unknown as typeof fetch;

--- a/extension/src/services/subtitle-sources.ts
+++ b/extension/src/services/subtitle-sources.ts
@@ -6,7 +6,7 @@ export interface JimakuEntry {
     english_name?: string;
     created_at?: string;
     last_updated_at?: string;
-    flags?: number;
+    anime?: boolean;
 }
 
 export interface JimakuFile {
@@ -137,9 +137,12 @@ export class JimakuClient {
         this._minRequestIntervalMs = minRequestIntervalMs;
     }
 
-    async searchEntries(query: string): Promise<JimakuResponse<JimakuEntry[]>> {
+    async searchEntries(query: string, anime?: boolean): Promise<JimakuResponse<JimakuEntry[]>> {
         const searchParams = new URLSearchParams();
         searchParams.set('query', query);
+        if (anime !== undefined) {
+            searchParams.set('anime', `${anime}`);
+        }
         return await this._request<JimakuEntry[]>(`entries/search?${searchParams.toString()}`);
     }
 

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -130,9 +130,23 @@ export default function OnlineSubtitleSourceDialog({
 
         try {
             const client = new JimakuClient({ apiKey: jimakuApiKey });
-            const entries = (await client.searchEntries(query)).data;
+            const [animeResult, dramaResult] = await Promise.all([
+                client.searchEntries(query),
+                client.searchEntries(query, false),
+            ]);
+
+            // Merge and deduplicate by entry id
+            const seen = new Set<number>();
+            const mergedEntries = [...animeResult.data, ...dramaResult.data].filter((entry) => {
+                if (seen.has(entry.id)) {
+                    return false;
+                }
+                seen.add(entry.id);
+                return true;
+            });
+
             setLastQuery(query);
-            setJimakuEntries(entries.map((entry) => ({ id: entry.id, name: entry.name })));
+            setJimakuEntries(mergedEntries.map((entry) => ({ id: entry.id, name: entry.name })));
             setJimakuSelectedEntry(undefined);
             setJimakuFiles(undefined);
         } catch (e) {

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -16,7 +16,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { JimakuClient, JimakuEntry } from '@/services/subtitle-sources';
 import IconButton from '@mui/material/IconButton';
@@ -103,6 +103,7 @@ export default function OnlineSubtitleSourceDialog({
     const [jimakuEntries, setJimakuEntries] = useState<{ id: number; name: string }[]>([]);
     const [jimakuSelectedEntry, setJimakuSelectedEntry] = useState<JimakuEntry>();
     const [jimakuFiles, setJimakuFiles] = useState<OnlineSubtitleImportCandidate[]>();
+    const resultsCache = useRef<Map<string, { anime: JimakuEntry[]; drama: JimakuEntry[] }>>(new Map());
 
     const normalizedDetectedTitleHint = useMemo(
         () => normalizeDetectedTitleHint(detectedTitleHint),
@@ -130,12 +131,39 @@ export default function OnlineSubtitleSourceDialog({
         }
     }, [open, normalizedDetectedTitleHint, resetState]);
 
+    useEffect(() => {
+        resultsCache.current.clear();
+    }, [query]);
+
+    const prevCategoryRef = useRef(jimakuSearchCategory);
+    useEffect(() => {
+        if (prevCategoryRef.current !== jimakuSearchCategory && lastQuery !== undefined) {
+            handleSearchJimaku();
+        }
+        prevCategoryRef.current = jimakuSearchCategory;
+    }, [jimakuSearchCategory]);
+
     const handleSearchJimaku = useCallback(async () => {
         setError(undefined);
         setSearching(true);
         setFilterString('');
 
         try {
+            const cacheKey = query.trim();
+            const cached = resultsCache.current.get(cacheKey);
+            if (cached) {
+                const cachedResult = jimakuSearchCategory === 'anime' ? cached.anime : cached.drama;
+                if (cachedResult.length > 0) {
+                    setLastQuery(query);
+                    setLastSearchCategory(jimakuSearchCategory);
+                    setJimakuEntries(cachedResult.map((entry) => ({ id: entry.id, name: entry.name })));
+                    setJimakuSelectedEntry(undefined);
+                    setJimakuFiles(undefined);
+                    setSearching(false);
+                    return;
+                }
+            }
+
             const client = new JimakuClient({ apiKey: jimakuApiKey });
             const result =
                 jimakuSearchCategory === 'anime'
@@ -145,6 +173,13 @@ export default function OnlineSubtitleSourceDialog({
             setLastQuery(query);
             setLastSearchCategory(jimakuSearchCategory);
             setJimakuEntries(result.data.map((entry) => ({ id: entry.id, name: entry.name })));
+            const cacheEntry = resultsCache.current.get(cacheKey) ?? { anime: [], drama: [] };
+            if (jimakuSearchCategory === 'anime') {
+                cacheEntry.anime = result.data;
+            } else {
+                cacheEntry.drama = result.data;
+            }
+            resultsCache.current.set(cacheKey, cacheEntry);
             setJimakuSelectedEntry(undefined);
             setJimakuFiles(undefined);
         } catch (e) {
@@ -252,6 +287,7 @@ export default function OnlineSubtitleSourceDialog({
                         exclusive
                         size="small"
                         fullWidth
+                        sx={{ '& .MuiToggleButton-root': { py: 0 } }}
                         onChange={(_, value) => {
                             if (value !== null) {
                                 onJimakuSearchCategoryChange(value);

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -36,8 +36,8 @@ interface Props {
     detectedTitleHint?: string;
     jimakuApiKey: string;
     onJimakuApiKeyChange: (jimakuApiKey: string) => void;
-    jimakuSearchCategory: 'anime' | 'drama' | 'both';
-    onJimakuSearchCategoryChange: (category: 'anime' | 'drama' | 'both') => void;
+    jimakuSearchCategory: 'anime' | 'drama';
+    onJimakuSearchCategoryChange: (category: 'anime' | 'drama') => void;
 }
 
 const SUPPORTED_JIMAKU_EXTENSIONS = ['.srt', '.ass'];
@@ -138,10 +138,9 @@ export default function OnlineSubtitleSourceDialog({
         try {
             const client = new JimakuClient({ apiKey: jimakuApiKey });
             const requests: Promise<{ data: { id: number; name: string }[] }>[] = [];
-            if (jimakuSearchCategory === 'anime' || jimakuSearchCategory === 'both') {
+            if (jimakuSearchCategory === 'anime') {
                 requests.push(client.searchEntries(query));
-            }
-            if (jimakuSearchCategory === 'drama' || jimakuSearchCategory === 'both') {
+            } else {
                 requests.push(client.searchEntries(query, false));
             }
             const results = await Promise.all(requests);
@@ -274,7 +273,6 @@ export default function OnlineSubtitleSourceDialog({
                     >
                         <ToggleButton value="anime">{t('onlineSubtitleSources.categoryAnime')}</ToggleButton>
                         <ToggleButton value="drama">{t('onlineSubtitleSources.categoryDrama')}</ToggleButton>
-                        <ToggleButton value="both">{t('onlineSubtitleSources.categoryBoth')}</ToggleButton>
                     </ToggleButtonGroup>
                     </Box>
 

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -99,6 +99,7 @@ export default function OnlineSubtitleSourceDialog({
 
     const [query, setQuery] = useState('');
     const [lastQuery, setLastQuery] = useState<string>();
+    const [lastSearchCategory, setLastSearchCategory] = useState<string>();
     const [jimakuEntries, setJimakuEntries] = useState<{ id: number; name: string }[]>([]);
     const [jimakuSelectedEntry, setJimakuSelectedEntry] = useState<JimakuEntry>();
     const [jimakuFiles, setJimakuFiles] = useState<OnlineSubtitleImportCandidate[]>();
@@ -111,7 +112,7 @@ export default function OnlineSubtitleSourceDialog({
         searching ||
         query.trim().length === 0 ||
         jimakuApiKey.trim().length === 0 ||
-        lastQuery === query ||
+        (lastQuery === query && lastSearchCategory === jimakuSearchCategory) ||
         loadingFiles;
 
     const resetState = useCallback(() => {
@@ -156,6 +157,7 @@ export default function OnlineSubtitleSourceDialog({
             });
 
             setLastQuery(query);
+            setLastSearchCategory(jimakuSearchCategory);
             setJimakuEntries(mergedEntries.map((entry) => ({ id: entry.id, name: entry.name })));
             setJimakuSelectedEntry(undefined);
             setJimakuFiles(undefined);
@@ -164,7 +166,7 @@ export default function OnlineSubtitleSourceDialog({
         } finally {
             setSearching(false);
         }
-    }, [jimakuApiKey, query]);
+    }, [jimakuApiKey, query, jimakuSearchCategory]);
 
     const handleLoadJimakuFiles = useCallback(
         async (entry: JimakuEntry) => {

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -137,27 +137,14 @@ export default function OnlineSubtitleSourceDialog({
 
         try {
             const client = new JimakuClient({ apiKey: jimakuApiKey });
-            const requests: Promise<{ data: { id: number; name: string }[] }>[] = [];
-            if (jimakuSearchCategory === 'anime') {
-                requests.push(client.searchEntries(query));
-            } else {
-                requests.push(client.searchEntries(query, false));
-            }
-            const results = await Promise.all(requests);
-
-            // Merge and deduplicate by entry id
-            const seen = new Set<number>();
-            const mergedEntries = results.flatMap((r) => r.data).filter((entry) => {
-                if (seen.has(entry.id)) {
-                    return false;
-                }
-                seen.add(entry.id);
-                return true;
-            });
+            const result =
+                jimakuSearchCategory === 'anime'
+                    ? await client.searchEntries(query)
+                    : await client.searchEntries(query, false);
 
             setLastQuery(query);
             setLastSearchCategory(jimakuSearchCategory);
-            setJimakuEntries(mergedEntries.map((entry) => ({ id: entry.id, name: entry.name })));
+            setJimakuEntries(result.data.map((entry) => ({ id: entry.id, name: entry.name })));
             setJimakuSelectedEntry(undefined);
             setJimakuFiles(undefined);
         } catch (e) {

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -11,6 +11,8 @@ import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import CloseIcon from '@mui/icons-material/Close';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -34,6 +36,8 @@ interface Props {
     detectedTitleHint?: string;
     jimakuApiKey: string;
     onJimakuApiKeyChange: (jimakuApiKey: string) => void;
+    jimakuSearchCategory: 'anime' | 'drama' | 'both';
+    onJimakuSearchCategoryChange: (category: 'anime' | 'drama' | 'both') => void;
 }
 
 const SUPPORTED_JIMAKU_EXTENSIONS = ['.srt', '.ass'];
@@ -85,6 +89,8 @@ export default function OnlineSubtitleSourceDialog({
     detectedTitleHint,
     jimakuApiKey,
     onJimakuApiKeyChange,
+    jimakuSearchCategory,
+    onJimakuSearchCategoryChange,
 }: Props) {
     const { t } = useTranslation();
     const [searching, setSearching] = useState(false);
@@ -130,14 +136,18 @@ export default function OnlineSubtitleSourceDialog({
 
         try {
             const client = new JimakuClient({ apiKey: jimakuApiKey });
-            const [animeResult, dramaResult] = await Promise.all([
-                client.searchEntries(query),
-                client.searchEntries(query, false),
-            ]);
+            const requests: Promise<{ data: { id: number; name: string }[] }>[] = [];
+            if (jimakuSearchCategory === 'anime' || jimakuSearchCategory === 'both') {
+                requests.push(client.searchEntries(query));
+            }
+            if (jimakuSearchCategory === 'drama' || jimakuSearchCategory === 'both') {
+                requests.push(client.searchEntries(query, false));
+            }
+            const results = await Promise.all(requests);
 
             // Merge and deduplicate by entry id
             const seen = new Set<number>();
-            const mergedEntries = [...animeResult.data, ...dramaResult.data].filter((entry) => {
+            const mergedEntries = results.flatMap((r) => r.data).filter((entry) => {
                 if (seen.has(entry.id)) {
                     return false;
                 }
@@ -249,6 +259,21 @@ export default function OnlineSubtitleSourceDialog({
                                 },
                             }}
                         />
+                    <ToggleButtonGroup
+                        value={jimakuSearchCategory}
+                        exclusive
+                        size="small"
+                        fullWidth
+                        onChange={(_, value) => {
+                            if (value !== null) {
+                                onJimakuSearchCategoryChange(value);
+                            }
+                        }}
+                    >
+                        <ToggleButton value="anime">{t('onlineSubtitleSources.categoryAnime')}</ToggleButton>
+                        <ToggleButton value="drama">{t('onlineSubtitleSources.categoryDrama')}</ToggleButton>
+                        <ToggleButton value="both">{t('onlineSubtitleSources.categoryBoth')}</ToggleButton>
+                    </ToggleButtonGroup>
                     </Box>
 
                     <TextField

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -252,7 +252,7 @@ export default function OnlineSubtitleSourceDialog({
             <DialogContent>
                 <Stack spacing={2}>
                     {error && <Alert severity="error">{error}</Alert>}
-                    <Box sx={{ display: 'flex', gap: 1 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
                         <TextField
                             autoFocus
                             margin="dense"
@@ -282,21 +282,21 @@ export default function OnlineSubtitleSourceDialog({
                                 },
                             }}
                         />
-                    <ToggleButtonGroup
-                        value={jimakuSearchCategory}
-                        exclusive
-                        size="small"
-                        fullWidth
-                        sx={{ '& .MuiToggleButton-root': { py: 0 } }}
-                        onChange={(_, value) => {
-                            if (value !== null) {
-                                onJimakuSearchCategoryChange(value);
-                            }
-                        }}
-                    >
-                        <ToggleButton value="anime">{t('onlineSubtitleSources.categoryAnime')}</ToggleButton>
-                        <ToggleButton value="drama">{t('onlineSubtitleSources.categoryDrama')}</ToggleButton>
-                    </ToggleButtonGroup>
+                        <ToggleButtonGroup
+                            value={jimakuSearchCategory}
+                            exclusive
+                            size="small"
+                            fullWidth
+                            sx={{ mt: 1, mb: 0.5, height: 56 }}
+                            onChange={(_, value) => {
+                                if (value !== null) {
+                                    onJimakuSearchCategoryChange(value);
+                                }
+                            }}
+                        >
+                            <ToggleButton value="anime">{t('onlineSubtitleSources.categoryAnime')}</ToggleButton>
+                            <ToggleButton value="drama">{t('onlineSubtitleSources.categoryDrama')}</ToggleButton>
+                        </ToggleButtonGroup>
                     </Box>
 
                     <TextField

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -111,7 +111,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
     const [hideRememberTrackPreferenceToggle, setHideRememberTrackPreferenceToggle] = useState<boolean>();
     const [onlineSubtitleSourceConfig, setOnlineSubtitleSourceConfig] = useState<OnlineSubtitleSourceConfig>({
         jimakuApiKey: '',
-        jimakuSearchCategory: 'both',
+        jimakuSearchCategory: 'anime',
     });
     const [onlineDialogOpen, setOnlineDialogOpen] = useState(false);
     const [onlineDialogTrackNumber, setOnlineDialogTrackNumber] = useState<number>();

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -111,6 +111,7 @@ export default function VideoDataSyncUi({ bridge }: Props) {
     const [hideRememberTrackPreferenceToggle, setHideRememberTrackPreferenceToggle] = useState<boolean>();
     const [onlineSubtitleSourceConfig, setOnlineSubtitleSourceConfig] = useState<OnlineSubtitleSourceConfig>({
         jimakuApiKey: '',
+        jimakuSearchCategory: 'both',
     });
     const [onlineDialogOpen, setOnlineDialogOpen] = useState(false);
     const [onlineDialogTrackNumber, setOnlineDialogTrackNumber] = useState<number>();
@@ -440,6 +441,8 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                     detectedTitleHint={detectedTitleHint}
                     jimakuApiKey={onlineSubtitleSourceConfig.jimakuApiKey}
                     onJimakuApiKeyChange={(jimakuApiKey) => handleOnlineSubtitleSourceConfigChanged({ jimakuApiKey })}
+                    jimakuSearchCategory={onlineSubtitleSourceConfig.jimakuSearchCategory}
+                    onJimakuSearchCategoryChange={(jimakuSearchCategory) => handleOnlineSubtitleSourceConfigChanged({ jimakuSearchCategory })}
                 />
                 <input
                     ref={fileInputRef}


### PR DESCRIPTION
Users reported this on QQ: searching live-action/drama subtitles (e.g. 逃げるは恥だが役に立つ) returned no results 
because subtitles under https://jimaku.cc/dramas were not queried.

Online subtitle search only queried the default anime category on jimaku.cc, missing subtitles listed under the dramas/live-action section. This changes searchEntries to accept an optional flags parameter and updates the search UI to fetch both anime and drama entries in parallel, deduplicating by entry id.

Assisted-by: Codex:GPT-5.3-Codex

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
