### PR TITLE
Infer if rank-based to allow undeclared frequency dictionaries

### DIFF
--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -95,6 +95,7 @@ interface TrackState {
     tokenCardIds: Map<string, Map<number, boolean>>;
     tokenAssignmentIds: Map<string, Set<number>>;
     tokenStates: Map<string, TokenState[]>;
+    indexTokenOccurrences: Map<number, Map<string, number>>;
 }
 
 function shouldUseExactForm(s: TokenMatchStrategy): boolean {
@@ -889,6 +890,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         let buildWasCancelled = false;
         let updateThresholds = false;
         let statisticsBatching = false;
+        let builtNewTokenization = false;
         try {
             this.annotationsBuilding = true;
             if (this.profile === null) {
@@ -910,6 +912,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     tokenCardIds: new Map(),
                     tokenAssignmentIds: new Map(),
                     tokenStates: new Map(),
+                    indexTokenOccurrences: new Map(),
                 }));
                 if (this.generateStatistics === undefined) {
                     this.generateStatistics = this._shouldAutoGenerateStatistics(this.trackStates.map((ts) => ts.dt));
@@ -1021,6 +1024,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                                 ) {
                                     return;
                                 }
+                                builtNewTokenization = true;
                                 const updatedSubtitles: RichSubtitleModel[] = [];
                                 if (tokenizationModel) {
                                     const { tokenization, reconstructedText } = tokenizationModel;
@@ -1031,6 +1035,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                                     subtitle.text = reconstructedText;
                                     subtitle.__tokenized = true;
                                     updatedSubtitles.push(subtitle);
+                                    this._recordTokenOccurrences(index, reconstructedText, tokenization, ts);
                                     if (generatingStatistics) {
                                         const sentence = { ...subtitle };
                                         renderRichTextOntoSubtitles(
@@ -1103,6 +1108,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 for (const track of this.tokenRequestFailedForTracks) resetYomitan(this.trackStates[track]);
                 this.tokenRequestFailedForTracks.clear();
             } else if (!this.shouldCancelBuild) {
+                if (builtNewTokenization) this._inferFrequencyModesFromTokenOccurrences();
                 this.initialized = true;
                 if (statisticsBatching) {
                     this.statisticsBatchProcessedIndex = annotationsEndIndex;
@@ -1130,6 +1136,28 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             this.annotationsBuilding = false;
         }
         return !buildWasCancelled;
+    }
+
+    private _recordTokenOccurrences(
+        index: number,
+        reconstructedText: string,
+        tokenization: Tokenization,
+        ts: TrackState
+    ): void {
+        const tokenOccurrences = new Map<string, number>();
+        for (const token of tokenization.tokens) {
+            const tokenText = reconstructedText.substring(token.pos[0], token.pos[1]).trim();
+            if (!HAS_LETTER_REGEX.test(tokenText)) continue;
+            tokenOccurrences.set(tokenText, (tokenOccurrences.get(tokenText) ?? 0) + 1);
+        }
+        ts.indexTokenOccurrences.set(index, tokenOccurrences);
+    }
+
+    private _inferFrequencyModesFromTokenOccurrences(): void {
+        for (const ts of this.trackStates) {
+            if (!dictionaryTrackEnabled(ts.dt) || !ts.yt) continue;
+            ts.yt.inferFrequencyModesFromTokenOccurrences(ts.indexTokenOccurrences);
+        }
     }
 
     private async _buildTokenAndLemmaMap(profile: string | undefined, subtitles: RichSubtitleModel[]): Promise<void> {

--- a/common/yomitan/yomitan.ts
+++ b/common/yomitan/yomitan.ts
@@ -6,6 +6,8 @@ import { coerce, lt, gte } from 'semver';
 const TOKENIZE_BATCH_SIZE = 100; // 1k can cause 1.5GB memory on Yomitan for subtitles, Anki cards may be larger too
 const TERM_ENTRIES_BATCH_SIZE = 10; // 100 is only 10% faster (17s vs 19s for a 23min subtitle)
 const TERM_ENTRIES_DEBOUNCE_MS = 10; // Prevents using too much resources
+const FREQUENCY_MODE_INFERENCE_GROUP_SIZE = 10;
+const FREQUENCY_MODE_INFERENCE_RANK_BASED_MATCHES = 7;
 
 const YEAR_MONTH_REGEX = /(?<year>20\d{2})(?<month>[01]\d)/;
 
@@ -38,6 +40,7 @@ interface TermSource {
     isPrimary: boolean;
 }
 
+type FrequencyMode = 'rank-based' | 'occurrence-based';
 interface TermFrequency {
     index: number;
     headwordIndex: number;
@@ -45,7 +48,7 @@ interface TermFrequency {
     dictionaryIndex: number;
     dictionaryAlias: string;
     hasReading: boolean;
-    frequencyMode?: 'occurrence-based' | 'rank-based' | null;
+    frequencyMode?: FrequencyMode | null;
     frequency: number;
     displayValue: string | null;
     displayValueParsed: boolean;
@@ -77,6 +80,8 @@ export class Yomitan {
     private readonly tokenizeCache: Map<string, TokenPart[][]>;
     private readonly lemmatizeCache: Map<string, string[]>;
     private readonly frequencyCache: Map<string, number | null>;
+    private readonly frequencyModeInferenceData: Map<string, Map<string, number>>;
+    private readonly inferredFrequencyModes: Map<string, FrequencyMode>;
     private readonly lemmaTokenFallback: boolean; // Allow collecting ungrouped segments (no dictionary entry)
     private readonly tokensWereModified?: (token: string) => void;
     private supportsMecab: boolean;
@@ -96,6 +101,8 @@ export class Yomitan {
         this.tokenizeCache = new Map();
         this.lemmatizeCache = new Map();
         this.frequencyCache = new Map();
+        this.frequencyModeInferenceData = new Map();
+        this.inferredFrequencyModes = new Map();
         this.lemmaTokenFallback = options?.lemmaTokenFallback ?? false;
         this.tokensWereModified = options?.tokensWereModified;
         this.supportsMecab = false;
@@ -122,6 +129,8 @@ export class Yomitan {
         this.tokenizeCache.clear();
         this.lemmatizeCache.clear();
         this.frequencyCache.clear();
+        this.frequencyModeInferenceData.clear();
+        this.inferredFrequencyModes.clear();
         this.lastCancelledAt = Date.now();
     }
 
@@ -324,7 +333,7 @@ export class Yomitan {
                     if (!headword.frequencies) continue;
                     for (const f of headword.frequencies) {
                         if (!Number.isFinite(f.frequency) || f.frequency <= 0) continue;
-                        if (f.frequencyMode !== 'rank-based') continue;
+                        if (this.frequencyMode(token, f) !== 'rank-based') continue;
                         minFrequency = minFrequency === null ? f.frequency : Math.min(minFrequency, f.frequency);
                     }
                     break;
@@ -482,7 +491,7 @@ export class Yomitan {
             for (const f of entry.frequencies) {
                 if (!matchingHeadwordIndices.has(f.headwordIndex)) continue;
                 if (!Number.isFinite(f.frequency) || f.frequency <= 0) continue;
-                if (f.frequencyMode !== 'rank-based' && this.supportsTokenizeFrequency) continue; // Exposed with this.supportsTokenizeFrequency
+                if (this.frequencyMode(token, f) !== 'rank-based') continue;
                 minFrequency = minFrequency === null ? f.frequency : Math.min(minFrequency, f.frequency);
             }
         }
@@ -538,6 +547,76 @@ export class Yomitan {
             );
         } finally {
             this.asyncSemaphore.release(semaphoreId);
+        }
+    }
+
+    private frequencyMode(token: string, f: TermFrequency): FrequencyMode | undefined {
+        if (f.frequencyMode) return f.frequencyMode;
+
+        let frequencies = this.frequencyModeInferenceData.get(f.dictionary);
+        if (!frequencies) {
+            frequencies = new Map();
+            this.frequencyModeInferenceData.set(f.dictionary, frequencies);
+        }
+        const existingFrequency = frequencies.get(token);
+        if (existingFrequency === undefined || f.frequency < existingFrequency) frequencies.set(token, f.frequency);
+        return this.inferredFrequencyModes.get(f.dictionary);
+    }
+
+    inferFrequencyModesFromTokenOccurrences(tokenOccurrencesByIndex: Map<number, Map<string, number>>): void {
+        const occurrencesByToken = new Map<string, number>();
+        for (const tokenOccurrences of tokenOccurrencesByIndex.values()) {
+            for (const [token, occurrences] of tokenOccurrences.entries()) {
+                occurrencesByToken.set(token, (occurrencesByToken.get(token) ?? 0) + occurrences);
+            }
+        }
+        for (const [dictionary, frequencies] of this.frequencyModeInferenceData.entries()) {
+            const records: { token: string; frequency: number; occurrences: number }[] = [];
+            for (const [token, frequency] of frequencies.entries()) {
+                const occurrences = occurrencesByToken.get(token);
+                if (occurrences === undefined) continue;
+                records.push({ token, frequency, occurrences });
+            }
+            if (records.length < FREQUENCY_MODE_INFERENCE_GROUP_SIZE * 2) continue;
+            const previousFrequencyMode = this.inferredFrequencyModes.get(dictionary);
+
+            const recordsByOccurrences = [...records].sort(
+                (left, right) => right.occurrences - left.occurrences || left.frequency - right.frequency
+            );
+            const mostOccurringWords = recordsByOccurrences.slice(0, FREQUENCY_MODE_INFERENCE_GROUP_SIZE);
+            const leastOccurringWords = recordsByOccurrences.slice(-FREQUENCY_MODE_INFERENCE_GROUP_SIZE);
+            let rankBasedMatches = 0;
+            for (let i = 0; i < FREQUENCY_MODE_INFERENCE_GROUP_SIZE; i++) {
+                if (mostOccurringWords[i].frequency < leastOccurringWords[i].frequency) ++rankBasedMatches;
+            }
+            const frequencyMode =
+                rankBasedMatches >= FREQUENCY_MODE_INFERENCE_RANK_BASED_MATCHES ? 'rank-based' : 'occurrence-based';
+
+            if (previousFrequencyMode === frequencyMode) continue;
+            console.log(
+                `Inferred '${frequencyMode}' for the '${dictionary}' frequency dictionary (previously ${previousFrequencyMode}) based on:`,
+                {
+                    mostOccurringWords,
+                    leastOccurringWords,
+                }
+            );
+
+            this.inferredFrequencyModes.set(dictionary, frequencyMode);
+            for (const [token, frequency] of frequencies.entries()) {
+                if (frequencyMode === 'rank-based') {
+                    const cachedFrequency = this.frequencyCache.get(token);
+                    this.frequencyCache.set(
+                        token,
+                        cachedFrequency === undefined || cachedFrequency === null
+                            ? frequency
+                            : Math.min(cachedFrequency, frequency)
+                    );
+                    this.tokensWereModified?.(token);
+                } else if (previousFrequencyMode === 'rank-based') {
+                    this.frequencyCache.delete(token);
+                    this.tokensWereModified?.(token);
+                }
+            }
         }
     }
 

--- a/common/yomitan/yomitan.ts
+++ b/common/yomitan/yomitan.ts
@@ -333,7 +333,7 @@ export class Yomitan {
                     if (!headword.frequencies) continue;
                     for (const f of headword.frequencies) {
                         if (!Number.isFinite(f.frequency) || f.frequency <= 0) continue;
-                        if (this.frequencyMode(token, f) !== 'rank-based') continue;
+                        if (this.resolveFrequencyMode(token, f) !== 'rank-based') continue;
                         minFrequency = minFrequency === null ? f.frequency : Math.min(minFrequency, f.frequency);
                     }
                     break;
@@ -491,7 +491,7 @@ export class Yomitan {
             for (const f of entry.frequencies) {
                 if (!matchingHeadwordIndices.has(f.headwordIndex)) continue;
                 if (!Number.isFinite(f.frequency) || f.frequency <= 0) continue;
-                if (this.frequencyMode(token, f) !== 'rank-based') continue;
+                if (this.resolveFrequencyMode(token, f) !== 'rank-based') continue;
                 minFrequency = minFrequency === null ? f.frequency : Math.min(minFrequency, f.frequency);
             }
         }
@@ -550,7 +550,7 @@ export class Yomitan {
         }
     }
 
-    private frequencyMode(token: string, f: TermFrequency): FrequencyMode | undefined {
+    private resolveFrequencyMode(token: string, f: TermFrequency): FrequencyMode | undefined {
         if (f.frequencyMode) return f.frequencyMode;
 
         let frequencies = this.frequencyModeInferenceData.get(f.dictionary);

--- a/docs/docs/reference/settings.md
+++ b/docs/docs/reference/settings.md
@@ -290,15 +290,9 @@ Shows a rank-based frequency value below words (when available). This is useful 
 - **Never**: disable frequency.
 
 :::tip
-Frequency information requires at least one rank-based frequency dictionary to be available in your Yomitan instance.
+Frequency information requires at least one rank-based frequency dictionary to be available in your Yomitan instance. If a frequency dictionary doesn't declare its mode, asbplayer will try to infer whether it is rank-based and use it accordingly.
 
 If multiple frequency numbers are available for a word, the lowest (most frequent) number is used.
-:::
-
-:::note
-If you are using Yomitan frequency-based dictionaries, make sure that
-
-Dictionary index.json should have the field "frequencyMode":"rank-based".
 :::
 
 ### Only show annotations on hover


### PR DESCRIPTION
Related to: #1003

Some frequency dictionaries in Yomitan may not have the `frequencyMode` which explicitly says if it's `rank-based` or `occurrence-based`. In these cases, we will now infer the type by leveraging the fact that common words are common. The test is simple, take the 10 most and least occurrent words in the current subtitle then compare these two groups against each other to see if the most occurrent words have the lowest frequency. To be considered `rank-based`, at least 7 of these comparisons need to win. Here is an example of a dictionary that would be previously ignored:

```json
{"mostOccurringWords": [
	{"token":"の","frequency":1,"occurrences":169},
	{"token":"に","frequency":3,"occurrences":122},
	{"token":"は","frequency":7,"occurrences":105},
	{"token":"が","frequency":4,"occurrences":101},
	{"token":"を","frequency":5,"occurrences":89},
	{"token":"だ","frequency":6,"occurrences":81},
	{"token":"で","frequency":12,"occurrences":73},
	{"token":"な","frequency":89,"occurrences":69},
	{"token":"も","frequency":13,"occurrences":64},
	{"token":"と","frequency":10,"occurrences":61}
],
"leastOccurringWords": [
	{"token":"眈々","frequency":62783,"occurrences":1},
	{"token":"チンピ","frequency":66671,"occurrences":1},
	{"token":"血生臭い","frequency":78451,"occurrences":1},
	{"token":"たぶん","frequency":81587,"occurrences":1},
	{"token":"澱んだ","frequency":85568,"occurrences":1},
	{"token":"呼び立てて","frequency":89612,"occurrences":1},
	{"token":"喰らいついて","frequency":91401,"occurrences":1},
	{"token":"弩","frequency":100182,"occurrences":1},
	{"token":"うえ","frequency":102895,"occurrences":1},
	{"token":"かかり","frequency":140158,"occurrences":1}
]}
```

Due to [Zipf's law](https://en.wikipedia.org/wiki/Zipf%27s_law), we can expect this to hold for pretty much any text that's natural language. This is even accurate with only 10 subtitle events with 50 unique words total. So this is a very strong signal and extremely low risk for full subtitles. The main shortcomings would be if a name or a place was used frequently but it's still unlikely to beat out the top words. At least we shouldn't expect 4 or more of the top 10 most occurrent words to not be of the most frequent in the dictionaries.

If we do need to make it stronger, we can increase the number of wins needed up from 7 or even change the group size for comparison to a higher number. There is a tradeoff though as we move into median words we could start seeing more random wins/losses due to the content word variance.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
