### PR TITLE
Feature/skip re-recording media when mining same subtitle

### DIFF
--- a/common/components/AnkiDialog.tsx
+++ b/common/components/AnkiDialog.tsx
@@ -22,6 +22,7 @@ import IconButton from '@mui/material/IconButton';
 import RestoreIcon from '@mui/icons-material/Restore';
 import SettingsIcon from '@mui/icons-material/Settings';
 import CloseIcon from '@mui/icons-material/Close';
+import LayersClearIcon from '@mui/icons-material/LayersClear';
 import Slider from '@mui/material/Slider';
 import Toolbar from '@mui/material/Toolbar';
 import Tooltip from './Tooltip';
@@ -187,6 +188,7 @@ interface AnkiDialogProps {
     card: CardModel;
     onProceed: (params: ExportParams) => void;
     onRerecord?: () => void;
+    onClearMediaCache?: () => void;
     onCancel: () => void;
     onOpenSettings?: () => void;
     onCopyToClipboard: (blob: Blob) => void;
@@ -217,6 +219,7 @@ const AnkiDialog = ({
     onCancel,
     onOpenSettings,
     onRerecord,
+    onClearMediaCache,
     onCopyToClipboard,
     settings,
     anki,
@@ -814,6 +817,13 @@ const AnkiDialog = ({
                             activeProfile={activeProfile}
                             onSetActiveProfile={onSetActiveProfile}
                         />
+                    )}
+                    {onClearMediaCache && (
+                        <Tooltip title={t('ankiDialog.clearMediaCache')!}>
+                            <IconButton edge="end" onClick={onClearMediaCache}>
+                                <LayersClearIcon />
+                            </IconButton>
+                        </Tooltip>
                     )}
                     {onOpenSettings && (
                         <TutorialBubble

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -80,6 +80,7 @@
         "openInAnki": "In Anki öffnen",
         "rerecord": "Neuaufnahme",
         "rerecordAndApplySelection": "Ausgewählten Zeitbereich aufnehmen",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "Zurücksetzen",
         "rewind": "Zu Zeilenanfang",
         "searchInAnki": "In Anki suchen",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -80,6 +80,7 @@
         "openInAnki": "Open in Anki",
         "rerecord": "Rerecord",
         "rerecordAndApplySelection": "Record selected time range",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "Reset",
         "rewind": "Rewind",
         "searchInAnki": "Search in Anki",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -80,6 +80,7 @@
         "openInAnki": "Abrir en Anki",
         "rerecord": "Regrabar",
         "rerecordAndApplySelection": "Grabar rango de tiempo seleccionado",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "Reestablecer",
         "rewind": "Retroceder",
         "searchInAnki": "Buscar en Anki",

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -80,6 +80,7 @@
         "openInAnki": "Avaa Ankilla",
         "rerecord": "Ennätys uudelleen",
         "rerecordAndApplySelection": "Tallenna valittu aikaväli",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "Palauta asetukset",
         "rewind": "Takaisinkelaus",
         "searchInAnki": "Etsi Ankilla",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -80,6 +80,7 @@
         "openInAnki": "Ouvrir dans Anki",
         "rerecord": "Réenregistrer",
         "rerecordAndApplySelection": "Enregistrer la plage temporelle sélectionnée",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "Réinitialiser",
         "rewind": "Retour arrière",
         "searchInAnki": "Rechercher dans Anki",

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -80,6 +80,7 @@
         "openInAnki": "Buka di Anki",
         "rerecord": "Rekam Ulang",
         "rerecordAndApplySelection": "Rekam rentang waktu yang dipilih",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "Atur Ulang",
         "rewind": "Mundur",
         "searchInAnki": "Cari di Anki",

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -80,6 +80,7 @@
         "openInAnki": "Apri in Anki",
         "rerecord": "Registra Nuovamente",
         "rerecordAndApplySelection": "Registra la durata selezionata",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "Azzera",
         "rewind": "Riavvolgi",
         "searchInAnki": "Cerca in Anki",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -80,6 +80,7 @@
         "openInAnki": "Anki で開く",
         "rerecord": "再録音",
         "rerecordAndApplySelection": "選択した時間範囲を録音",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "リセット",
         "rewind": "巻き戻し",
         "searchInAnki": "Anki で検索する",

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -80,6 +80,7 @@
         "openInAnki": "Anki에서 열기",
         "rerecord": "다시 녹화",
         "rerecordAndApplySelection": "선택한 시간 범위 녹음하기",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "리셋",
         "rewind": "되감기",
         "searchInAnki": "Anki에서 써치",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -80,6 +80,7 @@
         "openInAnki": "Otwórz w Anki",
         "rerecord": "Nagraj ponownie",
         "rerecordAndApplySelection": "Record selected time range",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "Resetuj",
         "rewind": "Przewiń",
         "searchInAnki": "Szukaj w Anki",

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -80,6 +80,7 @@
         "openInAnki": "Abrir no Anki",
         "rerecord": "Regravar",
         "rerecordAndApplySelection": "Gravar intervalo de tempo selecionado",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "Resetar",
         "rewind": "Retroceder",
         "searchInAnki": "Pesquisar no Anki",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -80,6 +80,7 @@
         "openInAnki": "Открыть в Anki",
         "rerecord": "Перезаписать",
         "rerecordAndApplySelection": "Перезаписать текущий отрезок",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "Сбросить ползунок",
         "rewind": "Перемотать назад",
         "searchInAnki": "Искать в Anki",

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -80,6 +80,7 @@
         "openInAnki": "在 Anki 中打开",
         "rerecord": "重新录音",
         "rerecordAndApplySelection": "录制选中时间段",
+        "clearMediaCache": "Clear cached media",
         "resetSlider": "重置",
         "rewind": "倒退",
         "searchInAnki": "在Anki中搜索",

--- a/common/src/message.ts
+++ b/common/src/message.ts
@@ -143,6 +143,7 @@ export interface RecordMediaAndForwardSubtitleMessage extends Message, CardTextF
     readonly playbackRate: number;
     readonly mediaTimestamp: number;
     readonly isBulkExport?: boolean;
+    readonly useCachedMedia?: boolean;
 }
 
 export interface StartRecordingMediaMessage extends Message, ImageCaptureParams {
@@ -507,6 +508,11 @@ export interface AnkiUiBridgeRerecordMessage extends Message {
     readonly uiState: AnkiUiSavedState;
     readonly recordStart: number;
     readonly recordEnd: number;
+    readonly clearMediaCache?: boolean;
+}
+
+export interface AnkiUiBridgeClearMediaCacheMessage extends Message {
+    readonly command: 'clear-media-cache';
 }
 
 export interface AnkiUiBridgeExportedMessage extends Message {

--- a/docs/docs/guides/mining-in-depth.md
+++ b/docs/docs/guides/mining-in-depth.md
@@ -4,6 +4,7 @@ sidebar_position: 3
 
 import NoteAddIcon from '@site/src/components/NoteAddIcon';
 import ImageIcon from '@site/src/components/ImageIcon';
+import LayersClearIcon from '@site/src/components/LayersClearIcon';
 
 # Mining in-depth
 
@@ -45,6 +46,23 @@ Any of the text fields - sentence, definition, word, custom fields, source, URL,
 ### Image field
 
 For local files, clicking the **Preview Button** <ImageIcon /> on the **Image Field** can be used to change the video timestamp from which the screenshot is extracted.
+
+### Media caching
+
+When you mine the same subtitle multiple times, asbplayer automatically reuses the audio recording and screenshot from the previous mine instead of re-recording them. This is useful when:
+
+- You want to adjust text fields or definitions while keeping the same media
+- You're creating multiple cards from the same subtitle with different words highlighted
+- You want to update a card without waiting for re-recording
+
+If you've trimmed the audio or made other adjustments and want to re-record the full, original subtitle with fresh media, use the **Clear Cached Media** button <LayersClearIcon /> in the dialog toolbar. This will:
+
+1. Clear the cached audio and screenshot
+2. Re-record the complete, untrimmed subtitle
+3. Reset the timeline to show the full subtitle range
+4. Cache the new recording for subsequent mines
+
+The cache is maintained separately for each video and browser tab, so mining the same subtitle in different tabs or videos won't interfere with each other.
 
 ## Exporting cards
 

--- a/docs/src/components/LayersClearIcon.tsx
+++ b/docs/src/components/LayersClearIcon.tsx
@@ -1,0 +1,14 @@
+// https://github.com/google/material-design-icons?tab=Apache-2.0-1-ov-file#readme
+
+const LayersClearIcon = () => {
+    return (
+        <svg width="24" height="24" style={{ transform: 'translateY(4px)' }}>
+            <path
+                fill="currentcolor"
+                d="m19.81 14.99 1.19-.92-1.43-1.43-1.19.92 1.43 1.43zm-.45-4.72L21 9l-9-7-2.91 2.27 7.87 7.88 2.4-1.88zM3.27 1 2 2.27l4.22 4.22L3 9l1.63 1.27L12 16l2.1-1.63 1.43 1.43L12 18.54l-7.37-5.73L3 14.07l9 7 4.95-3.85L20.73 21 22 19.73 3.27 1z"
+            />
+        </svg>
+    );
+};
+
+export default LayersClearIcon;

--- a/extension/src/controllers/anki-ui-controller.ts
+++ b/extension/src/controllers/anki-ui-controller.ts
@@ -2,6 +2,7 @@ import {
     ActiveProfileMessage,
     AnkiDialogSettings,
     AnkiDialogSettingsMessage,
+    AnkiUiBridgeClearMediaCacheMessage,
     AnkiUiBridgeExportedMessage,
     AnkiUiBridgeRerecordMessage,
     AnkiUiBridgeResumeMessage,
@@ -266,6 +267,9 @@ export default class AnkiUiController {
                         return;
                     case 'dismissedQuickSelectFtue':
                         globalStateProvider.set({ ftueHasSeenAnkiDialogQuickSelectV2: true }).catch(console.error);
+                        return;
+                    case 'clear-media-cache':
+                        context.clearMediaCache();
                         return;
                     case 'exported':
                         const exportedMessage = message as AnkiUiBridgeExportedMessage;

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -3,6 +3,7 @@ import ImageCapturer from '@/services/image-capturer';
 import VideoHeartbeatHandler from '@/handlers/video/video-heartbeat-handler';
 import RecordMediaHandler from '@/handlers/video/record-media-handler';
 import RerecordMediaHandler from '@/handlers/video/rerecord-media-handler';
+import MediaCache from '@/services/media-cache';
 import StartRecordingMediaHandler from '@/handlers/video/start-recording-media-handler';
 import StopRecordingMediaHandler from '@/handlers/video/stop-recording-media-handler';
 import ToggleSubtitlesHandler from '@/handlers/video/toggle-subtitles-handler';
@@ -169,12 +170,13 @@ export default defineBackground(() => {
     );
     const imageCapturer = new ImageCapturer(settings);
     const cardPublisher = new CardPublisher(settings);
+    const mediaCache = new MediaCache();
     const dictionaryDB = new DictionaryDB(settings);
 
     const handlers: CommandHandler[] = [
         new VideoHeartbeatHandler(tabRegistry),
-        new RecordMediaHandler(audioRecorder, imageCapturer, cardPublisher, settings),
-        new RerecordMediaHandler(settings, audioRecorder, cardPublisher),
+        new RecordMediaHandler(audioRecorder, imageCapturer, cardPublisher, settings, mediaCache),
+        new RerecordMediaHandler(settings, audioRecorder, cardPublisher, mediaCache),
         new StartRecordingMediaHandler(audioRecorder, imageCapturer, cardPublisher, settings),
         new StopRecordingMediaHandler(audioRecorder, imageCapturer, cardPublisher, settings),
         new TakeScreenshotHandler(imageCapturer, cardPublisher),

--- a/extension/src/handlers/video/record-media-handler.ts
+++ b/extension/src/handlers/video/record-media-handler.ts
@@ -16,23 +16,27 @@ import {
 import { SettingsProvider } from '@project/common/settings';
 import { CardPublisher } from '../../services/card-publisher';
 import AudioRecorderService, { DrmProtectedStreamError } from '../../services/audio-recorder-service';
+import MediaCache from '../../services/media-cache';
 
 export default class RecordMediaHandler {
     private readonly _audioRecorder: AudioRecorderService;
     private readonly _imageCapturer: ImageCapturer;
     private readonly _cardPublisher: CardPublisher;
     private readonly _settingsProvider: SettingsProvider;
+    private readonly _mediaCache: MediaCache;
 
     constructor(
         audioRecorder: AudioRecorderService,
         imageCapturer: ImageCapturer,
         cardPublisher: CardPublisher,
-        settingsProvider: SettingsProvider
+        settingsProvider: SettingsProvider,
+        mediaCache: MediaCache
     ) {
         this._audioRecorder = audioRecorder;
         this._imageCapturer = imageCapturer;
         this._cardPublisher = cardPublisher;
         this._settingsProvider = settingsProvider;
+        this._mediaCache = mediaCache;
     }
 
     get sender() {
@@ -56,96 +60,117 @@ export default class RecordMediaHandler {
     ) {
         const message = recordMediaCommand.message;
         const subtitle = message.subtitle;
-        let audioPromise = undefined;
-        let imagePromise = undefined;
         let imageModel: ImageModel | undefined = undefined;
         let audioModel: AudioModel | undefined = undefined;
-        let encodeAsMp3 = false;
 
-        if (message.record) {
-            const time = (subtitle.end - subtitle.start) / message.playbackRate + message.audioPaddingEnd;
+        const cacheKey = this._mediaCache.key(senderTab.id!, recordMediaCommand.src);
+        const cachedRecord = this._mediaCache.get(cacheKey);
+        const useCachedMedia =
+            !!message.useCachedMedia &&
+            cachedRecord !== undefined &&
+            cachedRecord.subtitleStart === subtitle.start &&
+            cachedRecord.subtitleEnd === subtitle.end;
 
-            if (message.postMineAction !== PostMineAction.showAnkiDialog) {
-                encodeAsMp3 = await this._settingsProvider.getSingle('preferMp3');
-            }
+        if (useCachedMedia) {
+            audioModel = message.record ? cachedRecord!.audioModel : undefined;
+            imageModel = message.screenshot ? cachedRecord!.imageModel : undefined;
+        } else {
+            let audioPromise = undefined;
+            let imagePromise = undefined;
+            let encodeAsMp3 = false;
 
-            audioPromise = this._audioRecorder.startWithTimeout(time, encodeAsMp3, {
-                src: recordMediaCommand.src,
-                tabId: sender.tab?.id!,
-            });
-        }
+            if (message.record) {
+                const time = (subtitle.end - subtitle.start) / message.playbackRate + message.audioPaddingEnd;
 
-        if (message.screenshot) {
-            const { maxWidth, maxHeight, rect, frameId } = message;
-            const screenshotDelay = Math.max(
-                0,
-                message.record
-                    ? message.mediaTimestamp - subtitle.start + message.audioPaddingStart
-                    : message.imageDelay
-            );
-            imagePromise = this._imageCapturer.capture(senderTab.id!, recordMediaCommand.src, screenshotDelay, {
-                maxWidth,
-                maxHeight,
-                rect,
-                frameId,
-            });
-            imagePromise.finally(() => {
-                const screenshotTakenCommand: ExtensionToVideoCommand<ScreenshotTakenMessage> = {
-                    sender: 'asbplayer-extension-to-video',
-                    message: {
-                        command: 'screenshot-taken',
-                    },
-                    src: recordMediaCommand.src,
-                };
-                browser.tabs.sendMessage(senderTab.id!, screenshotTakenCommand);
-            });
-        }
-
-        if (audioPromise) {
-            const { audioPaddingStart: paddingStart, audioPaddingEnd: paddingEnd, playbackRate } = message;
-            const baseAudioModel: AudioModel = {
-                base64: '',
-                extension: encodeAsMp3 ? 'mp3' : 'webm',
-                paddingStart,
-                paddingEnd,
-                playbackRate,
-            };
-
-            try {
-                const audioBase64 = await audioPromise;
-                audioModel = {
-                    ...baseAudioModel,
-                    base64: audioBase64,
-                };
-            } catch (e) {
-                if (!(e instanceof DrmProtectedStreamError)) {
-                    throw e;
+                if (message.postMineAction !== PostMineAction.showAnkiDialog) {
+                    encodeAsMp3 = await this._settingsProvider.getSingle('preferMp3');
                 }
 
-                audioModel = {
-                    ...baseAudioModel,
-                    error: AudioErrorCode.drmProtected,
-                };
+                audioPromise = this._audioRecorder.startWithTimeout(time, encodeAsMp3, {
+                    src: recordMediaCommand.src,
+                    tabId: sender.tab?.id!,
+                });
             }
-        }
 
-        if (imagePromise) {
-            try {
-                await imagePromise;
+            if (message.screenshot) {
+                const { maxWidth, maxHeight, rect, frameId } = message;
+                const screenshotDelay = Math.max(
+                    0,
+                    message.record
+                        ? message.mediaTimestamp - subtitle.start + message.audioPaddingStart
+                        : message.imageDelay
+                );
+                imagePromise = this._imageCapturer.capture(senderTab.id!, recordMediaCommand.src, screenshotDelay, {
+                    maxWidth,
+                    maxHeight,
+                    rect,
+                    frameId,
+                });
+                imagePromise.finally(() => {
+                    const screenshotTakenCommand: ExtensionToVideoCommand<ScreenshotTakenMessage> = {
+                        sender: 'asbplayer-extension-to-video',
+                        message: {
+                            command: 'screenshot-taken',
+                        },
+                        src: recordMediaCommand.src,
+                    };
+                    browser.tabs.sendMessage(senderTab.id!, screenshotTakenCommand);
+                });
+            }
 
-                // Use the last screenshot taken to allow user to re-take screenshot while audio is recording
-                imageModel = {
-                    base64: this._imageCapturer.lastImageBase64!,
-                    extension: 'jpeg',
-                };
-            } catch (e) {
-                console.error(e);
-                imageModel = {
+            if (audioPromise) {
+                const { audioPaddingStart: paddingStart, audioPaddingEnd: paddingEnd, playbackRate } = message;
+                const baseAudioModel: AudioModel = {
                     base64: '',
-                    extension: 'jpeg',
-                    error: ImageErrorCode.captureFailed,
+                    extension: encodeAsMp3 ? 'mp3' : 'webm',
+                    paddingStart,
+                    paddingEnd,
+                    playbackRate,
                 };
+
+                try {
+                    const audioBase64 = await audioPromise;
+                    audioModel = {
+                        ...baseAudioModel,
+                        base64: audioBase64,
+                    };
+                } catch (e) {
+                    if (!(e instanceof DrmProtectedStreamError)) {
+                        throw e;
+                    }
+
+                    audioModel = {
+                        ...baseAudioModel,
+                        error: AudioErrorCode.drmProtected,
+                    };
+                }
             }
+
+            if (imagePromise) {
+                try {
+                    await imagePromise;
+
+                    // Use the last screenshot taken to allow user to re-take screenshot while audio is recording
+                    imageModel = {
+                        base64: this._imageCapturer.lastImageBase64!,
+                        extension: 'jpeg',
+                    };
+                } catch (e) {
+                    console.error(e);
+                    imageModel = {
+                        base64: '',
+                        extension: 'jpeg',
+                        error: ImageErrorCode.captureFailed,
+                    };
+                }
+            }
+
+            this._mediaCache.set(cacheKey, {
+                subtitleStart: subtitle.start,
+                subtitleEnd: subtitle.end,
+                audioModel,
+                imageModel,
+            });
         }
 
         const { isBulkExport, ...messageWithoutBulkFlag } = message;

--- a/extension/src/handlers/video/rerecord-media-handler.ts
+++ b/extension/src/handlers/video/rerecord-media-handler.ts
@@ -11,16 +11,24 @@ import {
 import { CardPublisher } from '../../services/card-publisher';
 import { SettingsProvider } from '@project/common/settings';
 import AudioRecorderService, { DrmProtectedStreamError } from '../../services/audio-recorder-service';
+import MediaCache from '../../services/media-cache';
 
 export default class RerecordMediaHandler {
     private readonly _settingsProvider: SettingsProvider;
     private readonly _audioRecorder: AudioRecorderService;
     private readonly _cardPublisher: CardPublisher;
+    private readonly _mediaCache: MediaCache;
 
-    constructor(settingsProvider: SettingsProvider, audioRecorder: AudioRecorderService, cardPublisher: CardPublisher) {
+    constructor(
+        settingsProvider: SettingsProvider,
+        audioRecorder: AudioRecorderService,
+        cardPublisher: CardPublisher,
+        mediaCache: MediaCache
+    ) {
         this._settingsProvider = settingsProvider;
         this._audioRecorder = audioRecorder;
         this._cardPublisher = cardPublisher;
+        this._mediaCache = mediaCache;
     }
 
     get sender() {
@@ -68,13 +76,22 @@ export default class RerecordMediaHandler {
             };
         }
 
+        const { uiState } = rerecordCommand.message;
+        const cacheKey = this._mediaCache.key(sender.tab!.id!, rerecordCommand.src);
+        this._mediaCache.set(cacheKey, {
+            subtitleStart: uiState.subtitle.start,
+            subtitleEnd: uiState.subtitle.end,
+            audioModel: audio,
+            imageModel: uiState.image,
+        });
+
         this._cardPublisher.publish(
             {
                 audio: audio,
-                image: rerecordCommand.message.uiState.image,
-                url: rerecordCommand.message.uiState.url,
-                subtitle: rerecordCommand.message.uiState.subtitle,
-                surroundingSubtitles: rerecordCommand.message.uiState.surroundingSubtitles,
+                image: uiState.image,
+                url: uiState.url,
+                subtitle: uiState.subtitle,
+                surroundingSubtitles: uiState.surroundingSubtitles,
                 subtitleFileName: rerecordCommand.message.subtitleFileName,
                 mediaTimestamp: rerecordCommand.message.timestamp,
             },
@@ -84,9 +101,9 @@ export default class RerecordMediaHandler {
         );
 
         const newUiState = {
-            ...rerecordCommand.message.uiState,
+            ...uiState,
             audio: audio,
-            lastAppliedTimestampIntervalToAudio: rerecordCommand.message.uiState.timestampInterval,
+            lastAppliedTimestampIntervalToAudio: uiState.timestampInterval,
         };
 
         const showAnkiUiAfterRerecordCommand: ExtensionToVideoCommand<ShowAnkiUiAfterRerecordMessage> = {

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -143,6 +143,7 @@ export default class Binding {
     seekableTracks: SeekableTracks = calculateSeekableTracksValue([0]);
     private recordingMediaStartedTimestamp?: number;
     private recordingMediaWithScreenshot: boolean;
+    private _lastMinedSubtitle: SubtitleModel | undefined;
     private pausedDueToHover = false;
     private _playModes: Set<PlayMode> = new Set([PlayMode.normal]);
     private _seekDuration = 3;
@@ -1263,7 +1264,13 @@ export default class Binding {
 
         const mediaTimestamp = subtitleTimestampWithDelay(subtitle, this.imageDelay);
 
-        if (this.takeScreenshot) {
+        const isSameSubtitleAsPrevious =
+            !isBulkExport &&
+            this._lastMinedSubtitle !== undefined &&
+            this._lastMinedSubtitle.start === subtitle.start &&
+            this._lastMinedSubtitle.end === subtitle.end;
+
+        if (this.takeScreenshot && !isSameSubtitleAsPrevious) {
             await this._prepareScreenshot();
         }
 
@@ -1272,7 +1279,7 @@ export default class Binding {
             return;
         }
 
-        if (this.recordMedia) {
+        if (this.recordMedia && !isSameSubtitleAsPrevious) {
             this.recordingState = RecordingState.requested;
             this.recordingPostMineAction = postMineAction;
             this.wasPlayingBeforeRecordingMedia = !this.video.paused;
@@ -1282,6 +1289,8 @@ export default class Binding {
             this.seek(start / 1000);
             await this.play();
         }
+
+        this._lastMinedSubtitle = subtitle;
 
         if (!text || subtitle.text.includes(text.trim())) {
             text = extractText(subtitle, surroundingSubtitles);
@@ -1310,6 +1319,7 @@ export default class Binding {
                 word,
                 customFieldValues,
                 isBulkExport,
+                useCachedMedia: isSameSubtitleAsPrevious,
                 ...this._imageCaptureParams,
             },
             src: this.video.src,
@@ -1438,6 +1448,10 @@ export default class Binding {
         };
 
         browser.runtime.sendMessage(command);
+    }
+
+    clearMediaCache() {
+        this._lastMinedSubtitle = undefined;
     }
 
     seek(timestamp: number) {

--- a/extension/src/services/media-cache.test.ts
+++ b/extension/src/services/media-cache.test.ts
@@ -1,0 +1,204 @@
+import MediaCache from './media-cache';
+import { AudioModel, ImageModel } from '@project/common';
+
+describe('MediaCache', () => {
+    let cache: MediaCache;
+
+    beforeEach(() => {
+        cache = new MediaCache();
+    });
+
+    describe('key generation', () => {
+        it('generates key from tabId and src', () => {
+            const key = cache.key(123, 'https://example.com/video.mp4');
+            expect(key).toBe('123:https://example.com/video.mp4');
+        });
+
+        it('generates different keys for different tabs', () => {
+            const key1 = cache.key(123, 'https://example.com/video.mp4');
+            const key2 = cache.key(456, 'https://example.com/video.mp4');
+            expect(key1).not.toBe(key2);
+        });
+
+        it('generates different keys for different sources', () => {
+            const key1 = cache.key(123, 'https://example.com/video1.mp4');
+            const key2 = cache.key(123, 'https://example.com/video2.mp4');
+            expect(key1).not.toBe(key2);
+        });
+    });
+
+    describe('get and set', () => {
+        it('returns undefined for non-existent key', () => {
+            const result = cache.get('123:https://example.com/video.mp4');
+            expect(result).toBeUndefined();
+        });
+
+        it('stores and retrieves audio model', () => {
+            const key = cache.key(123, 'https://example.com/video.mp4');
+            const audioModel: AudioModel = {
+                base64: 'mockBase64Audio',
+                extension: 'mp3',
+                paddingStart: 0,
+                paddingEnd: 0,
+                start: 1000,
+                end: 2000,
+                playbackRate: 1,
+            };
+
+            cache.set(key, {
+                subtitleStart: 1000,
+                subtitleEnd: 2000,
+                audioModel,
+            });
+
+            const result = cache.get(key);
+            expect(result).toBeDefined();
+            expect(result?.audioModel).toEqual(audioModel);
+            expect(result?.subtitleStart).toBe(1000);
+            expect(result?.subtitleEnd).toBe(2000);
+        });
+
+        it('stores and retrieves image model', () => {
+            const key = cache.key(123, 'https://example.com/video.mp4');
+            const imageModel: ImageModel = {
+                base64: 'mockBase64Image',
+                extension: 'jpeg',
+            };
+
+            cache.set(key, {
+                subtitleStart: 1000,
+                subtitleEnd: 2000,
+                imageModel,
+            });
+
+            const result = cache.get(key);
+            expect(result).toBeDefined();
+            expect(result?.imageModel).toEqual(imageModel);
+        });
+
+        it('stores and retrieves both audio and image models', () => {
+            const key = cache.key(123, 'https://example.com/video.mp4');
+            const audioModel: AudioModel = {
+                base64: 'mockBase64Audio',
+                extension: 'mp3',
+                paddingStart: 0,
+                paddingEnd: 0,
+                start: 1000,
+                end: 2000,
+                playbackRate: 1,
+            };
+            const imageModel: ImageModel = {
+                base64: 'mockBase64Image',
+                extension: 'jpeg',
+            };
+
+            cache.set(key, {
+                subtitleStart: 1000,
+                subtitleEnd: 2000,
+                audioModel,
+                imageModel,
+            });
+
+            const result = cache.get(key);
+            expect(result).toBeDefined();
+            expect(result?.audioModel).toEqual(audioModel);
+            expect(result?.imageModel).toEqual(imageModel);
+        });
+
+        it('overwrites previous value for same key', () => {
+            const key = cache.key(123, 'https://example.com/video.mp4');
+
+            cache.set(key, {
+                subtitleStart: 1000,
+                subtitleEnd: 2000,
+            });
+
+            cache.set(key, {
+                subtitleStart: 3000,
+                subtitleEnd: 4000,
+            });
+
+            const result = cache.get(key);
+            expect(result?.subtitleStart).toBe(3000);
+            expect(result?.subtitleEnd).toBe(4000);
+        });
+    });
+
+    describe('multiple tabs and sources', () => {
+        it('isolates cache by tab and source', () => {
+            const key1 = cache.key(123, 'https://example.com/video1.mp4');
+            const key2 = cache.key(456, 'https://example.com/video2.mp4');
+
+            cache.set(key1, {
+                subtitleStart: 1000,
+                subtitleEnd: 2000,
+            });
+
+            cache.set(key2, {
+                subtitleStart: 3000,
+                subtitleEnd: 4000,
+            });
+
+            const result1 = cache.get(key1);
+            const result2 = cache.get(key2);
+
+            expect(result1?.subtitleStart).toBe(1000);
+            expect(result2?.subtitleStart).toBe(3000);
+        });
+
+        it('maintains separate caches for same video in different tabs', () => {
+            const key1 = cache.key(123, 'https://example.com/video.mp4');
+            const key2 = cache.key(456, 'https://example.com/video.mp4');
+
+            const audioModel1: AudioModel = {
+                base64: 'audio1',
+                extension: 'mp3',
+                paddingStart: 0,
+                paddingEnd: 0,
+                start: 1000,
+                end: 2000,
+                playbackRate: 1,
+            };
+
+            const audioModel2: AudioModel = {
+                base64: 'audio2',
+                extension: 'mp3',
+                paddingStart: 0,
+                paddingEnd: 0,
+                start: 3000,
+                end: 4000,
+                playbackRate: 1,
+            };
+
+            cache.set(key1, {
+                subtitleStart: 1000,
+                subtitleEnd: 2000,
+                audioModel: audioModel1,
+            });
+
+            cache.set(key2, {
+                subtitleStart: 3000,
+                subtitleEnd: 4000,
+                audioModel: audioModel2,
+            });
+
+            expect(cache.get(key1)?.audioModel?.base64).toBe('audio1');
+            expect(cache.get(key2)?.audioModel?.base64).toBe('audio2');
+        });
+    });
+
+    describe('subtitle timing', () => {
+        it('stores subtitle start and end times', () => {
+            const key = cache.key(123, 'https://example.com/video.mp4');
+
+            cache.set(key, {
+                subtitleStart: 12345,
+                subtitleEnd: 67890,
+            });
+
+            const result = cache.get(key);
+            expect(result?.subtitleStart).toBe(12345);
+            expect(result?.subtitleEnd).toBe(67890);
+        });
+    });
+});

--- a/extension/src/services/media-cache.ts
+++ b/extension/src/services/media-cache.ts
@@ -1,0 +1,24 @@
+import { AudioModel, ImageModel } from '@project/common';
+
+export interface CachedMediaRecord {
+    subtitleStart: number;
+    subtitleEnd: number;
+    audioModel?: AudioModel;
+    imageModel?: ImageModel;
+}
+
+export default class MediaCache {
+    private readonly _byTab = new Map<string, CachedMediaRecord>();
+
+    key(tabId: number, src: string) {
+        return `${tabId}:${src}`;
+    }
+
+    get(key: string): CachedMediaRecord | undefined {
+        return this._byTab.get(key);
+    }
+
+    set(key: string, record: CachedMediaRecord) {
+        this._byTab.set(key, record);
+    }
+}

--- a/extension/src/services/subtitle-media-caching.test.ts
+++ b/extension/src/services/subtitle-media-caching.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Integration tests documenting the subtitle media caching behavior.
+ *
+ * Feature: When mining the same subtitle multiple times, the audio and screenshot
+ * are cached to avoid re-recording. The "Clear cached media" button allows users
+ * to re-record and update the cache.
+ */
+
+import MediaCache from './media-cache';
+import { AudioModel, ImageModel, SubtitleModel } from '@project/common';
+
+describe('Subtitle Media Caching Integration', () => {
+    let cache: MediaCache;
+    const tabId = 123;
+    const videoSrc = 'https://example.com/video.mp4';
+
+    const createSubtitle = (start: number, end: number, text: string): SubtitleModel => ({
+        text,
+        start,
+        end,
+        originalStart: start,
+        originalEnd: end,
+        track: 0,
+    });
+
+    const createAudioModel = (label: string): AudioModel => ({
+        base64: `audio-${label}`,
+        extension: 'mp3',
+        paddingStart: 0,
+        paddingEnd: 0,
+        start: 1000,
+        end: 2000,
+        playbackRate: 1,
+    });
+
+    const createImageModel = (label: string): ImageModel => ({
+        base64: `image-${label}`,
+        extension: 'jpeg',
+    });
+
+    beforeEach(() => {
+        cache = new MediaCache();
+    });
+
+    describe('Initial mine behavior', () => {
+        it('records fresh media for first mine of a subtitle', () => {
+            const key = cache.key(tabId, videoSrc);
+            const subtitle = createSubtitle(1000, 2000, 'Hello');
+
+            // First mine: no cache exists
+            expect(cache.get(key)).toBeUndefined();
+
+            // After recording, media is cached
+            const audio = createAudioModel('initial');
+            const image = createImageModel('initial');
+
+            cache.set(key, {
+                subtitleStart: subtitle.start,
+                subtitleEnd: subtitle.end,
+                audioModel: audio,
+                imageModel: image,
+            });
+
+            const cached = cache.get(key);
+            expect(cached).toBeDefined();
+            expect(cached?.audioModel?.base64).toBe('audio-initial');
+            expect(cached?.imageModel?.base64).toBe('image-initial');
+        });
+    });
+
+    describe('Repeated mine behavior', () => {
+        it('reuses cached media when mining the same subtitle again', () => {
+            const key = cache.key(tabId, videoSrc);
+            const subtitle = createSubtitle(1000, 2000, 'Hello');
+
+            // First mine: cache media
+            const audio1 = createAudioModel('first-recording');
+            const image1 = createImageModel('first-recording');
+            cache.set(key, {
+                subtitleStart: subtitle.start,
+                subtitleEnd: subtitle.end,
+                audioModel: audio1,
+                imageModel: image1,
+            });
+
+            // Second mine of same subtitle: check cache first
+            const cached = cache.get(key);
+            const isSameSubtitle =
+                cached !== undefined && cached.subtitleStart === subtitle.start && cached.subtitleEnd === subtitle.end;
+
+            expect(isSameSubtitle).toBe(true);
+            expect(cached?.audioModel?.base64).toBe('audio-first-recording');
+            expect(cached?.imageModel?.base64).toBe('image-first-recording');
+        });
+
+        it('does not reuse cache for different subtitle', () => {
+            const key = cache.key(tabId, videoSrc);
+
+            // Cache first subtitle
+            cache.set(key, {
+                subtitleStart: 1000,
+                subtitleEnd: 2000,
+                audioModel: createAudioModel('first'),
+                imageModel: createImageModel('first'),
+            });
+
+            // Mining a different subtitle (different timing)
+            const differentSubtitle = createSubtitle(3000, 4000, 'World');
+            const cached = cache.get(key);
+            const isSameSubtitle =
+                cached !== undefined &&
+                cached.subtitleStart === differentSubtitle.start &&
+                cached.subtitleEnd === differentSubtitle.end;
+
+            expect(isSameSubtitle).toBe(false);
+        });
+    });
+
+    describe('Clear cache behavior', () => {
+        it('allows re-recording after cache is updated', () => {
+            const key = cache.key(tabId, videoSrc);
+            const subtitle = createSubtitle(1000, 2000, 'Hello');
+
+            // Initial mine
+            cache.set(key, {
+                subtitleStart: subtitle.start,
+                subtitleEnd: subtitle.end,
+                audioModel: createAudioModel('initial'),
+                imageModel: createImageModel('initial'),
+            });
+
+            // User presses "Clear cached media" button -> re-records
+            // The re-record updates the cache with new media
+            const newAudio = createAudioModel('re-recorded');
+            const newImage = createImageModel('re-recorded');
+            cache.set(key, {
+                subtitleStart: subtitle.start,
+                subtitleEnd: subtitle.end,
+                audioModel: newAudio,
+                imageModel: newImage,
+            });
+
+            // Next mine of same subtitle uses the updated cache
+            const cached = cache.get(key);
+            expect(cached?.audioModel?.base64).toBe('audio-re-recorded');
+            expect(cached?.imageModel?.base64).toBe('image-re-recorded');
+        });
+    });
+
+    describe('Multi-tab isolation', () => {
+        it('maintains separate caches for same video in different tabs', () => {
+            const tab1Key = cache.key(123, videoSrc);
+            const tab2Key = cache.key(456, videoSrc);
+            const subtitle = createSubtitle(1000, 2000, 'Hello');
+
+            // Tab 1: mine and cache
+            cache.set(tab1Key, {
+                subtitleStart: subtitle.start,
+                subtitleEnd: subtitle.end,
+                audioModel: createAudioModel('tab1'),
+            });
+
+            // Tab 2: mine same subtitle, no cache exists
+            expect(cache.get(tab2Key)).toBeUndefined();
+
+            // Tab 2: mine and cache
+            cache.set(tab2Key, {
+                subtitleStart: subtitle.start,
+                subtitleEnd: subtitle.end,
+                audioModel: createAudioModel('tab2'),
+            });
+
+            // Both tabs have independent caches
+            expect(cache.get(tab1Key)?.audioModel?.base64).toBe('audio-tab1');
+            expect(cache.get(tab2Key)?.audioModel?.base64).toBe('audio-tab2');
+        });
+
+        it('maintains separate caches for different videos in same tab', () => {
+            const video1Key = cache.key(tabId, 'https://example.com/video1.mp4');
+            const video2Key = cache.key(tabId, 'https://example.com/video2.mp4');
+            const subtitle = createSubtitle(1000, 2000, 'Hello');
+
+            cache.set(video1Key, {
+                subtitleStart: subtitle.start,
+                subtitleEnd: subtitle.end,
+                audioModel: createAudioModel('video1'),
+            });
+
+            cache.set(video2Key, {
+                subtitleStart: subtitle.start,
+                subtitleEnd: subtitle.end,
+                audioModel: createAudioModel('video2'),
+            });
+
+            expect(cache.get(video1Key)?.audioModel?.base64).toBe('audio-video1');
+            expect(cache.get(video2Key)?.audioModel?.base64).toBe('audio-video2');
+        });
+    });
+
+    describe('Edge cases', () => {
+        it('handles cache with only audio', () => {
+            const key = cache.key(tabId, videoSrc);
+            cache.set(key, {
+                subtitleStart: 1000,
+                subtitleEnd: 2000,
+                audioModel: createAudioModel('audio-only'),
+            });
+
+            const cached = cache.get(key);
+            expect(cached?.audioModel).toBeDefined();
+            expect(cached?.imageModel).toBeUndefined();
+        });
+
+        it('handles cache with only image', () => {
+            const key = cache.key(tabId, videoSrc);
+            cache.set(key, {
+                subtitleStart: 1000,
+                subtitleEnd: 2000,
+                imageModel: createImageModel('image-only'),
+            });
+
+            const cached = cache.get(key);
+            expect(cached?.imageModel).toBeDefined();
+            expect(cached?.audioModel).toBeUndefined();
+        });
+
+        it('handles empty cache record', () => {
+            const key = cache.key(tabId, videoSrc);
+            cache.set(key, {
+                subtitleStart: 1000,
+                subtitleEnd: 2000,
+            });
+
+            const cached = cache.get(key);
+            expect(cached).toBeDefined();
+            expect(cached?.audioModel).toBeUndefined();
+            expect(cached?.imageModel).toBeUndefined();
+            expect(cached?.subtitleStart).toBe(1000);
+            expect(cached?.subtitleEnd).toBe(2000);
+        });
+    });
+});

--- a/extension/src/ui/components/AnkiUi.tsx
+++ b/extension/src/ui/components/AnkiUi.tsx
@@ -234,6 +234,27 @@ export default function AnkiUi({ bridge }: Props) {
         bridge.sendMessageFromServer(message);
     }, [bridge, savedState]);
 
+    const handleClearMediaCache = useCallback(() => {
+        setOpen(false);
+        const state = savedState();
+        const fullInterval = [state.subtitle.start, state.subtitle.end];
+        const resetState = {
+            ...state,
+            timestampInterval: fullInterval,
+            initialTimestampInterval: fullInterval,
+            lastAppliedTimestampIntervalToText: fullInterval,
+            lastAppliedTimestampIntervalToAudio: fullInterval,
+        };
+        const message: AnkiUiBridgeRerecordMessage = {
+            command: 'rerecord',
+            uiState: resetState,
+            recordStart: state.subtitle.start,
+            recordEnd: state.subtitle.end,
+            clearMediaCache: true,
+        };
+        bridge.sendMessageFromServer(message);
+    }, [bridge, savedState]);
+
     const handleOpenSettings = useCallback(() => {
         bridge.sendMessageFromServer({ command: 'openSettings' });
     }, [bridge]);
@@ -372,6 +393,7 @@ export default function AnkiUi({ bridge }: Props) {
                         anki={anki}
                         onProceed={handleProceed}
                         onRerecord={canRerecord ? handleRerecord : undefined}
+                        onClearMediaCache={canRerecord ? handleClearMediaCache : undefined}
                         onCancel={handleCancel}
                         onOpenSettings={handleOpenSettings}
                         onCopyToClipboard={handleCopyToClipboard}

--- a/loc/notes.json
+++ b/loc/notes.json
@@ -40,6 +40,7 @@
         "ankiDialog.imageFileLinkLost": "File link, or \"file reference.\" \"Page reload\" in the context of the browser.",
         "ankiDialog.openInAnki": "Button that opens  Anki's card creator with the contents of asbplayer's card creator.",
         "ankiDialog.rerecord": "Button to re-record audio.",
+        "ankiDialog.clearMediaCache": "Button to clear the cached audio/screenshot so the next mine of the same subtitle records fresh media.",
         "ankiDialog.resetSlider": "Button to reset the time-interval selector to it's initial state.",
         "ankiDialog.rewind": "Button that rewinds the video back to beginning of the subtitle that is currently in the card creator.",
         "ankiDialog.searchInAnki": "Button that queries the user's Anki deck for cards that already contain a particular word.",


### PR DESCRIPTION
Should cache the last recorded subtitle sentence

- Add MediaCache to reuse audio and screenshot from a previous mine when the same subtitle is mined again. 
- Add a "Clear cached media" toolbar button in the Anki dialog that clears the cache and immediately re-records the full subtitle from scratch.

Should fix
https://github.com/asbplayer/asbplayer/issues/914
https://github.com/asbplayer/asbplayer/issues/842

Demo:

Video is low quality (GitHub restrictions for file size so converted to gif)

But you can see here

1. Media for a subtitle is cached
2. When using re-recording media with custom timeline is also cached
3. When pressing clear cached media, the whole subtitle is re-recorded with initial timelines(not adjusted manually)

I think maybe it's better to move the clear cached media button somewhere else, and change the icon, but so far it's just a POC, open to suggestions

<img width="480" height="272" alt="ezgif-3359b6390a6a90e3" src="https://github.com/user-attachments/assets/62d64f33-2de7-4ba0-b6fa-83ad871197a9" />


I am new for asbplayer code, so this feature is 
Assisted-by: Claude Sonnet 4.6

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

