### PR TITLE
project Anki and WaniKani stats on past/future material

### DIFF
--- a/common/anki/anki.ts
+++ b/common/anki/anki.ts
@@ -249,7 +249,7 @@ export interface CardInfo {
     ord: number;
     type: number;
     queue: number;
-    due: number;
+    due: number; // This cannot be used to get the due date because it's relative to the Anki db creation time which AnkiConnect doesn't expose
     reps: number;
     lapses: number;
     left: number;

--- a/common/components/DictionarySettingsTab.tsx
+++ b/common/components/DictionarySettingsTab.tsx
@@ -425,6 +425,8 @@ const DictionarySettingsTab: React.FC<Props> = ({
     const [waniKaniUserInfo, setWaniKaniUserInfo] = useState<WaniKaniUser>();
     const [pendingDictionaryWaniKaniApiToken, setPendingDictionaryWaniKaniApiToken] = useState<string>();
     const [showDictionaryWaniKaniApiToken, setShowDictionaryWaniKaniApiToken] = useState(false);
+    const dictionaryWaniKaniApiTokenVisible =
+        showDictionaryWaniKaniApiToken || !selectedDictionary.dictionaryWaniKaniApiToken;
     const waniKaniUserInfoRequestId = useRef(0);
     const waniKaniUserInfoApiToken = useRef<string | undefined>(undefined);
     const waniKaniUserInfoRequest = useRef<{ apiToken: string; promise: Promise<WaniKaniUser> } | undefined>(undefined);
@@ -1619,7 +1621,7 @@ const DictionarySettingsTab: React.FC<Props> = ({
                             type="text"
                             label={t('settings.dictionaryWaniKaniApiToken')}
                             value={
-                                showDictionaryWaniKaniApiToken || !selectedDictionary.dictionaryWaniKaniApiToken
+                                dictionaryWaniKaniApiTokenVisible
                                     ? selectedDictionary.dictionaryWaniKaniApiToken
                                     : maskedDictionaryWaniKaniApiToken
                             }
@@ -1645,7 +1647,7 @@ const DictionarySettingsTab: React.FC<Props> = ({
                             }}
                             slotProps={{
                                 input: {
-                                    readOnly: !showDictionaryWaniKaniApiToken,
+                                    readOnly: !dictionaryWaniKaniApiTokenVisible,
                                     endAdornment: (
                                         <InputAdornment position="end">
                                             <Tooltip title="">
@@ -1655,7 +1657,7 @@ const DictionarySettingsTab: React.FC<Props> = ({
                                                     }
                                                     onMouseDown={(event) => event.preventDefault()}
                                                 >
-                                                    {showDictionaryWaniKaniApiToken ? (
+                                                    {dictionaryWaniKaniApiTokenVisible ? (
                                                         <VisibilityOffIcon />
                                                     ) : (
                                                         <VisibilityIcon />

--- a/common/components/Statistics.tsx
+++ b/common/components/Statistics.tsx
@@ -17,6 +17,9 @@ import {
     percent,
     percentDisplay,
     DictionaryStatisticsSnapshot,
+    DictionaryStatisticsRewatchProjection,
+    DictionaryStatisticsRewatchProjectionsByTrack,
+    DictionaryStatisticsRewatchSnapshot,
     processDictionaryStatisticsAnkiTrackSnapshot,
     processDictionaryStatisticsSnapshot,
     processDictionaryStatisticsWaniKaniTrackSnapshot,
@@ -38,6 +41,7 @@ import IconButton from '@mui/material/IconButton';
 import LinearProgress from '@mui/material/LinearProgress';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
+import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography, { type TypographyProps } from '@mui/material/Typography';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
@@ -50,6 +54,8 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PictureInPictureAltIcon from '@mui/icons-material/PictureInPictureAlt';
 import Link from '@mui/material/Link';
+import { WaniKani, type WaniKaniUser } from '@project/common/wanikani';
+import SwitchLabelWithHoverEffect from './SwitchLabelWithHoverEffect';
 
 export interface MediaInfo {
     sourceString: string;
@@ -467,6 +473,8 @@ interface SentenceStatsPanelProps {
     globalKnownCount: number;
     onOpenSentenceBucketDetails: (bucket: DictionaryStatisticsSentenceDialogBucket) => void;
     headerAction?: ReactNode;
+    extraStats?: ReactNode;
+    hideStats?: boolean;
     sentenceFiltersPosition: 'top' | 'bottom';
     emptyMessage?: string;
 }
@@ -529,6 +537,219 @@ function StatBoxes({ keyPrefix, stats }: StatBoxesProps) {
     );
 }
 
+const maxWaniKaniLevelFallback = 60;
+
+function clampIntegerInput(value: string, min: number, max: number) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed)) return min;
+    return Math.max(min, Math.min(max, parsed));
+}
+
+function useWaniKaniUserInfo(apiToken: string) {
+    const [userInfo, setUserInfo] = useState<WaniKaniUser>();
+    const [error, setError] = useState<string>();
+
+    useEffect(() => {
+        const trimmedApiToken = apiToken.trim();
+        setUserInfo(undefined);
+        setError(undefined);
+        if (!trimmedApiToken) return;
+
+        let canceled = false;
+        void new WaniKani(trimmedApiToken)
+            .user()
+            .then((user) => {
+                if (!canceled) setUserInfo(user);
+            })
+            .catch((error) => {
+                if (!canceled) setError(error instanceof Error ? error.message : String(error));
+            });
+
+        return () => {
+            canceled = true;
+        };
+    }, [apiToken]);
+
+    return { userInfo, error };
+}
+
+type KnowledgeStatsSnapshot = Pick<DictionaryStatisticsRewatchSnapshot, 'ankiDeckStats' | 'waniKaniStats'>;
+
+function KnowledgeStats({ snapshot }: { snapshot: KnowledgeStatsSnapshot }) {
+    const { t } = useTranslation();
+
+    if (!snapshot.ankiDeckStats.length && snapshot.waniKaniStats === undefined) return null;
+
+    return (
+        <Stack spacing={1} sx={{ mt: 0.5 }}>
+            {snapshot.ankiDeckStats.length > 0 && (
+                <Box>
+                    <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                        {t('statistics.anki.knownDeckWords')}
+                    </Typography>
+                    <Stack spacing={0.5}>
+                        {snapshot.ankiDeckStats.map((deckStats) => (
+                            <StatRow
+                                key={deckStats.deckName}
+                                label={deckStats.deckName}
+                                value={`${deckStats.knownWords} / ${deckStats.totalWords}`}
+                            />
+                        ))}
+                    </Stack>
+                </Box>
+            )}
+            {snapshot.waniKaniStats !== undefined && (
+                <Box>
+                    <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                        {t('statistics.waniKani.projectedWords')}
+                    </Typography>
+                    <StatRow
+                        label={
+                            snapshot.waniKaniStats.level === undefined
+                                ? t('statistics.waniKani.currentKnowledge')
+                                : t('statistics.waniKani.projectedLevel', { level: snapshot.waniKaniStats.level })
+                        }
+                        value={`${snapshot.waniKaniStats.knownWords} / ${snapshot.waniKaniStats.totalWords}`}
+                    />
+                </Box>
+            )}
+        </Stack>
+    );
+}
+
+function ProjectedRewatchControls({
+    rewatchSnapshots,
+    selectedRewatch,
+    totalUnknownAnkiCards,
+    projection,
+    waniKaniApiToken,
+    onSelectedRewatchChanged,
+    onProjectionChanged,
+}: {
+    rewatchSnapshots: DictionaryStatisticsTrackSnapshot['rewatchSnapshots'];
+    selectedRewatch: number;
+    totalUnknownAnkiCards: number;
+    projection: DictionaryStatisticsRewatchProjection;
+    waniKaniApiToken: string;
+    onSelectedRewatchChanged: (rewatch: number) => void;
+    onProjectionChanged: (projection: DictionaryStatisticsRewatchProjection) => void;
+}) {
+    const { t } = useTranslation();
+    const { userInfo: waniKaniUserInfo, error: waniKaniUserInfoError } = useWaniKaniUserInfo(waniKaniApiToken);
+    const ankiUnknownCards = projection.ankiUnknownCards ?? 0;
+    const ankiLearningOrAboveIsMature = projection.ankiLearningOrAboveIsMature ?? false;
+    const waniKaniLevel = projection.waniKaniLevel;
+    const maxWaniKaniLevel = waniKaniUserInfo?.data.subscription.max_level_granted ?? maxWaniKaniLevelFallback;
+    const waniKaniHelperText = waniKaniUserInfo
+        ? `${waniKaniUserInfo.data.username}: ${waniKaniUserInfo.data.level}/${maxWaniKaniLevel}`
+        : waniKaniUserInfoError;
+
+    const updateProjection = useCallback(
+        (patch: DictionaryStatisticsRewatchProjection) => onProjectionChanged({ ...projection, ...patch }),
+        [onProjectionChanged, projection]
+    );
+
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 1,
+            }}
+        >
+            <TextField
+                select
+                fullWidth
+                size="small"
+                value={selectedRewatch}
+                label={t('statistics.rewatchSelect')}
+                onChange={(event) => onSelectedRewatchChanged(Number(event.target.value))}
+            >
+                {rewatchSnapshots.map((rewatchSnapshot) => (
+                    <MenuItem key={rewatchSnapshot.rewatch} value={rewatchSnapshot.rewatch}>
+                        {t('statistics.rewatchOption', {
+                            rewatch: rewatchSnapshot.rewatch,
+                        })}
+                    </MenuItem>
+                ))}
+            </TextField>
+            <Box
+                sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+                    gap: 1,
+                }}
+            >
+                <TextField
+                    type="number"
+                    size="small"
+                    fullWidth
+                    label={t('statistics.anki.projectNewCards')}
+                    value={ankiUnknownCards}
+                    helperText={t('statistics.anki.projectNewCardsHelper', {
+                        count: totalUnknownAnkiCards,
+                    })}
+                    onChange={(event) =>
+                        updateProjection({
+                            ankiUnknownCards: clampIntegerInput(event.target.value, 0, totalUnknownAnkiCards),
+                        })
+                    }
+                    slotProps={{
+                        htmlInput: {
+                            min: 0,
+                            max: totalUnknownAnkiCards,
+                            inputMode: 'numeric',
+                            pattern: '[0-9]*',
+                        },
+                    }}
+                />
+                <TextField
+                    type="number"
+                    size="small"
+                    fullWidth
+                    label={t('statistics.waniKani.projectLevel')}
+                    value={waniKaniLevel ?? ''}
+                    helperText={waniKaniHelperText}
+                    error={Boolean(waniKaniUserInfoError)}
+                    onChange={(event) => {
+                        if (event.target.value === '') {
+                            updateProjection({ waniKaniLevel: undefined });
+                            return;
+                        }
+
+                        updateProjection({
+                            waniKaniLevel: clampIntegerInput(event.target.value, 1, maxWaniKaniLevel),
+                        });
+                    }}
+                    slotProps={{
+                        htmlInput: {
+                            min: 1,
+                            max: maxWaniKaniLevel,
+                            inputMode: 'numeric',
+                            pattern: '[0-9]*',
+                        },
+                    }}
+                />
+            </Box>
+            <SwitchLabelWithHoverEffect
+                control={
+                    <Switch
+                        checked={ankiLearningOrAboveIsMature}
+                        onChange={(event) =>
+                            updateProjection({
+                                ankiLearningOrAboveIsMature: event.target.checked,
+                            })
+                        }
+                    />
+                }
+                label={t('statistics.anki.projectReviewedCards')}
+                labelPlacement="start"
+                sx={{ width: '100%', mt: -0.25 }}
+            />
+        </Box>
+    );
+}
+
 function SentenceStatsPanel({
     title,
     infoLines,
@@ -549,6 +770,8 @@ function SentenceStatsPanel({
     globalKnownLabel,
     globalKnownCount,
     headerAction,
+    extraStats,
+    hideStats,
     sentenceFiltersPosition,
     emptyMessage,
     onOpenSentenceBucketDetails,
@@ -677,7 +900,7 @@ function SentenceStatsPanel({
                     </Box>
                 </Box>
                 {headerAction && <Box sx={{ mb: 1.5 }}>{headerAction}</Box>}
-                {emptyMessage ? (
+                {hideStats ? null : emptyMessage ? (
                     <Typography typography="body2" color="text.secondary">
                         {emptyMessage}
                     </Typography>
@@ -685,6 +908,7 @@ function SentenceStatsPanel({
                     <>
                         {sentenceFiltersPosition === 'top' && sentenceFilterRows}
                         {statRows}
+                        {extraStats}
                         {sentenceFiltersPosition === 'bottom' && sentenceFilterRows}
                     </>
                 )}
@@ -1025,13 +1249,17 @@ function TrackSnapshot({
     trackSnapshot,
     statisticsSnapshot,
     selectedRewatchesByTrack,
+    rewatchProjection,
     onSelectedRewatchChanged,
+    onRewatchProjectionChanged,
     onSentenceDialogState,
 }: {
     trackSnapshot: DictionaryStatisticsTrackSnapshot;
     statisticsSnapshot: DictionaryStatisticsSnapshot;
     selectedRewatchesByTrack: Record<number, number>;
+    rewatchProjection: DictionaryStatisticsRewatchProjection;
     onSelectedRewatchChanged: (track: number, rewatch: number) => void;
+    onRewatchProjectionChanged: (track: number, projection: DictionaryStatisticsRewatchProjection) => void;
     onSentenceDialogState: (state: SentenceDialogState) => void;
 }) {
     const { t } = useTranslation();
@@ -1053,7 +1281,14 @@ function TrackSnapshot({
         [t]
     );
     const sentenceStatisticsInfoLines = useMemo(() => [t('statistics.info.sentenceStatistics')], [t]);
-    const projectedRewatchInfoLines = useMemo(() => [t('statistics.info.projectedRewatch')], [t]);
+    const projectedRewatchInfoLines = useMemo(
+        () => [
+            `${t('statistics.rewatchSelect')}: ${t('statistics.info.projectedRewatch')}`,
+            `${t('settings.anki')}: ${t('statistics.anki.info.projectedCards')}`,
+            `${t('settings.dictionaryWaniKaniSection')}: ${t('statistics.waniKani.info.projectedLevel')}`,
+        ],
+        [t]
+    );
     const uniqueWordsPerSentenceLabel = t('statistics.uniqueWordsPerSentence');
     const knownWordsPerSentenceLabel = t('statistics.knownWordsPerSentence');
     const uncollectedLabel = statusLabels[TokenStatus.UNCOLLECTED];
@@ -1071,10 +1306,11 @@ function TrackSnapshot({
     const emptyDeckBreakdownMessage = t('statistics.anki.noDeckBreakdown');
     const waniKaniUnavailableMessage = t('statistics.waniKani.waniKaniNeedsToBeAvailable');
     const emptyWaniKaniBreakdownMessage = t('statistics.waniKani.noWaniKaniBreakdown');
+    const dictionaryWaniKaniApiToken =
+        statisticsSnapshot.settings.dictionaryTracks[trackSnapshot.track]?.dictionaryWaniKaniApiToken ?? '';
 
     const totalSentences = trackSnapshot.progress.total;
     const selectedRewatchSnapshot = selectedRewatchSnapshotForTrack(trackSnapshot, selectedRewatchesByTrack);
-    const maxRewatches = trackSnapshot.rewatchSnapshots.length;
     const projectedSentenceBuckets = selectedRewatchSnapshot?.sentenceBuckets ?? emptySentenceBuckets;
     const projectedKnownCount = selectedRewatchSnapshot?.numKnownTokens ?? 0;
     const projectedGlobalKnownCount = selectedRewatchSnapshot?.numDictionaryKnownTokens ?? 0;
@@ -1082,6 +1318,11 @@ function TrackSnapshot({
     const projectedAverageKnownWordsPerSentence = selectedRewatchSnapshot?.averageKnownWordsPerSentence ?? 0;
     const projectedKnownPercent = selectedRewatchSnapshot?.knownPercent ?? 0;
     const projectedComprehension = selectedRewatchSnapshot?.comprehensionPercent ?? 0;
+    const hasProjectedKnowledge =
+        (rewatchProjection.ankiUnknownCards ?? 0) > 0 ||
+        (rewatchProjection.ankiLearningOrAboveIsMature ?? false) ||
+        (rewatchProjection.waniKaniLevel !== undefined && rewatchProjection.waniKaniLevel > 0);
+    const hideProjectedStats = selectedRewatchSnapshot?.rewatch === 0 && !hasProjectedKnowledge;
     const miningEnabled = trackSnapshot.progress.current >= trackSnapshot.progress.total;
     const ankiTrackSnapshot = processDictionaryStatisticsAnkiTrackSnapshot(statisticsSnapshot, trackSnapshot.track);
     const waniKaniTrackSnapshot = processDictionaryStatisticsWaniKaniTrackSnapshot(
@@ -1313,6 +1554,7 @@ function TrackSnapshot({
                         comprehensionPercent={trackSnapshot.comprehensionPercent}
                         globalKnownLabel={t('statistics.globalKnownWords')}
                         globalKnownCount={trackSnapshot.numDictionaryKnownTokens}
+                        extraStats={<KnowledgeStats snapshot={trackSnapshot} />}
                         sentenceFiltersPosition="top"
                         onOpenSentenceBucketDetails={(bucket) => {
                             const bucketData = sentenceDialogBucketData(bucket, trackSnapshot.sentenceBuckets, {
@@ -1333,7 +1575,7 @@ function TrackSnapshot({
                 </Box>
                 <Box>
                     <SentenceStatsPanel
-                        title={t('statistics.projectedRewatch')}
+                        title={t('statistics.projected')}
                         infoLines={projectedRewatchInfoLines}
                         totalSentences={totalSentences}
                         sentenceBuckets={projectedSentenceBuckets}
@@ -1353,27 +1595,28 @@ function TrackSnapshot({
                         globalKnownCount={projectedGlobalKnownCount}
                         headerAction={
                             selectedRewatchSnapshot !== undefined ? (
-                                <TextField
-                                    select
-                                    fullWidth
-                                    size="small"
-                                    value={selectedRewatchSnapshot.rewatch}
-                                    onChange={(event) =>
-                                        onSelectedRewatchChanged(trackSnapshot.track, Number(event.target.value))
+                                <ProjectedRewatchControls
+                                    rewatchSnapshots={trackSnapshot.rewatchSnapshots}
+                                    selectedRewatch={selectedRewatchSnapshot.rewatch}
+                                    totalUnknownAnkiCards={trackSnapshot.totalUnknownAnkiCards}
+                                    projection={rewatchProjection}
+                                    waniKaniApiToken={dictionaryWaniKaniApiToken}
+                                    onSelectedRewatchChanged={(rewatch) =>
+                                        onSelectedRewatchChanged(trackSnapshot.track, rewatch)
                                     }
-                                >
-                                    {trackSnapshot.rewatchSnapshots.map((rewatchSnapshot) => (
-                                        <MenuItem key={rewatchSnapshot.rewatch} value={rewatchSnapshot.rewatch}>
-                                            {t('statistics.rewatchOption', {
-                                                rewatch: rewatchSnapshot.rewatch,
-                                            })}
-                                        </MenuItem>
-                                    ))}
-                                </TextField>
+                                    onProjectionChanged={(projection) =>
+                                        onRewatchProjectionChanged(trackSnapshot.track, projection)
+                                    }
+                                />
                             ) : undefined
                         }
+                        extraStats={
+                            selectedRewatchSnapshot !== undefined ? (
+                                <KnowledgeStats snapshot={selectedRewatchSnapshot} />
+                            ) : undefined
+                        }
+                        hideStats={hideProjectedStats}
                         sentenceFiltersPosition="bottom"
-                        emptyMessage={maxRewatches === 0 ? t('statistics.noMoreRewatches') : undefined}
                         onOpenSentenceBucketDetails={(bucket) => {
                             if (selectedRewatchSnapshot === undefined) return;
                             const bucketData = sentenceDialogBucketData(
@@ -1464,13 +1707,22 @@ export default function Statistics({
     const { t } = useTranslation();
     const [mediaInfo, setMediaInfo] = useState<MediaInfo>();
     const [statisticsSnapshot, setStatisticsSnapshot] = useState<DictionaryStatisticsSnapshot>();
-    const [trackSnapshots, setTrackSnapshots] = useState<DictionaryStatisticsTrackSnapshot[]>();
+    const [statisticsSnapshotLoaded, setStatisticsSnapshotLoaded] = useState(false);
     const [selectedTrackSnapshotIndex, setSelectedTrackSnapshotIndex] = useState<number>(0);
     const [generationRequested, setGenerationRequested] = useState(false);
     const [selectedRewatchesByTrack, setSelectedRewatchesByTrack] = useState<Record<number, number>>({});
+    const [rewatchProjectionsByTrack, setRewatchProjectionsByTrack] =
+        useState<DictionaryStatisticsRewatchProjectionsByTrack>({});
     const [sentenceDialogState, setSentenceDialogState] = useState<SentenceDialogState>();
+    const trackSnapshots = useMemo(
+        () =>
+            statisticsSnapshotLoaded
+                ? processDictionaryStatisticsSnapshot(statisticsSnapshot, rewatchProjectionsByTrack)
+                : undefined,
+        [statisticsSnapshot, statisticsSnapshotLoaded, rewatchProjectionsByTrack]
+    );
     const hasSnapshots = trackSnapshots && trackSnapshots.length > 0;
-    const loadingSnapshots = trackSnapshots === undefined;
+    const loadingSnapshots = !statisticsSnapshotLoaded;
     const allTrackProgressComplete = useMemo(
         () => hasSnapshots && trackSnapshots.every((s) => s.progress.current >= s.progress.total),
         [hasSnapshots, trackSnapshots]
@@ -1478,12 +1730,21 @@ export default function Statistics({
     const isGenerating = generationRequested && (!hasSnapshots || !allTrackProgressComplete);
 
     useEffect(() => {
+        setMediaInfo(undefined);
+        setStatisticsSnapshot(undefined);
+        setStatisticsSnapshotLoaded(false);
+        setSelectedTrackSnapshotIndex(0);
+        setSelectedRewatchesByTrack({});
+        setRewatchProjectionsByTrack({});
+    }, [mediaId]);
+
+    useEffect(() => {
         const unsubscribeStatistics = dictionaryProvider.onStatisticsSnapshot(
             (snapshot?: DictionaryStatisticsSnapshot) => {
                 if (!snapshot) {
                     setMediaInfo(undefined);
                     setStatisticsSnapshot(undefined);
-                    setTrackSnapshots([]);
+                    setStatisticsSnapshotLoaded(true);
                     setGenerationRequested(false);
                     return;
                 }
@@ -1495,16 +1756,7 @@ export default function Statistics({
                         setMediaInfo(undefined);
                     }
                     setStatisticsSnapshot(snapshot);
-                    const nextTrackSnapshots = processDictionaryStatisticsSnapshot(snapshot);
-                    setTrackSnapshots(nextTrackSnapshots);
-                    if (
-                        nextTrackSnapshots.length &&
-                        nextTrackSnapshots.every(
-                            (trackSnapshot) => trackSnapshot.progress.current >= trackSnapshot.progress.total
-                        )
-                    ) {
-                        setGenerationRequested(false);
-                    }
+                    setStatisticsSnapshotLoaded(true);
                 }
             }
         );
@@ -1520,7 +1772,9 @@ export default function Statistics({
         };
     }, [dictionaryProvider, mediaInfoFetcher, mediaId]);
 
-    useEffect(() => setSelectedTrackSnapshotIndex(0), [mediaId]);
+    useEffect(() => {
+        if (allTrackProgressComplete) setGenerationRequested(false);
+    }, [allTrackProgressComplete]);
 
     const handleGenerate = useCallback(() => {
         setGenerationRequested(true);
@@ -1539,6 +1793,12 @@ export default function Statistics({
     const handleSelectedRewatchChanged = useCallback((track: number, rewatch: number) => {
         setSelectedRewatchesByTrack((current) => ({ ...current, [track]: rewatch }));
     }, []);
+    const handleRewatchProjectionChanged = useCallback(
+        (track: number, projection: DictionaryStatisticsRewatchProjection) => {
+            setRewatchProjectionsByTrack((current) => ({ ...current, [track]: projection }));
+        },
+        []
+    );
     const handleCloseSentenceBucketDetails = useCallback(() => setSentenceDialogState(undefined), []);
     const handleSeekSentence = useCallback(
         (sentence: DictionaryStatisticsSentence) => {
@@ -1662,8 +1922,10 @@ export default function Statistics({
                             trackSnapshot={trackSnapshot}
                             statisticsSnapshot={statisticsSnapshot}
                             onSelectedRewatchChanged={handleSelectedRewatchChanged}
+                            onRewatchProjectionChanged={handleRewatchProjectionChanged}
                             onSentenceDialogState={setSentenceDialogState}
                             selectedRewatchesByTrack={selectedRewatchesByTrack}
+                            rewatchProjection={rewatchProjectionsByTrack[trackSnapshot.track] ?? {}}
                         />
                     )}
                 </Box>

--- a/common/components/Statistics.tsx
+++ b/common/components/Statistics.tsx
@@ -445,9 +445,15 @@ function StatisticsSectionHeading({ title, infoLines }: { title: string; infoLin
     );
 }
 
-function StatisticsSectionSubHeading({ children }: { children: React.ReactNode }) {
+function StatisticsSectionSubHeading({
+    children,
+    marginBottom = 1,
+}: {
+    children: React.ReactNode;
+    marginBottom?: number;
+}) {
     return (
-        <Typography variant="body1" sx={{ mb: 1, fontWeight: 500 }}>
+        <Typography variant="body1" sx={{ mb: marginBottom, fontWeight: 500 }}>
             {children}
         </Typography>
     );
@@ -559,20 +565,10 @@ function useWaniKaniUserInfo(apiToken: string) {
         setUserInfo(undefined);
         setError(undefined);
         if (!trimmedApiToken) return;
-
-        let canceled = false;
         void new WaniKani(trimmedApiToken)
             .user()
-            .then((user) => {
-                if (!canceled) setUserInfo(user);
-            })
-            .catch((error) => {
-                if (!canceled) setError(error instanceof Error ? error.message : String(error));
-            });
-
-        return () => {
-            canceled = true;
-        };
+            .then((user) => setUserInfo(user))
+            .catch((e) => setError(e instanceof Error ? e.message : String(e)));
     }, [apiToken]);
 
     return { userInfo, error };
@@ -927,8 +923,8 @@ function SentenceStatsPanel({
         >
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, height: '100%' }}>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1, alignItems: 'flex-start' }}>
-                    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
-                        <StatisticsSectionSubHeading>{title}</StatisticsSectionSubHeading>
+                    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, mb: 1 }}>
+                        <StatisticsSectionSubHeading marginBottom={0}>{title}</StatisticsSectionSubHeading>
                         {infoLines !== undefined && <StatisticsInfoTooltip label={title} lines={infoLines} />}
                     </Box>
                 </Box>

--- a/common/components/Statistics.tsx
+++ b/common/components/Statistics.tsx
@@ -20,6 +20,7 @@ import {
     DictionaryStatisticsRewatchProjection,
     DictionaryStatisticsRewatchProjectionsByTrack,
     DictionaryStatisticsRewatchSnapshot,
+    DictionaryStatisticsAnkiUnknownCardsByDeck,
     processDictionaryStatisticsAnkiTrackSnapshot,
     processDictionaryStatisticsSnapshot,
     processDictionaryStatisticsWaniKaniTrackSnapshot,
@@ -539,6 +540,10 @@ function StatBoxes({ keyPrefix, stats }: StatBoxesProps) {
 
 const maxWaniKaniLevelFallback = 60;
 
+function hasProjectedAnkiUnknownCards(projection: DictionaryStatisticsRewatchProjection) {
+    return Object.values(projection.ankiUnknownCardsByDeck ?? {}).some((count) => count > 0);
+}
+
 function clampIntegerInput(value: string, min: number, max: number) {
     const parsed = Number.parseInt(value, 10);
     if (Number.isNaN(parsed)) return min;
@@ -620,7 +625,9 @@ function KnowledgeStats({ snapshot }: { snapshot: KnowledgeStatsSnapshot }) {
 function ProjectedRewatchControls({
     rewatchSnapshots,
     selectedRewatch,
-    totalUnknownAnkiCards,
+    unknownAnkiCardsByDeck,
+    ankiAvailable,
+    waniKaniAvailable,
     projection,
     waniKaniApiToken,
     onSelectedRewatchChanged,
@@ -628,25 +635,40 @@ function ProjectedRewatchControls({
 }: {
     rewatchSnapshots: DictionaryStatisticsTrackSnapshot['rewatchSnapshots'];
     selectedRewatch: number;
-    totalUnknownAnkiCards: number;
+    unknownAnkiCardsByDeck: DictionaryStatisticsAnkiUnknownCardsByDeck[];
+    ankiAvailable: boolean;
+    waniKaniAvailable: boolean;
     projection: DictionaryStatisticsRewatchProjection;
     waniKaniApiToken: string;
     onSelectedRewatchChanged: (rewatch: number) => void;
     onProjectionChanged: (projection: DictionaryStatisticsRewatchProjection) => void;
 }) {
     const { t } = useTranslation();
-    const { userInfo: waniKaniUserInfo, error: waniKaniUserInfoError } = useWaniKaniUserInfo(waniKaniApiToken);
-    const ankiUnknownCards = projection.ankiUnknownCards ?? 0;
+    const { userInfo: waniKaniUserInfo, error: waniKaniUserInfoError } = useWaniKaniUserInfo(
+        waniKaniAvailable ? waniKaniApiToken : ''
+    );
+    const projectedAnkiUnknownCardsByDeck = projection.ankiUnknownCardsByDeck ?? {};
     const ankiLearningOrAboveIsMature = projection.ankiLearningOrAboveIsMature ?? false;
-    const waniKaniLevel = projection.waniKaniLevel;
+    const waniKaniLevel = projection.waniKaniLevel ?? 0;
     const maxWaniKaniLevel = waniKaniUserInfo?.data.subscription.max_level_granted ?? maxWaniKaniLevelFallback;
     const waniKaniHelperText = waniKaniUserInfo
-        ? `${waniKaniUserInfo.data.username}: ${waniKaniUserInfo.data.level}/${maxWaniKaniLevel}`
-        : waniKaniUserInfoError;
+        ? ` (${waniKaniUserInfo.data.username}: ${waniKaniUserInfo.data.level}/${maxWaniKaniLevel})`
+        : '';
 
     const updateProjection = useCallback(
         (patch: DictionaryStatisticsRewatchProjection) => onProjectionChanged({ ...projection, ...patch }),
         [onProjectionChanged, projection]
+    );
+
+    const updateProjectedAnkiUnknownCardsByDeck = useCallback(
+        (deckName: string, value: string, totalUnknownCards: number) => {
+            const count = clampIntegerInput(value, 0, totalUnknownCards);
+            const ankiUnknownCardsByDeck = { ...(projection.ankiUnknownCardsByDeck ?? {}) };
+            if (count > 0) ankiUnknownCardsByDeck[deckName] = count;
+            else delete ankiUnknownCardsByDeck[deckName];
+            updateProjection({ ankiUnknownCardsByDeck });
+        },
+        [projection.ankiUnknownCardsByDeck, updateProjection]
     );
 
     return (
@@ -673,79 +695,90 @@ function ProjectedRewatchControls({
                     </MenuItem>
                 ))}
             </TextField>
-            <Box
-                sx={{
-                    display: 'grid',
-                    gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
-                    gap: 1,
-                }}
-            >
-                <TextField
-                    type="number"
-                    size="small"
-                    fullWidth
-                    label={t('statistics.anki.projectNewCards')}
-                    value={ankiUnknownCards}
-                    helperText={t('statistics.anki.projectNewCardsHelper', {
-                        count: totalUnknownAnkiCards,
-                    })}
-                    onChange={(event) =>
-                        updateProjection({
-                            ankiUnknownCards: clampIntegerInput(event.target.value, 0, totalUnknownAnkiCards),
-                        })
+            {ankiAvailable && (
+                <SwitchLabelWithHoverEffect
+                    control={
+                        <Switch
+                            checked={ankiLearningOrAboveIsMature}
+                            onChange={(event) =>
+                                updateProjection({
+                                    ankiLearningOrAboveIsMature: event.target.checked,
+                                })
+                            }
+                        />
                     }
-                    slotProps={{
-                        htmlInput: {
-                            min: 0,
-                            max: totalUnknownAnkiCards,
-                            inputMode: 'numeric',
-                            pattern: '[0-9]*',
-                        },
-                    }}
+                    label={t('statistics.anki.projectReviewedCards')}
+                    labelPlacement="start"
+                    sx={{ width: '100%', mt: -0.25 }}
                 />
-                <TextField
-                    type="number"
-                    size="small"
-                    fullWidth
-                    label={t('statistics.waniKani.projectLevel')}
-                    value={waniKaniLevel ?? ''}
-                    helperText={waniKaniHelperText}
-                    error={Boolean(waniKaniUserInfoError)}
-                    onChange={(event) => {
-                        if (event.target.value === '') {
-                            updateProjection({ waniKaniLevel: undefined });
-                            return;
-                        }
-
-                        updateProjection({
-                            waniKaniLevel: clampIntegerInput(event.target.value, 1, maxWaniKaniLevel),
-                        });
+            )}
+            {(ankiAvailable || waniKaniAvailable) && (
+                <Typography variant="caption" color="text.secondary">
+                    {t('statistics.projectMature')}
+                </Typography>
+            )}
+            {ankiAvailable && unknownAnkiCardsByDeck.length > 0 && (
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+                    <Stack spacing={1}>
+                        {unknownAnkiCardsByDeck.map(({ deckName, totalUnknownCards }) => (
+                            <TextField
+                                key={deckName}
+                                type="number"
+                                size="small"
+                                fullWidth
+                                label={`${deckName} (${t('statistics.anki.newCardsCount', { count: totalUnknownCards })})`}
+                                value={projectedAnkiUnknownCardsByDeck[deckName] ?? 0}
+                                onChange={(event) =>
+                                    updateProjectedAnkiUnknownCardsByDeck(
+                                        deckName,
+                                        event.target.value,
+                                        totalUnknownCards
+                                    )
+                                }
+                                slotProps={{
+                                    htmlInput: {
+                                        min: 0,
+                                        max: totalUnknownCards,
+                                        inputMode: 'numeric',
+                                        pattern: '[0-9]*',
+                                    },
+                                }}
+                            />
+                        ))}
+                    </Stack>
+                </Box>
+            )}
+            {waniKaniAvailable && (
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
                     }}
-                    slotProps={{
-                        htmlInput: {
-                            min: 1,
-                            max: maxWaniKaniLevel,
-                            inputMode: 'numeric',
-                            pattern: '[0-9]*',
-                        },
-                    }}
-                />
-            </Box>
-            <SwitchLabelWithHoverEffect
-                control={
-                    <Switch
-                        checked={ankiLearningOrAboveIsMature}
+                >
+                    <TextField
+                        type="number"
+                        size="small"
+                        fullWidth
+                        label={`${t('statistics.waniKani.projectLevel')}${waniKaniHelperText}`}
+                        value={waniKaniLevel}
+                        helperText={waniKaniUserInfoError}
+                        error={Boolean(waniKaniUserInfoError)}
                         onChange={(event) =>
                             updateProjection({
-                                ankiLearningOrAboveIsMature: event.target.checked,
+                                waniKaniLevel: clampIntegerInput(event.target.value, 0, maxWaniKaniLevel),
                             })
                         }
+                        slotProps={{
+                            htmlInput: {
+                                min: 0,
+                                max: maxWaniKaniLevel,
+                                inputMode: 'numeric',
+                                pattern: '[0-9]*',
+                            },
+                        }}
                     />
-                }
-                label={t('statistics.anki.projectReviewedCards')}
-                labelPlacement="start"
-                sx={{ width: '100%', mt: -0.25 }}
-            />
+                </Box>
+            )}
         </Box>
     );
 }
@@ -1318,17 +1351,20 @@ function TrackSnapshot({
     const projectedAverageKnownWordsPerSentence = selectedRewatchSnapshot?.averageKnownWordsPerSentence ?? 0;
     const projectedKnownPercent = selectedRewatchSnapshot?.knownPercent ?? 0;
     const projectedComprehension = selectedRewatchSnapshot?.comprehensionPercent ?? 0;
-    const hasProjectedKnowledge =
-        (rewatchProjection.ankiUnknownCards ?? 0) > 0 ||
-        (rewatchProjection.ankiLearningOrAboveIsMature ?? false) ||
-        (rewatchProjection.waniKaniLevel !== undefined && rewatchProjection.waniKaniLevel > 0);
-    const hideProjectedStats = selectedRewatchSnapshot?.rewatch === 0 && !hasProjectedKnowledge;
-    const miningEnabled = trackSnapshot.progress.current >= trackSnapshot.progress.total;
     const ankiTrackSnapshot = processDictionaryStatisticsAnkiTrackSnapshot(statisticsSnapshot, trackSnapshot.track);
     const waniKaniTrackSnapshot = processDictionaryStatisticsWaniKaniTrackSnapshot(
         statisticsSnapshot,
         trackSnapshot.track
     );
+    const ankiAvailable = ankiTrackSnapshot.available === true;
+    const waniKaniAvailable = waniKaniTrackSnapshot.available === true;
+    const hasProjectedKnowledge =
+        (ankiAvailable &&
+            (hasProjectedAnkiUnknownCards(rewatchProjection) ||
+                (rewatchProjection.ankiLearningOrAboveIsMature ?? false))) ||
+        (waniKaniAvailable && rewatchProjection.waniKaniLevel !== undefined && rewatchProjection.waniKaniLevel > 0);
+    const hideProjectedStats = selectedRewatchSnapshot?.rewatch === 0 && !hasProjectedKnowledge;
+    const miningEnabled = trackSnapshot.progress.current >= trackSnapshot.progress.total;
     const ankiHasStats = ankiTrackSnapshot.deckSnapshots.length > 0;
     const waniKaniHasStats = waniKaniTrackSnapshot.uniqueWords > 0;
     const defaultReviewStatisticsSource: ReviewStatisticsSource =
@@ -1598,7 +1634,9 @@ function TrackSnapshot({
                                 <ProjectedRewatchControls
                                     rewatchSnapshots={trackSnapshot.rewatchSnapshots}
                                     selectedRewatch={selectedRewatchSnapshot.rewatch}
-                                    totalUnknownAnkiCards={trackSnapshot.totalUnknownAnkiCards}
+                                    unknownAnkiCardsByDeck={trackSnapshot.unknownAnkiCardsByDeck}
+                                    ankiAvailable={ankiAvailable}
+                                    waniKaniAvailable={waniKaniAvailable}
                                     projection={rewatchProjection}
                                     waniKaniApiToken={dictionaryWaniKaniApiToken}
                                     onSelectedRewatchChanged={(rewatch) =>

--- a/common/components/Statistics.tsx
+++ b/common/components/Statistics.tsx
@@ -42,9 +42,11 @@ import IconButton from '@mui/material/IconButton';
 import LinearProgress from '@mui/material/LinearProgress';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
+import Popover from '@mui/material/Popover';
 import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography, { type TypographyProps } from '@mui/material/Typography';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ChevronRightRoundedIcon from '@mui/icons-material/ChevronRightRounded';
 import Tooltip from '@mui/material/Tooltip';
@@ -479,6 +481,7 @@ interface SentenceStatsPanelProps {
     globalKnownLabel: string;
     globalKnownCount: number;
     onOpenSentenceBucketDetails: (bucket: DictionaryStatisticsSentenceDialogBucket) => void;
+    headerEndAction?: ReactNode;
     headerAction?: ReactNode;
     extraStats?: ReactNode;
     hideStats?: boolean;
@@ -618,28 +621,96 @@ function KnowledgeStats({ snapshot }: { snapshot: KnowledgeStatsSnapshot }) {
     );
 }
 
-function ProjectedRewatchControls({
+function ProjectedRewatchSelect({
     rewatchSnapshots,
     selectedRewatch,
+    onSelectedRewatchChanged,
+}: {
+    rewatchSnapshots: DictionaryStatisticsTrackSnapshot['rewatchSnapshots'];
+    selectedRewatch: number;
+    onSelectedRewatchChanged: (rewatch: number) => void;
+}) {
+    const { t } = useTranslation();
+    return (
+        <TextField
+            select
+            fullWidth
+            size="small"
+            value={selectedRewatch}
+            label={t('statistics.rewatchSelect')}
+            onChange={(event) => onSelectedRewatchChanged(Number(event.target.value))}
+            sx={{ minWidth: 132 }}
+        >
+            {rewatchSnapshots.map((rewatchSnapshot) => (
+                <MenuItem key={rewatchSnapshot.rewatch} value={rewatchSnapshot.rewatch}>
+                    {t('statistics.rewatchOption', {
+                        rewatch: rewatchSnapshot.rewatch,
+                    })}
+                </MenuItem>
+            ))}
+        </TextField>
+    );
+}
+
+function ProjectedPopoverButton({
+    label,
+    open,
+    onClick,
+}: {
+    label: string;
+    open: boolean;
+    onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+}) {
+    return (
+        <Button
+            variant="outlined"
+            size="small"
+            fullWidth
+            aria-haspopup="dialog"
+            aria-expanded={open ? 'true' : undefined}
+            endIcon={<ArrowDropDownIcon fontSize="small" />}
+            onClick={onClick}
+            sx={(theme) => ({
+                justifyContent: 'space-between',
+                minWidth: 0,
+                textTransform: 'none',
+                color: 'text.primary',
+                borderColor: theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)',
+                '&:hover': {
+                    borderColor: 'text.primary',
+                    backgroundColor: 'action.hover',
+                },
+                '& .MuiButton-endIcon': {
+                    color: 'action.active',
+                },
+            })}
+        >
+            <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {label}
+            </Box>
+        </Button>
+    );
+}
+
+type ProjectedPopoverSource = 'anki' | 'waniKani';
+
+function ProjectedProjectionControls({
     unknownAnkiCardsByDeck,
     ankiAvailable,
     waniKaniAvailable,
     projection,
     waniKaniApiToken,
-    onSelectedRewatchChanged,
     onProjectionChanged,
 }: {
-    rewatchSnapshots: DictionaryStatisticsTrackSnapshot['rewatchSnapshots'];
-    selectedRewatch: number;
     unknownAnkiCardsByDeck: DictionaryStatisticsAnkiUnknownCardsByDeck[];
     ankiAvailable: boolean;
     waniKaniAvailable: boolean;
     projection: DictionaryStatisticsRewatchProjection;
     waniKaniApiToken: string;
-    onSelectedRewatchChanged: (rewatch: number) => void;
     onProjectionChanged: (projection: DictionaryStatisticsRewatchProjection) => void;
 }) {
     const { t } = useTranslation();
+    const [openPopover, setOpenPopover] = useState<{ source: ProjectedPopoverSource; anchorEl: HTMLElement }>();
     const { userInfo: waniKaniUserInfo, error: waniKaniUserInfoError } = useWaniKaniUserInfo(
         waniKaniAvailable ? waniKaniApiToken : ''
     );
@@ -667,90 +738,107 @@ function ProjectedRewatchControls({
         [projection.ankiUnknownCardsByDeck, updateProjection]
     );
 
+    const openProjectionPopover = useCallback(
+        (source: ProjectedPopoverSource) => (event: MouseEvent<HTMLButtonElement>) =>
+            setOpenPopover({ source, anchorEl: event.currentTarget }),
+        []
+    );
+    const closeProjectionPopover = useCallback(() => setOpenPopover(undefined), []);
+    const ankiPopoverOpen = openPopover?.source === 'anki';
+    const waniKaniPopoverOpen = openPopover?.source === 'waniKani';
+
+    if (!ankiAvailable && !waniKaniAvailable) return null;
+
     return (
-        <Box
-            sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 1,
-            }}
-        >
-            <TextField
-                select
-                fullWidth
-                size="small"
-                value={selectedRewatch}
-                label={t('statistics.rewatchSelect')}
-                onChange={(event) => onSelectedRewatchChanged(Number(event.target.value))}
-            >
-                {rewatchSnapshots.map((rewatchSnapshot) => (
-                    <MenuItem key={rewatchSnapshot.rewatch} value={rewatchSnapshot.rewatch}>
-                        {t('statistics.rewatchOption', {
-                            rewatch: rewatchSnapshot.rewatch,
-                        })}
-                    </MenuItem>
-                ))}
-            </TextField>
-            {ankiAvailable && (
-                <SwitchLabelWithHoverEffect
-                    control={
-                        <Switch
-                            checked={ankiLearningOrAboveIsMature}
-                            onChange={(event) =>
-                                updateProjection({
-                                    ankiLearningOrAboveIsMature: event.target.checked,
-                                })
-                            }
+        <>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                {ankiAvailable && (
+                    <Box sx={{ flex: '1 1 120px', minWidth: 0 }}>
+                        <ProjectedPopoverButton
+                            label={t('settings.anki')}
+                            open={ankiPopoverOpen}
+                            onClick={openProjectionPopover('anki')}
                         />
-                    }
-                    label={t('statistics.anki.projectReviewedCards')}
-                    labelPlacement="start"
-                    sx={{ width: '100%', mt: -0.25 }}
-                />
-            )}
-            {(ankiAvailable || waniKaniAvailable) && (
-                <Typography variant="caption" color="text.secondary">
-                    {t('statistics.projectMature')}
-                </Typography>
-            )}
-            {ankiAvailable && unknownAnkiCardsByDeck.length > 0 && (
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                    <Stack spacing={1}>
-                        {unknownAnkiCardsByDeck.map(({ deckName, totalUnknownCards }) => (
-                            <TextField
-                                key={deckName}
-                                type="number"
-                                size="small"
-                                fullWidth
-                                label={`${deckName} (${t('statistics.anki.newCardsCount', { count: totalUnknownCards })})`}
-                                value={projectedAnkiUnknownCardsByDeck[deckName] ?? 0}
+                    </Box>
+                )}
+                {waniKaniAvailable && (
+                    <Box sx={{ flex: '1 1 120px', minWidth: 0 }}>
+                        <ProjectedPopoverButton
+                            label={t('settings.dictionaryWaniKaniSection')}
+                            open={waniKaniPopoverOpen}
+                            onClick={openProjectionPopover('waniKani')}
+                        />
+                    </Box>
+                )}
+            </Box>
+            <Popover
+                disableEnforceFocus={true}
+                open={ankiPopoverOpen}
+                anchorEl={ankiPopoverOpen ? openPopover.anchorEl : undefined}
+                onClose={closeProjectionPopover}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+                PaperProps={{ sx: { p: 1.5, width: 320, maxWidth: 'calc(100vw - 32px)' } }}
+            >
+                <Stack spacing={1.5}>
+                    <Typography variant="body1">{t('statistics.projectMature')}</Typography>
+                    {unknownAnkiCardsByDeck.length > 0 && (
+                        <Stack spacing={1}>
+                            {unknownAnkiCardsByDeck.map(({ deckName, totalUnknownCards }) => (
+                                <TextField
+                                    key={deckName}
+                                    type="number"
+                                    size="small"
+                                    fullWidth
+                                    label={`${deckName} (${t('statistics.anki.newCardsCount', { count: totalUnknownCards })})`}
+                                    value={projectedAnkiUnknownCardsByDeck[deckName] ?? 0}
+                                    onChange={(event) =>
+                                        updateProjectedAnkiUnknownCardsByDeck(
+                                            deckName,
+                                            event.target.value,
+                                            totalUnknownCards
+                                        )
+                                    }
+                                    slotProps={{
+                                        htmlInput: {
+                                            min: 0,
+                                            max: totalUnknownCards,
+                                            inputMode: 'numeric',
+                                            pattern: '[0-9]*',
+                                        },
+                                    }}
+                                />
+                            ))}
+                        </Stack>
+                    )}
+                    <SwitchLabelWithHoverEffect
+                        control={
+                            <Switch
+                                checked={ankiLearningOrAboveIsMature}
                                 onChange={(event) =>
-                                    updateProjectedAnkiUnknownCardsByDeck(
-                                        deckName,
-                                        event.target.value,
-                                        totalUnknownCards
-                                    )
+                                    updateProjection({
+                                        ankiLearningOrAboveIsMature: event.target.checked,
+                                    })
                                 }
-                                slotProps={{
-                                    htmlInput: {
-                                        min: 0,
-                                        max: totalUnknownCards,
-                                        inputMode: 'numeric',
-                                        pattern: '[0-9]*',
-                                    },
-                                }}
                             />
-                        ))}
-                    </Stack>
-                </Box>
-            )}
-            {waniKaniAvailable && (
-                <Box
-                    sx={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                    }}
-                >
+                        }
+                        label={t('statistics.anki.projectReviewedCards')}
+                        labelPlacement="start"
+                        sx={{ width: '100%', mt: -0.25 }}
+                    />
+                </Stack>
+            </Popover>
+            <Popover
+                disableEnforceFocus={true}
+                open={waniKaniPopoverOpen}
+                anchorEl={waniKaniPopoverOpen ? openPopover.anchorEl : undefined}
+                onClose={closeProjectionPopover}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+                PaperProps={{ sx: { p: 1.5, width: 320, maxWidth: 'calc(100vw - 32px)' } }}
+            >
+                <Stack spacing={1.5}>
+                    <Typography variant="body1">{t('statistics.projectMature')}</Typography>
                     <TextField
                         type="number"
                         size="small"
@@ -773,9 +861,9 @@ function ProjectedRewatchControls({
                             },
                         }}
                     />
-                </Box>
-            )}
-        </Box>
+                </Stack>
+            </Popover>
+        </>
     );
 }
 
@@ -798,6 +886,7 @@ function SentenceStatsPanel({
     comprehensionPercent,
     globalKnownLabel,
     globalKnownCount,
+    headerEndAction,
     headerAction,
     extraStats,
     hideStats,
@@ -922,13 +1011,24 @@ function SentenceStatsPanel({
             }}
         >
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, height: '100%' }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1, alignItems: 'flex-start' }}>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        gap: 1,
+                        alignItems: 'flex-start',
+                        flexWrap: 'wrap',
+                    }}
+                >
                     <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, mb: 1 }}>
                         <StatisticsSectionSubHeading marginBottom={0}>{title}</StatisticsSectionSubHeading>
                         {infoLines !== undefined && <StatisticsInfoTooltip label={title} lines={infoLines} />}
                     </Box>
+                    {headerEndAction && (
+                        <Box sx={{ flex: { xs: '1 1 100%', sm: '0 0 132px' }, minWidth: 132 }}>{headerEndAction}</Box>
+                    )}
                 </Box>
-                {headerAction && <Box sx={{ mb: 1.5 }}>{headerAction}</Box>}
+                {headerAction && <Box>{headerAction}</Box>}
                 {hideStats ? null : emptyMessage ? (
                     <Typography typography="body2" color="text.secondary">
                         {emptyMessage}
@@ -1625,19 +1725,25 @@ function TrackSnapshot({
                         comprehensionPercent={projectedComprehension}
                         globalKnownLabel={t('statistics.globalKnownWords')}
                         globalKnownCount={projectedGlobalKnownCount}
-                        headerAction={
+                        headerEndAction={
                             selectedRewatchSnapshot !== undefined ? (
-                                <ProjectedRewatchControls
+                                <ProjectedRewatchSelect
                                     rewatchSnapshots={trackSnapshot.rewatchSnapshots}
                                     selectedRewatch={selectedRewatchSnapshot.rewatch}
+                                    onSelectedRewatchChanged={(rewatch) =>
+                                        onSelectedRewatchChanged(trackSnapshot.track, rewatch)
+                                    }
+                                />
+                            ) : undefined
+                        }
+                        headerAction={
+                            selectedRewatchSnapshot !== undefined && (ankiAvailable || waniKaniAvailable) ? (
+                                <ProjectedProjectionControls
                                     unknownAnkiCardsByDeck={trackSnapshot.unknownAnkiCardsByDeck}
                                     ankiAvailable={ankiAvailable}
                                     waniKaniAvailable={waniKaniAvailable}
                                     projection={rewatchProjection}
                                     waniKaniApiToken={dictionaryWaniKaniApiToken}
-                                    onSelectedRewatchChanged={(rewatch) =>
-                                        onSelectedRewatchChanged(trackSnapshot.track, rewatch)
-                                    }
                                     onProjectionChanged={(projection) =>
                                         onRewatchProjectionChanged(trackSnapshot.track, projection)
                                     }

--- a/common/components/Statistics.tsx
+++ b/common/components/Statistics.tsx
@@ -448,6 +448,7 @@ function StatisticsSectionSubHeading({ children }: { children: React.ReactNode }
 
 interface SentenceStatsPanelProps {
     title: string;
+    infoLines?: string[];
     totalSentences: number;
     sentenceBuckets: DictionaryStatisticsSentenceBuckets;
     uncollectedLabel: string;
@@ -466,6 +467,7 @@ interface SentenceStatsPanelProps {
     globalKnownCount: number;
     onOpenSentenceBucketDetails: (bucket: DictionaryStatisticsSentenceDialogBucket) => void;
     headerAction?: ReactNode;
+    sentenceFiltersPosition: 'top' | 'bottom';
     emptyMessage?: string;
 }
 
@@ -529,6 +531,7 @@ function StatBoxes({ keyPrefix, stats }: StatBoxesProps) {
 
 function SentenceStatsPanel({
     title,
+    infoLines,
     totalSentences,
     sentenceBuckets,
     uncollectedLabel,
@@ -546,6 +549,7 @@ function SentenceStatsPanel({
     globalKnownLabel,
     globalKnownCount,
     headerAction,
+    sentenceFiltersPosition,
     emptyMessage,
     onOpenSentenceBucketDetails,
 }: SentenceStatsPanelProps) {
@@ -618,6 +622,43 @@ function SentenceStatsPanel({
 
     const comprehensionBand = dictionaryStatisticsComprehensionBandForPercent(comprehensionPercent);
 
+    const sentenceFilterRows = (
+        <>
+            {renderSentenceBucketRow(
+                { kind: 'allKnown' },
+                knownSentencesLabel,
+                sentenceBuckets.allKnown.count,
+                sentenceBuckets.allKnown.entries
+            )}
+            {uncollectedSentenceBuckets.map(({ bucket, label, count, entries }, index) => (
+                <Box key={label} sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                    {renderSentenceBucketRow(bucket, label, count, entries)}
+                    {unknownSentenceBuckets[index] !== undefined &&
+                        renderSentenceBucketRow(
+                            unknownSentenceBuckets[index].bucket,
+                            unknownSentenceBuckets[index].label,
+                            unknownSentenceBuckets[index].count,
+                            unknownSentenceBuckets[index].entries
+                        )}
+                </Box>
+            ))}
+        </>
+    );
+
+    const statRows = (
+        <>
+            <StatRow
+                label={comprehensionLabel}
+                value={percentDisplay(comprehensionPercent)}
+                valueSx={{ color: comprehensionBand.color, fontWeight: 600 }}
+            />
+            <StatRow label={knownWordsLabel} value={`${knownWordsCount} · ${percentDisplay(knownWordsPercent)}`} />
+            <StatRow label={globalKnownLabel} value={`${globalKnownCount}`} />
+            <StatRow label={uniqueWordsPerSentenceLabel} value={averageDisplay(uniqueWordsPerSentence)} />
+            <StatRow label={knownWordsPerSentenceLabel} value={averageDisplay(knownWordsPerSentence)} />
+        </>
+    );
+
     return (
         <Box
             sx={{
@@ -630,7 +671,10 @@ function SentenceStatsPanel({
         >
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, height: '100%' }}>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1, alignItems: 'flex-start' }}>
-                    <StatisticsSectionSubHeading>{title}</StatisticsSectionSubHeading>
+                    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+                        <StatisticsSectionSubHeading>{title}</StatisticsSectionSubHeading>
+                        {infoLines !== undefined && <StatisticsInfoTooltip label={title} lines={infoLines} />}
+                    </Box>
                 </Box>
                 {headerAction && <Box sx={{ mb: 1.5 }}>{headerAction}</Box>}
                 {emptyMessage ? (
@@ -639,36 +683,9 @@ function SentenceStatsPanel({
                     </Typography>
                 ) : (
                     <>
-                        <StatRow
-                            label={comprehensionLabel}
-                            value={percentDisplay(comprehensionPercent)}
-                            valueSx={{ color: comprehensionBand.color, fontWeight: 600 }}
-                        />
-                        <StatRow
-                            label={knownWordsLabel}
-                            value={`${knownWordsCount} · ${percentDisplay(knownWordsPercent)}`}
-                        />
-                        <StatRow label={globalKnownLabel} value={`${globalKnownCount}`} />
-                        <StatRow label={uniqueWordsPerSentenceLabel} value={averageDisplay(uniqueWordsPerSentence)} />
-                        <StatRow label={knownWordsPerSentenceLabel} value={averageDisplay(knownWordsPerSentence)} />
-                        {renderSentenceBucketRow(
-                            { kind: 'allKnown' },
-                            knownSentencesLabel,
-                            sentenceBuckets.allKnown.count,
-                            sentenceBuckets.allKnown.entries
-                        )}
-                        {uncollectedSentenceBuckets.map(({ bucket, label, count, entries }, index) => (
-                            <Box key={label} sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                                {renderSentenceBucketRow(bucket, label, count, entries)}
-                                {unknownSentenceBuckets[index] !== undefined &&
-                                    renderSentenceBucketRow(
-                                        unknownSentenceBuckets[index].bucket,
-                                        unknownSentenceBuckets[index].label,
-                                        unknownSentenceBuckets[index].count,
-                                        unknownSentenceBuckets[index].entries
-                                    )}
-                            </Box>
-                        ))}
+                        {sentenceFiltersPosition === 'top' && sentenceFilterRows}
+                        {statRows}
+                        {sentenceFiltersPosition === 'bottom' && sentenceFilterRows}
                     </>
                 )}
             </Box>
@@ -1035,13 +1052,8 @@ function TrackSnapshot({
         () => [t('statistics.info.wordDistribution'), t('statistics.info.occurrences'), t('statistics.info.frequency')],
         [t]
     );
-    const sentenceStatisticsInfoLines = useMemo(
-        () => [
-            t('statistics.info.sentenceStatistics'),
-            `${t('statistics.projectedRewatch')}: ${t('statistics.info.projectedRewatch')}`,
-        ],
-        [t]
-    );
+    const sentenceStatisticsInfoLines = useMemo(() => [t('statistics.info.sentenceStatistics')], [t]);
+    const projectedRewatchInfoLines = useMemo(() => [t('statistics.info.projectedRewatch')], [t]);
     const uniqueWordsPerSentenceLabel = t('statistics.uniqueWordsPerSentence');
     const knownWordsPerSentenceLabel = t('statistics.knownWordsPerSentence');
     const uncollectedLabel = statusLabels[TokenStatus.UNCOLLECTED];
@@ -1301,6 +1313,7 @@ function TrackSnapshot({
                         comprehensionPercent={trackSnapshot.comprehensionPercent}
                         globalKnownLabel={t('statistics.globalKnownWords')}
                         globalKnownCount={trackSnapshot.numDictionaryKnownTokens}
+                        sentenceFiltersPosition="top"
                         onOpenSentenceBucketDetails={(bucket) => {
                             const bucketData = sentenceDialogBucketData(bucket, trackSnapshot.sentenceBuckets, {
                                 knownSentencesLabel: t('statistics.knownSentences'),
@@ -1321,6 +1334,7 @@ function TrackSnapshot({
                 <Box>
                     <SentenceStatsPanel
                         title={t('statistics.projectedRewatch')}
+                        infoLines={projectedRewatchInfoLines}
                         totalSentences={totalSentences}
                         sentenceBuckets={projectedSentenceBuckets}
                         uncollectedLabel={uncollectedLabel}
@@ -1358,6 +1372,7 @@ function TrackSnapshot({
                                 </TextField>
                             ) : undefined
                         }
+                        sentenceFiltersPosition="bottom"
                         emptyMessage={maxRewatches === 0 ? t('statistics.noMoreRewatches') : undefined}
                         onOpenSentenceBucketDetails={(bucket) => {
                             if (selectedRewatchSnapshot === undefined) return;

--- a/common/components/WordBrowserDialog.tsx
+++ b/common/components/WordBrowserDialog.tsx
@@ -1189,12 +1189,23 @@ export default function WordBrowserDialog({
             const waniKaniAssignmentRecords = isWaniKaniRecord
                 ? record.cardIds.flatMap((subjectId) => trackWaniKaniAssignmentRecordsBySubject?.[subjectId] ?? [])
                 : [];
-            const waniKaniSubjectStatuses: TokenStatusInfo[] = waniKaniAssignmentRecords.map((assignmentRecord) => ({
-                assignmentId: assignmentRecord.assignmentId,
-                subjectId: assignmentRecord.subjectId,
-                status: assignmentRecord.status,
-                suspended: false,
-            }));
+            const trackWaniKaniSubjectRecords = records.waniKaniSubjectRecords?.[record.track];
+            const waniKaniSubjectStatuses: TokenStatusInfo[] = waniKaniAssignmentRecords.flatMap((assignmentRecord) => {
+                const subjectRecord = trackWaniKaniSubjectRecords?.[assignmentRecord.subjectId];
+                if (!subjectRecord) return [];
+                return [
+                    {
+                        waniKani: {
+                            assignmentId: assignmentRecord.assignmentId,
+                            availableAt: assignmentRecord.data.available_at,
+                            subjectId: assignmentRecord.subjectId,
+                            subjectLevel: subjectRecord.data.level,
+                        },
+                        status: assignmentRecord.status,
+                        suspended: false,
+                    },
+                ];
+            });
             const ankiNoteIds = dedupeNumbers(cardRecords.map((cardRecord) => cardRecord.noteId));
             const status = isAnkiRecord
                 ? getTokenStatus(

--- a/common/dictionary-db/dictionary-db-anki.ts
+++ b/common/dictionary-db/dictionary-db-anki.ts
@@ -26,7 +26,7 @@ import {
     _buildIdHealthCheck,
     _clearBuildIds,
     DictionaryAnkiCardKey,
-    DictionaryAnkiCardRecord,
+    _DictionaryAnkiCardRecord,
     DictionaryMetaKey,
     DictionaryTokenRecord,
     _ensureBuildId,
@@ -296,7 +296,7 @@ async function _getAnkiCardsByNoteIdBulk(
     db: _DictionaryDatabase,
     profile: string,
     noteIds: number[]
-): Promise<Map<number, DictionaryAnkiCardRecord[]>> {
+): Promise<Map<number, _DictionaryAnkiCardRecord[]>> {
     if (!noteIds.length) return new Map();
     return db.ankiCards
         .where('[profile+noteId]')
@@ -304,7 +304,7 @@ async function _getAnkiCardsByNoteIdBulk(
         .toArray()
         .then((ankiCards) => {
             if (!ankiCards.length) return new Map();
-            const cardRecordsByNoteId = new Map<number, DictionaryAnkiCardRecord[]>();
+            const cardRecordsByNoteId = new Map<number, _DictionaryAnkiCardRecord[]>();
             for (const ankiCard of ankiCards) {
                 const val = cardRecordsByNoteId.get(ankiCard.noteId);
                 if (val) val.push(ankiCard);
@@ -851,7 +851,7 @@ async function _buildTokensForTracks(
             }
 
             const records: DictionaryTokenRecord[] = [];
-            const ankiCards: DictionaryAnkiCardRecord[] = [];
+            const ankiCards: _DictionaryAnkiCardRecord[] = [];
             for (const track of trackStates.keys()) {
                 for (const [source, tokenCardsMap] of partialTokenRecordsByTrack.get(track)!.entries()) {
                     const tokenRecordMap = await _getFromSourceBulk(
@@ -935,7 +935,7 @@ async function _saveTokensForDB(
     profile: string,
     trackStates: Map<number, TrackStateForDB>,
     records: DictionaryTokenRecord[],
-    ankiCards: DictionaryAnkiCardRecord[],
+    ankiCards: _DictionaryAnkiCardRecord[],
     modifiedCardsBatch: CardsForDB,
     partialTokenRecordsByTrack: Map<
         number,

--- a/common/dictionary-db/dictionary-db-anki.ts
+++ b/common/dictionary-db/dictionary-db-anki.ts
@@ -314,6 +314,10 @@ async function _getAnkiCardsByNoteIdBulk(
         });
 }
 
+function isAnkiSource(source: DictionaryTokenSource): boolean {
+    return source === DictionaryTokenSource.ANKI_WORD || source === DictionaryTokenSource.ANKI_SENTENCE;
+}
+
 /**
  * There are five scenarios where tokens/cards need to be deleted:
  * 1. The card was removed from Anki (handled by _syncTrackStatesWithAnki())
@@ -341,7 +345,7 @@ async function _deleteCardBulk(
                     .where('cardIds')
                     .anyOf(orphanedCardIds)
                     .distinct()
-                    .filter((r) => r.track === track && r.profile === profile)
+                    .filter((r) => r.track === track && r.profile === profile && isAnkiSource(r.source))
                     .modify((record, ref) => {
                         const remainingCardIds = record.cardIds.filter((id) => !cardIdsSet.has(id));
                         if (remainingCardIds.length === record.cardIds.length) return;
@@ -949,7 +953,7 @@ async function _saveTokensForDB(
             .where('cardIds')
             .anyOf(Array.from(modifiedCardsBatch.keys()))
             .distinct()
-            .filter((r) => trackStates.has(r.track) && r.profile === profile)
+            .filter((r) => trackStates.has(r.track) && r.profile === profile && isAnkiSource(r.source))
             .modify((record, ref) => {
                 // We want tokens that were not updated but refers to updated cards (e.g. field value changed, different tokens)
                 if (partialTokenRecordsByTrack.get(record.track)!.get(record.source)!.has(record.token)) return;

--- a/common/dictionary-db/dictionary-db-anki.ts
+++ b/common/dictionary-db/dictionary-db-anki.ts
@@ -34,12 +34,14 @@ import {
     _getFromSourceBulk,
     _saveRecordBulk,
     TrackStateForDB,
+    CardInfoForDB,
 } from '@project/common/dictionary-db';
 
 /**
  * If adding/removing fields here, add/remove the UI helperText in the settings tab
  */
 interface AnkiCacheSettingsDependencies {
+    version?: number; // Bump to force a cache rebuild when needed
     ankiConnectUrl: string;
     dictionaryYomitanUrl: string;
     dictionaryYomitanParser: string;
@@ -54,11 +56,11 @@ type CardsForDB = Map<
     number,
     {
         noteId: number;
-        deckName: string;
         fields: Map<string, string>;
         modifiedAt: number;
         statuses: Map<number, TokenStatus>;
         suspended: boolean;
+        data: CardInfoForDB;
     }
 >;
 
@@ -469,19 +471,23 @@ async function _syncTrackStatesWithAnki(
         for (const cardId of noteInfo.cards) modifiedCardIdsSet.add(cardId);
     }
 
-    const modifiedCardsDeck: Map<number, string> = new Map();
+    const modifiedCardsDeck: Map<number, CardInfoForDB> = new Map();
     if (modifiedNotes.length) {
         const modifiedCardIds = Array.from(modifiedCardIdsSet);
         for (const cardInfo of await anki.cardsInfo(modifiedCardIds, async (progress) => {
             await _updateBuildAnkiCacheProgress(db, buildId, activeTracks, progress, [], statusUpdates, true);
         })) {
-            modifiedCardsDeck.set(cardInfo.cardId, cardInfo.deckName); // cardsInfo is much slower than notesInfo so we try to call it only if needed
+            modifiedCardsDeck.set(cardInfo.cardId, {
+                deckName: cardInfo.deckName,
+                modelName: cardInfo.modelName,
+                due: cardInfo.due,
+            }); // cardsInfo is much slower than notesInfo so we try to call it only if needed
         }
         const dts = Array.from(trackStates.values()).map((ts) => ts.dt);
         for (let i = modifiedNotes.length - 1; i >= 0; i--) {
             let modified = false;
             for (const dt of dts) {
-                if (!modifiedNotes[i].cards.some((c) => _hasDeck(dt, modifiedCardsDeck.get(c)!))) continue;
+                if (!modifiedNotes[i].cards.some((c) => _hasDeck(dt, modifiedCardsDeck.get(c)!.deckName))) continue;
                 if (!_hasField(dt, Object.keys(modifiedNotes[i].fields))) continue;
                 modified = true;
                 break;
@@ -511,11 +517,11 @@ async function _syncTrackStatesWithAnki(
             for (const cardId of modifiedNote.cards) {
                 modifiedCards.set(cardId, {
                     noteId: modifiedNote.noteId,
-                    deckName: modifiedCardsDeck.get(cardId)!,
                     fields,
                     modifiedAt: modifiedNote.mod,
                     statuses: new Map(),
                     suspended: suspendedCards.has(cardId),
+                    data: modifiedCardsDeck.get(cardId)!,
                 });
             }
         }
@@ -533,7 +539,7 @@ async function _syncTrackStatesWithAnki(
         }
         if (!modifiedCardIdsSet.has(cardId)) continue; // Card unchanged
         const modifiedCard = modifiedCards.get(cardId)!;
-        if (!_hasDeck(ts.dt, modifiedCard.deckName)) {
+        if (!_hasDeck(ts.dt, modifiedCard.data.deckName)) {
             orphanedTrackCardIds.get(track)!.push(cardId); // Card no longer in relevant deck
             continue;
         }
@@ -570,7 +576,7 @@ async function _buildAnkiCardStatuses(
     const matureCutoff = ts.dt.dictionaryAnkiMatureCutoff;
     const gradCutoff = Math.ceil(matureCutoff / 2);
     let numRemaining = Array.from(modifiedCards.values()).filter(
-        (card) => _hasDeck(ts.dt, card.deckName) && _hasField(ts.dt, Array.from(card.fields.keys()))
+        (card) => _hasDeck(ts.dt, card.data.deckName) && _hasField(ts.dt, Array.from(card.fields.keys()))
     ).length;
 
     numRemaining = _processAnkiCardStatuses(
@@ -779,7 +785,7 @@ async function _buildTokensForTracks(
                 const texts: string[] = [];
                 const ankiFields = new Set([...ts.dt.dictionaryAnkiWordFields, ...ts.dt.dictionaryAnkiSentenceFields]);
                 for (const card of modifiedCardsBatch.values()) {
-                    if (!_hasDeck(ts.dt, card.deckName)) continue;
+                    if (!_hasDeck(ts.dt, card.data.deckName)) continue;
                     for (const ankiField of ankiFields) {
                         const field = card.fields.get(ankiField);
                         if (field) texts.push(field);
@@ -813,7 +819,7 @@ async function _buildTokensForTracks(
                 const sourceTokensMap = partialTokenRecordsByTrack.get(track)!;
                 const sourceAnkiFieldsMap = ankiFieldsMap.get(track)!;
                 for (const [cardId, card] of modifiedCardsBatch.entries()) {
-                    if (!_hasDeck(ts.dt, card.deckName)) continue;
+                    if (!_hasDeck(ts.dt, card.data.deckName)) continue;
                     for (const [source, ankiFields] of sourceAnkiFieldsMap.entries()) {
                         for (const ankiField of ankiFields) {
                             const tokenCardsMap = sourceTokensMap.get(source)!;
@@ -885,6 +891,7 @@ async function _buildTokensForTracks(
                         modifiedAt: updatedCard.modifiedAt,
                         status,
                         suspended: updatedCard.suspended,
+                        data: updatedCard.data,
                     });
                 }
             }

--- a/common/dictionary-db/dictionary-db-wanikani.ts
+++ b/common/dictionary-db/dictionary-db-wanikani.ts
@@ -14,7 +14,6 @@ import {
     WaniKani,
     WaniKaniApiError,
     WaniKaniAssignment,
-    WaniKaniReset,
     WaniKaniSpacedRepetitionSystem,
     WaniKaniSubject,
 } from '@project/common/wanikani';
@@ -46,6 +45,7 @@ import {
  * If adding/removing fields here, add/remove the UI helperText in the settings tab.
  */
 interface WaniKaniCacheSettingsDependencies {
+    version?: number; // Bump to force a cache rebuild when needed
     dictionaryYomitanUrl: string;
     dictionaryYomitanParser: string;
     dictionaryYomitanScanLength: number;
@@ -156,7 +156,7 @@ export async function buildWaniKaniCachePipeline(
                     key,
                     changes: { settings: null, dataUpdatedAt: {}, spacedRepetitionSystems: [] },
                 });
-                continue;
+                continue; // Explicitly clear cache for no WaniKani token
             }
 
             const yomitan = new Yomitan(dt);
@@ -176,16 +176,16 @@ export async function buildWaniKaniCachePipeline(
                 return;
             }
 
-            const waniKani = new WaniKani(currSettings.dictionaryWaniKaniApiToken);
             try {
                 const currSettingsStr = JSON.stringify(currSettings);
                 const settingsChanged = currSettingsStr !== prevWaniKaniMeta.settings;
                 let dataUpdatedAt: WaniKaniDataUpdatedAt = settingsChanged ? {} : { ...prevWaniKaniMeta.dataUpdatedAt };
                 let clearTokens = settingsChanged;
                 let clearResources = settingsChanged;
+                const waniKani = new WaniKani(currSettings.dictionaryWaniKaniApiToken); // We only perform work based on changes since the last build using updateAfter
 
-                const resetResponse = await waniKani.resets({ updatedAfter: dataUpdatedAt.resets });
-                if (_hasConfirmedWaniKaniReset(resetResponse.data)) {
+                const resetResponse = await waniKani.resets({ updatedAfter: dataUpdatedAt.resets }); // Resets clear the cache like settings changes regardless if they were confirmed
+                if (resetResponse.totalCount) {
                     dataUpdatedAt = {
                         ...dataUpdatedAt,
                         assignments: undefined,
@@ -214,15 +214,23 @@ export async function buildWaniKaniCachePipeline(
                         spacedRepetitionSystemsResponse.dataUpdatedAt ?? dataUpdatedAt.spacedRepetitionSystems,
                 };
 
-                const existingSubjectIds = clearResources
-                    ? new Set<number>()
-                    : await _getWaniKaniSubjectIdsForTrack(db, profile, track);
-                const [hasAssignmentCache, hasSubjectCache] = clearResources
-                    ? [false, false]
-                    : await Promise.all([
-                          db.waniKaniAssignments.where('[profile+track]').equals([profile, track]).count(),
-                          db.waniKaniSubjects.where('[profile+track]').equals([profile, track]).count(),
-                      ]).then(([assignmentCount, subjectCount]) => [assignmentCount > 0, subjectCount > 0]);
+                const { existingSubjectIds, hasAssignmentCache, hasSubjectCache } = clearResources
+                    ? { existingSubjectIds: new Set<number>(), hasAssignmentCache: false, hasSubjectCache: false }
+                    : await db
+                          .transaction('r', db.waniKaniSubjects, db.waniKaniAssignments, () =>
+                              Promise.all([
+                                  db.waniKaniSubjects.where('[profile+track]').equals([profile, track]).toArray(),
+                                  db.waniKaniAssignments.where('[profile+track]').equals([profile, track]).toArray(),
+                              ])
+                          )
+                          .then(([subjects, assignments]) => ({
+                              existingSubjectIds: new Set([
+                                  ...subjects.map((subject) => subject.subjectId),
+                                  ...assignments.map((a) => a.subjectId),
+                              ]),
+                              hasAssignmentCache: assignments.length > 0,
+                              hasSubjectCache: subjects.length > 0,
+                          }));
 
                 const assignmentsResponse = await waniKani.assignments({
                     subjectTypes: ['vocabulary', 'kana_vocabulary'],
@@ -240,10 +248,7 @@ export async function buildWaniKaniCachePipeline(
                 const affectedSubjectIds =
                     clearTokens || spacedRepetitionSystemsChanged
                         ? new Set([...existingSubjectIds, ...responseSubjectIds])
-                        : new Set([
-                              ...assignmentsResponse.data.map((assignment) => assignment.data.subject_id),
-                              ...subjectsResponse.data.map((subject) => subject.id),
-                          ]);
+                        : responseSubjectIds;
                 dataUpdatedAt = {
                     ...dataUpdatedAt,
                     assignments: assignmentsResponse.dataUpdatedAt ?? dataUpdatedAt.assignments,
@@ -299,7 +304,7 @@ export async function buildWaniKaniCachePipeline(
         for (const track of tracksClearedWithoutBuild) {
             if (!trackStates.has(track)) trackStats.push({ track, isTokensCleared: true });
         }
-        _sortWaniKaniTrackStats(trackStats);
+        trackStats.sort((lhs, rhs) => lhs.track - rhs.track);
 
         if (trackStates.size || tracksClearedWithoutBuild.size || tokenlessMetaUpdates.length) {
             const tracksWithTokensToClear = new Set([
@@ -421,18 +426,6 @@ async function _deleteWaniKaniResourcesForTracks(
     await Promise.all([db.waniKaniSubjects.bulkDelete(subjectKeys), db.waniKaniAssignments.bulkDelete(assignmentKeys)]);
 }
 
-async function _getWaniKaniSubjectIdsForTrack(
-    db: _DictionaryDatabase,
-    profile: string,
-    track: number
-): Promise<Set<number>> {
-    const [subjects, assignments] = await Promise.all([
-        db.waniKaniSubjects.where('[profile+track]').equals([profile, track]).toArray(),
-        db.waniKaniAssignments.where('[profile+track]').equals([profile, track]).toArray(),
-    ]);
-    return new Set([...subjects.map((subject) => subject.subjectId), ...assignments.map((a) => a.subjectId)]);
-}
-
 function _mergeWaniKaniSpaceRepetitionSystems(
     existing: WaniKaniSpacedRepetitionSystem[],
     updated: WaniKaniSpacedRepetitionSystem[]
@@ -440,10 +433,6 @@ function _mergeWaniKaniSpaceRepetitionSystems(
     const systemsById = new Map(existing.map((system) => [system.id, system]));
     for (const system of updated) systemsById.set(system.id, system);
     return Array.from(systemsById.values()).sort((lhs, rhs) => lhs.id - rhs.id);
-}
-
-function _hasConfirmedWaniKaniReset(resets: WaniKaniReset[]): boolean {
-    return resets.some((reset) => reset.data.confirmed_at !== null);
 }
 
 function _waniKaniAssignmentRecord(
@@ -480,10 +469,6 @@ function _waniKaniSubjectRecord(
             spaced_repetition_system_id: subject.data.spaced_repetition_system_id,
         },
     };
-}
-
-function _sortWaniKaniTrackStats(trackStats: WaniKaniTrackStats[]): void {
-    trackStats.sort((lhs, rhs) => lhs.track - rhs.track);
 }
 
 function _publishWaniKaniTrackStats(
@@ -568,8 +553,7 @@ async function _processWaniKaniTracks(
                 errorTracks = [track];
                 throw e;
             }
-            const stats = trackStats.find((stats) => stats.track === track);
-            if (stats) stats.numImportedTokens = importedTokens.size;
+            trackStats.find((stats) => stats.track === track)!.numImportedTokens = importedTokens.size;
         }
 
         await _saveWaniKaniTrackMetadataForDB(db, profile, buildId, activeTracks, trackStates);
@@ -601,6 +585,7 @@ async function _buildWaniKaniTokensForTrack(
     const affectedSubjectIds = Array.from(ts.affectedSubjectIds);
     const importedTokens = new Set<string>();
     if (!affectedSubjectIds.length) return importedTokens;
+    const waniKaniTokenStatus = null; // Calculate when getting due to certain settings
 
     const subjects = await db.waniKaniSubjects
         .where('[subjectId+track+profile]')
@@ -628,29 +613,27 @@ async function _buildWaniKaniTokensForTrack(
             for (const subjectId of batch) {
                 const subject = subjectById.get(subjectId);
                 const characters = subject?.data.characters?.trim();
-                if (subject?.data.hidden_at || !characters || !HAS_LETTER_REGEX.test(characters)) continue;
-
+                if (subject?.data.hidden_at || !characters) continue;
                 subjectsToTokenize.push({ subjectId, characters });
             }
 
             if (subjectsToTokenize.length) {
                 await ts.yomitan.tokenizeBulk(subjectsToTokenize.map((subject) => subject.characters));
-            }
-            for (const { subjectId, characters } of subjectsToTokenize) {
-                const tokens = new Set<string>();
-                for (const tokenParts of await ts.yomitan.tokenize(characters)) {
-                    const token = tokenParts
-                        .map((part) => part.text)
-                        .join('')
-                        .trim();
-                    if (!token || !HAS_LETTER_REGEX.test(token)) continue;
-                    tokens.add(token);
-                }
-
-                for (const token of tokens) {
-                    const subjectIds = newSubjectIdsByToken.get(token);
-                    if (subjectIds) subjectIds.add(subjectId);
-                    else newSubjectIdsByToken.set(token, new Set([subjectId]));
+                for (const { subjectId, characters } of subjectsToTokenize) {
+                    const tokens = new Set<string>();
+                    for (const tokenParts of await ts.yomitan.tokenize(characters)) {
+                        const token = tokenParts
+                            .map((part) => part.text)
+                            .join('')
+                            .trim();
+                        if (!HAS_LETTER_REGEX.test(token)) continue;
+                        tokens.add(token);
+                    }
+                    for (const token of tokens) {
+                        const subjectIds = newSubjectIdsByToken.get(token);
+                        if (subjectIds) subjectIds.add(subjectId);
+                        else newSubjectIdsByToken.set(token, new Set([subjectId]));
+                    }
                 }
             }
 
@@ -668,20 +651,17 @@ async function _buildWaniKaniTokensForTrack(
             const records: DictionaryTokenRecord[] = [];
             for (const token of affectedTokens) {
                 const existingRecord = existingRecordByToken.get(token);
-                const subjectIds = new Set(
-                    existingRecord?.cardIds.filter((subjectId) => !batchSubjectIds.has(subjectId)) ?? []
-                );
+                const subjectIds = new Set(existingRecord?.cardIds.filter((id) => !batchSubjectIds.has(id)) ?? []);
                 for (const subjectId of newSubjectIdsByToken.get(token) ?? []) subjectIds.add(subjectId);
                 if (!subjectIds.size) {
                     importedTokens.delete(token);
                     continue;
                 }
 
-                const lemmas =
-                    (await ts.yomitan.lemmatize(token))?.filter((lemma) => HAS_LETTER_REGEX.test(lemma)) ?? [];
+                const lemmas = (await ts.yomitan.lemmatize(token)) ?? [];
                 if (!lemmas.length) {
                     importedTokens.delete(token);
-                    continue;
+                    continue; // Not a valid dictionary entry
                 }
 
                 importedTokens.add(token);
@@ -690,12 +670,13 @@ async function _buildWaniKaniTokensForTrack(
                     track,
                     source: DictionaryTokenSource.WANIKANI,
                     token,
-                    status: null,
+                    status: waniKaniTokenStatus,
                     lemmas,
                     states: existingRecord?.states ?? [],
                     cardIds: Array.from(subjectIds).sort((lhs, rhs) => lhs - rhs),
                 });
             }
+            ts.yomitan.resetCache();
 
             const batchModifiedTokens = new Set<string>();
             if (existingRecords.length || records.length) {
@@ -722,7 +703,6 @@ async function _buildWaniKaniTokensForTrack(
                 Array.from(batchModifiedTokens),
                 statusUpdates
             );
-            ts.yomitan.resetCache();
         },
         { batchSize: 100 }
     );
@@ -732,8 +712,8 @@ async function _buildWaniKaniTokensForTrack(
 
 /**
  * There are five scenarios where WaniKani tokens need to be deleted:
- * 1. The WaniKani-dependent settings changed (handled by clearTokens)
- * 2. A confirmed WaniKani reset was detected (handled by clearTokens/clearResources)
+ * 1. The WaniKani-dependent settings changed (handled by clearTokens/clearResources)
+ * 2. A WaniKani reset was detected (handled by clearTokens/clearResources)
  * 3. An assignment was hidden or moved to a token-ineligible state (handled by affectedSubjectIds)
  * 4. A subject was hidden or its characters no longer tokenize the same way (handled by affectedSubjectIds)
  * 5. Based on track settings such as no WaniKani token (handled by tracksClearedWithoutBuild)

--- a/common/dictionary-db/dictionary-db-wanikani.ts
+++ b/common/dictionary-db/dictionary-db-wanikani.ts
@@ -459,6 +459,7 @@ function _waniKaniAssignmentRecord(
         data: {
             srs_stage: assignment.data.srs_stage,
             hidden: assignment.data.hidden,
+            available_at: assignment.data.available_at,
         },
     };
 }
@@ -475,6 +476,7 @@ function _waniKaniSubjectRecord(
         data: {
             characters: subject.data.characters,
             hidden_at: subject.data.hidden_at,
+            level: subject.data.level,
             spaced_repetition_system_id: subject.data.spaced_repetition_system_id,
         },
     };

--- a/common/dictionary-db/dictionary-db.ts
+++ b/common/dictionary-db/dictionary-db.ts
@@ -15,6 +15,7 @@ import { Yomitan } from '@project/common/yomitan/yomitan';
 import Dexie from 'dexie';
 import { buildAnkiCachePipeline } from '@project/common/dictionary-db';
 import { buildWaniKaniCachePipeline } from '@project/common/dictionary-db';
+import { CardInfo } from '@project/common/anki';
 
 /**
  * This file only contains the public interface functions and types.
@@ -85,6 +86,7 @@ export interface DictionaryLocalTokenInput {
 }
 
 export type DictionaryAnkiCardKey = [number, number, string];
+export type CardInfoForDB = Pick<CardInfo, 'deckName' | 'modelName' | 'due'>;
 export interface DictionaryAnkiCardRecord {
     profile: string;
     track: number;
@@ -93,6 +95,7 @@ export interface DictionaryAnkiCardRecord {
     modifiedAt: number;
     status: TokenStatus;
     suspended: boolean;
+    data: CardInfoForDB;
 }
 
 export type DictionaryWaniKaniSubjectKey = [number, number, string];
@@ -146,7 +149,7 @@ class DictionaryDatabase extends Dexie {
                             lastBuildStartedAt: meta.lastBuildStartedAt ?? 0,
                             lastBuildExpiresAt: meta.lastBuildExpiresAt ?? 0,
                             buildId: meta.buildId ?? null,
-                            settings: meta.settings ?? null,
+                            settings: null, // Force a rebuild since we added fields to DictionaryAnkiCardRecord
                         };
                         meta.waniKaniMeta = {
                             lastBuildStartedAt: 0,

--- a/common/dictionary-db/dictionary-db.ts
+++ b/common/dictionary-db/dictionary-db.ts
@@ -95,6 +95,9 @@ export interface DictionaryAnkiCardRecord {
     modifiedAt: number;
     status: TokenStatus;
     suspended: boolean;
+    data?: CardInfoForDB;
+}
+export interface _DictionaryAnkiCardRecord extends DictionaryAnkiCardRecord {
     data: CardInfoForDB;
 }
 
@@ -124,7 +127,7 @@ export type _DictionaryDatabase = DictionaryDatabase;
 class DictionaryDatabase extends Dexie {
     meta!: Dexie.Table<DictionaryMetaRecord, DictionaryMetaKey>;
     tokens!: Dexie.Table<DictionaryTokenRecord, DictionaryTokenKey>;
-    ankiCards!: Dexie.Table<DictionaryAnkiCardRecord, DictionaryAnkiCardKey>;
+    ankiCards!: Dexie.Table<_DictionaryAnkiCardRecord, DictionaryAnkiCardKey>;
     waniKaniSubjects!: Dexie.Table<DictionaryWaniKaniSubjectRecord, DictionaryWaniKaniSubjectKey>;
     waniKaniAssignments!: Dexie.Table<DictionaryWaniKaniAssignmentRecord, DictionaryWaniKaniAssignmentKey>;
 

--- a/common/dictionary-db/dictionary-db.ts
+++ b/common/dictionary-db/dictionary-db.ts
@@ -949,6 +949,7 @@ export class DictionaryDB {
             'r',
             [this.db.tokens, this.db.ankiCards, this.db.waniKaniAssignments, this.db.waniKaniSubjects, this.db.meta],
             async () => {
+                const trackMatches = (record: { track: number }) => track === undefined || record.track === track;
                 const tokenRecords =
                     track === undefined
                         ? await this.db.tokens.where('profile').equals(profile).toArray()
@@ -957,105 +958,71 @@ export class DictionaryDB {
                               .equals(profile)
                               .filter((r) => r.track === track || r.track === LOCAL_TOKEN_TRACK)
                               .toArray();
-                if (!tokenRecords.length) {
-                    return {
-                        tokenRecords: [],
-                        ankiCardRecords: {},
-                        waniKaniSubjectRecords: {},
-                        waniKaniAssignmentRecords: {},
-                    };
+
+                const ankiCards = await this.db.ankiCards
+                    .where('profile')
+                    .equals(profile)
+                    .filter(trackMatches)
+                    .toArray();
+                const ankiCardRecords: DictionaryAnkiCardRecordsByTrack = {};
+                for (const record of ankiCards) {
+                    const trackRecords = ankiCardRecords[record.track];
+                    if (trackRecords) trackRecords[record.cardId] = record;
+                    else ankiCardRecords[record.track] = { [record.cardId]: record };
                 }
 
-                const ankiCardKeys = Array.from(
-                    new Map(
-                        tokenRecords.flatMap((record) =>
-                            record.source === DictionaryTokenSource.WANIKANI
-                                ? []
-                                : record.cardIds.map((cardId) => [
-                                      `${cardId}:${record.track}`,
-                                      [cardId, record.track, profile] as const,
-                                  ])
-                        )
-                    ).values()
-                );
-                const ankiCardRecords = ankiCardKeys.length
-                    ? await this.db.ankiCards
-                          .where('[cardId+track+profile]')
-                          .anyOf(ankiCardKeys)
-                          .toArray()
-                          .then((records) => {
-                              const recordsByTrack: DictionaryAnkiCardRecordsByTrack = {};
-                              for (const record of records) {
-                                  const trackRecords = recordsByTrack[record.track];
-                                  if (trackRecords) {
-                                      trackRecords[record.cardId] = record;
-                                  } else {
-                                      recordsByTrack[record.track] = { [record.cardId]: record };
-                                  }
-                              }
-                              return recordsByTrack;
-                          })
-                    : {};
-
-                const waniKaniSubjectIdsByTrack = new Map<number, number[]>();
-                for (const record of tokenRecords) {
-                    if (record.source !== DictionaryTokenSource.WANIKANI || !record.cardIds.length) continue;
-                    const subjectIds = waniKaniSubjectIdsByTrack.get(record.track);
-                    if (subjectIds) subjectIds.push(...record.cardIds);
-                    else waniKaniSubjectIdsByTrack.set(record.track, [...record.cardIds]);
-                }
+                const waniKaniSubjects = await this.db.waniKaniSubjects
+                    .where('profile')
+                    .equals(profile)
+                    .filter(trackMatches)
+                    .toArray();
                 const waniKaniSubjectRecords: DictionaryWaniKaniSubjectRecordsByTrack = {};
+                for (const subject of waniKaniSubjects) {
+                    const trackRecords = waniKaniSubjectRecords[subject.track];
+                    if (trackRecords) trackRecords[subject.subjectId] = subject;
+                    else waniKaniSubjectRecords[subject.track] = { [subject.subjectId]: subject };
+                }
+
+                const metaRecords =
+                    track === undefined
+                        ? await this.db.meta.where('profile').equals(profile).toArray()
+                        : await this.db.meta.get([profile, track]).then((record) => (record ? [record] : []));
+                const spacedRepetitionSystemByTrack = new Map<number, Map<number, WaniKaniSpacedRepetitionSystem>>();
+                for (const meta of metaRecords) {
+                    spacedRepetitionSystemByTrack.set(
+                        meta.track,
+                        new Map(meta.waniKaniMeta.spacedRepetitionSystems.map((system) => [system.id, system]))
+                    );
+                }
+
+                const waniKaniAssignments = await this.db.waniKaniAssignments
+                    .where('profile')
+                    .equals(profile)
+                    .filter(trackMatches)
+                    .toArray();
                 const waniKaniAssignmentRecords: DictionaryWaniKaniAssignmentRecordsByTrack = {};
-                await Promise.all(
-                    Array.from(waniKaniSubjectIdsByTrack.entries()).map(async ([recordTrack, subjectIds]) => {
-                        const uniqueSubjectIds = Array.from(new Set(subjectIds));
-                        const subjectKeys = uniqueSubjectIds.map(
-                            (subjectId) => [subjectId, recordTrack, profile] as const
-                        );
-                        const [subjects, assignments, trackMeta] = await Promise.all([
-                            this.db.waniKaniSubjects.where('[subjectId+track+profile]').anyOf(subjectKeys).toArray(),
-                            this.db.waniKaniAssignments.where('[subjectId+track+profile]').anyOf(subjectKeys).toArray(),
-                            this.db.meta.get([profile, recordTrack]),
-                        ]);
-                        const trackSubjectRecords: Record<number, DictionaryWaniKaniSubjectRecord> = {};
-                        for (const subject of subjects) {
-                            trackSubjectRecords[subject.subjectId] = subject;
-                        }
-
-                        const spacedRepetitionSystemById = new Map<number, WaniKaniSpacedRepetitionSystem>(
-                            trackMeta?.waniKaniMeta.spacedRepetitionSystems.map((system) => [system.id, system]) ?? []
-                        );
-                        const trackAssignmentRecords: Record<number, DictionaryWaniKaniAssignmentRecordWithStatus> = {};
-                        for (const assignment of assignments) {
-                            if (assignment.data.hidden) continue;
-                            const subject = trackSubjectRecords[assignment.subjectId];
-                            if (subject?.data.hidden_at) continue;
-                            const spacedRepetitionSystem =
-                                subject === undefined
-                                    ? undefined
-                                    : spacedRepetitionSystemById.get(subject.data.spaced_repetition_system_id);
-                            trackAssignmentRecords[assignment.assignmentId] = {
-                                ...assignment,
-                                status:
-                                    spacedRepetitionSystem === undefined
-                                        ? TokenStatus.UNKNOWN
-                                        : _waniKaniStatusFromSrsStage(
-                                              assignment.data.srs_stage,
-                                              spacedRepetitionSystem
-                                          ),
-                            };
-                        }
-                        waniKaniSubjectRecords[recordTrack] = trackSubjectRecords;
-                        waniKaniAssignmentRecords[recordTrack] = trackAssignmentRecords;
-                    })
-                );
-
-                const normalizedTokenRecords = tokenRecords.map((record) =>
-                    record.source === DictionaryTokenSource.LOCAL ? record : { ...record, status: null }
-                );
+                for (const assignment of waniKaniAssignments) {
+                    const subject = waniKaniSubjectRecords[assignment.track]?.[assignment.subjectId];
+                    const spacedRepetitionSystem =
+                        subject === undefined
+                            ? undefined
+                            : spacedRepetitionSystemByTrack
+                                  .get(assignment.track)
+                                  ?.get(subject.data.spaced_repetition_system_id);
+                    const record = {
+                        ...assignment,
+                        status:
+                            spacedRepetitionSystem === undefined
+                                ? TokenStatus.UNKNOWN
+                                : _waniKaniStatusFromSrsStage(assignment.data.srs_stage, spacedRepetitionSystem),
+                    };
+                    const trackRecords = waniKaniAssignmentRecords[assignment.track];
+                    if (trackRecords) trackRecords[assignment.assignmentId] = record;
+                    else waniKaniAssignmentRecords[assignment.track] = { [assignment.assignmentId]: record };
+                }
 
                 return {
-                    tokenRecords: normalizedTokenRecords,
+                    tokenRecords,
                     ankiCardRecords,
                     waniKaniSubjectRecords,
                     waniKaniAssignmentRecords,

--- a/common/dictionary-db/dictionary-db.ts
+++ b/common/dictionary-db/dictionary-db.ts
@@ -30,18 +30,18 @@ export const BUILD_MIN_EXPIRATION_MS = 5 * 60 * 1000; // 5 minutes
  */
 export const LOCAL_TOKEN_TRACK = -1; // null cannot be used in Dexie indexes
 
-export interface WaniKaniDataUpdatedAt {
-    assignments?: string;
-    subjects?: string;
-    resets?: string;
-    spacedRepetitionSystems?: string;
-}
-
 export interface AnkiMeta {
     lastBuildStartedAt: number;
     lastBuildExpiresAt: number;
     buildId: string | null;
     settings: string | null;
+}
+
+export interface WaniKaniDataUpdatedAt {
+    assignments?: string;
+    subjects?: string;
+    resets?: string;
+    spacedRepetitionSystems?: string;
 }
 
 export interface WaniKaniMeta {
@@ -95,14 +95,11 @@ export interface DictionaryAnkiCardRecord {
     suspended: boolean;
 }
 
-export type WaniKaniAssignmentDataForDB = Pick<WaniKaniAssignment['data'], 'srs_stage' | 'hidden'>;
-
+export type DictionaryWaniKaniSubjectKey = [number, number, string];
 export type WaniKaniSubjectDataForDB = Pick<
     WaniKaniSubject['data'],
-    'characters' | 'hidden_at' | 'spaced_repetition_system_id'
+    'characters' | 'hidden_at' | 'level' | 'spaced_repetition_system_id'
 >;
-
-export type DictionaryWaniKaniSubjectKey = [number, number, string];
 export interface DictionaryWaniKaniSubjectRecord {
     profile: string;
     track: number;
@@ -111,6 +108,7 @@ export interface DictionaryWaniKaniSubjectRecord {
 }
 
 export type DictionaryWaniKaniAssignmentKey = [number, number, string];
+export type WaniKaniAssignmentDataForDB = Pick<WaniKaniAssignment['data'], 'srs_stage' | 'hidden' | 'available_at'>;
 export interface DictionaryWaniKaniAssignmentRecord {
     profile: string;
     track: number;
@@ -172,10 +170,16 @@ export interface TrackStateForDB {
     yomitan: Yomitan;
 }
 
+export interface WaniKaniTokenStatusInfo {
+    subjectId: number;
+    subjectLevel: number;
+    assignmentId: number | undefined;
+    availableAt: string | null | undefined;
+}
+
 export interface TokenStatusInfo {
     cardId?: number;
-    subjectId?: number;
-    assignmentId?: number;
+    waniKani?: WaniKaniTokenStatusInfo;
     status: TokenStatus;
     suspended: boolean;
 }
@@ -347,8 +351,12 @@ export class DictionaryDB {
                         ? undefined
                         : spacedRepetitionSystemById.get(subject.data.spaced_repetition_system_id);
                 subjectStatusMap.set(subject.subjectId, {
-                    ...(assignment === undefined ? {} : { assignmentId: assignment.assignmentId }),
-                    subjectId: subject.subjectId,
+                    waniKani: {
+                        subjectId: subject.subjectId,
+                        subjectLevel: subject.data.level,
+                        assignmentId: assignment?.assignmentId,
+                        availableAt: assignment?.data.available_at,
+                    },
                     status:
                         assignment === undefined || spacedRepetitionSystem === undefined
                             ? TokenStatus.UNKNOWN
@@ -516,9 +524,9 @@ export class DictionaryDB {
      * External word sources are prioritized by highest status as a user may have abandoned a source.
      */
     async getBulk(inputProfile: string | undefined, track: number, tokens: string[]): Promise<TokenResults> {
-        const settings = await this.settingsProvider.getAll();
         if (!tokens.length) return {};
         const profile = this._getProfile(inputProfile);
+        const settings = await this.settingsProvider.getAll();
 
         return this.db.transaction(
             'r',
@@ -539,8 +547,8 @@ export class DictionaryDB {
      * External word sources are prioritized by highest status as a user may have abandoned a source.
      */
     async getAllTokens(inputProfile: string | undefined, track: number): Promise<TokenResults> {
-        const settings = await this.settingsProvider.getAll();
         const profile = this._getProfile(inputProfile);
+        const settings = await this.settingsProvider.getAll();
 
         return this.db.transaction(
             'r',
@@ -561,10 +569,10 @@ export class DictionaryDB {
      * External word sources are prioritized by highest status per lemma as a user may have abandoned a source.
      */
     async getByLemmaBulk(inputProfile: string | undefined, track: number, lemmas: string[]): Promise<LemmaResults> {
-        const settings = await this.settingsProvider.getAll();
         if (!lemmas.length) return {};
         const lemmasSet = new Set(lemmas);
         const profile = this._getProfile(inputProfile);
+        const settings = await this.settingsProvider.getAll();
 
         return this.db.transaction(
             'r',

--- a/common/dictionary-statistics/dictionary-statistics-view.ts
+++ b/common/dictionary-statistics/dictionary-statistics-view.ts
@@ -152,6 +152,26 @@ export interface DictionaryStatisticsSentenceBuckets {
     unknown: DictionaryStatisticsSentenceUnknownBucket[];
 }
 
+export interface DictionaryStatisticsRewatchProjection {
+    ankiUnknownCards?: number;
+    ankiLearningOrAboveIsMature?: boolean;
+    waniKaniLevel?: number;
+}
+
+export type DictionaryStatisticsRewatchProjectionsByTrack = Record<number, DictionaryStatisticsRewatchProjection>;
+
+export interface DictionaryStatisticsAnkiDeckProjectionStats {
+    deckName: string;
+    knownWords: number;
+    totalWords: number;
+}
+
+export interface DictionaryStatisticsWaniKaniProjectionStats {
+    level?: number;
+    knownWords: number;
+    totalWords: number;
+}
+
 export interface DictionaryStatisticsRewatchSnapshot {
     rewatch: number;
     numKnownTokens: number;
@@ -163,6 +183,8 @@ export interface DictionaryStatisticsRewatchSnapshot {
     sentenceTotals: DictionaryStatisticsSentenceTotals;
     statusCounts: DictionaryStatisticsTokenStatusCounts;
     sentenceBuckets: DictionaryStatisticsSentenceBuckets;
+    ankiDeckStats: DictionaryStatisticsAnkiDeckProjectionStats[];
+    waniKaniStats?: DictionaryStatisticsWaniKaniProjectionStats;
 }
 
 export interface DictionaryStatisticsTrackSnapshot {
@@ -187,7 +209,10 @@ export interface DictionaryStatisticsTrackSnapshot {
     statusCounts: DictionaryStatisticsTokenStatusCounts;
     frequencyBuckets: DictionaryStatisticsFrequencyBucket[];
     sentenceBuckets: DictionaryStatisticsSentenceBuckets;
+    ankiDeckStats: DictionaryStatisticsAnkiDeckProjectionStats[];
+    waniKaniStats?: DictionaryStatisticsWaniKaniProjectionStats;
     rewatchSnapshots: DictionaryStatisticsRewatchSnapshot[];
+    totalUnknownAnkiCards: number;
 }
 
 export interface DictionaryStatisticsAnkiDueCounts {
@@ -239,6 +264,8 @@ interface ProcessedSentenceSnapshot {
     sentence: DictionaryStatisticsSentence;
     tokens: ProcessedTokenSnapshots;
 }
+
+type DictionaryStatisticsDictionaryTokens = DictionaryStatisticsRawTrackSnapshot['stats']['dictionary']['tokens'];
 
 interface EvaluatedSentenceSnapshot {
     sentence: DictionaryStatisticsSentence;
@@ -330,10 +357,7 @@ function waniKaniDueAssignmentSets(reviewAssignments?: DictionaryStatisticsWaniK
     return { dueByToday, dueByTomorrow, dueByWeek };
 }
 
-function dictionaryTokenForGroupingKey(
-    groupingKey: string,
-    dictionaryTokens: DictionaryStatisticsRawTrackSnapshot['stats']['dictionary']['tokens']
-) {
+function dictionaryTokenForGroupingKey(groupingKey: string, dictionaryTokens: DictionaryStatisticsDictionaryTokens) {
     if (groupingKey in dictionaryTokens) return dictionaryTokens[groupingKey];
     if (groupingKey.startsWith('token:')) return dictionaryTokens[groupingKey.slice('token:'.length)];
     return;
@@ -841,6 +865,129 @@ function dictionaryCountsFromRaw(
     return { numKnownTokens, numIgnoredTokens };
 }
 
+function tokenStatusesForProjection(
+    tokenKey: string,
+    tokenSnapshot: ProcessedTokenSnapshot,
+    dictionaryTokens: DictionaryStatisticsDictionaryTokens
+) {
+    const token = dictionaryTokenForGroupingKey(tokenKey, dictionaryTokens);
+    return tokenSnapshot.externalCandidateStatuses ?? token?.externalCandidateStatuses ?? token?.statuses ?? [];
+}
+
+function sortedUnknownAnkiCardIds(
+    tokenEntries: [string, ProcessedTokenSnapshot][],
+    dictionaryTokens: DictionaryStatisticsDictionaryTokens,
+    cardsInfo: DictionaryStatisticsSnapshot['anki']['cardsInfo']
+) {
+    const unknownCards = new Map<number, { cardId: number; due: number }>();
+
+    for (const [tokenKey, tokenSnapshot] of tokenEntries) {
+        if (tokenSnapshot.ignored) continue;
+
+        for (const status of tokenStatusesForProjection(tokenKey, tokenSnapshot, dictionaryTokens).filter(hasCardId)) {
+            if (status.status !== TokenStatus.UNKNOWN) continue;
+
+            const due = cardsInfo[status.cardId]?.due ?? Number.POSITIVE_INFINITY;
+            const current = unknownCards.get(status.cardId);
+            if (current === undefined || due < current.due)
+                unknownCards.set(status.cardId, { cardId: status.cardId, due });
+        }
+    }
+
+    return Array.from(unknownCards.values())
+        .sort((left, right) => left.due - right.due || left.cardId - right.cardId)
+        .map(({ cardId }) => cardId);
+}
+
+interface ProjectionOptions {
+    dictionaryTokens: DictionaryStatisticsDictionaryTokens;
+    cardsInfo: DictionaryStatisticsSnapshot['anki']['cardsInfo'];
+    dictionaryAnkiTreatSuspended: TokenStatus | 'NORMAL';
+    ankiCardIds: Set<number>;
+    ankiLearningOrAboveIsMature: boolean;
+    waniKaniLevel?: number;
+}
+
+interface ProjectionData {
+    projectedStatuses: Map<string, TokenStatus>;
+    ankiDeckStats: DictionaryStatisticsAnkiDeckProjectionStats[];
+    waniKaniStats?: DictionaryStatisticsWaniKaniProjectionStats;
+}
+
+function projectedByAnki(status: TokenStatusInfo, options: ProjectionOptions) {
+    if (!hasCardId(status)) return false;
+    return (
+        options.ankiCardIds.has(status.cardId) ||
+        (options.ankiLearningOrAboveIsMature && status.status >= TokenStatus.LEARNING)
+    );
+}
+
+function projectedByWaniKani(status: TokenStatusInfo, waniKaniLevel: number | undefined) {
+    return hasWaniKani(status) && waniKaniLevel !== undefined && status.waniKani.subjectLevel <= waniKaniLevel;
+}
+
+function projectionData(tokenEntries: [string, ProcessedTokenSnapshot][], options: ProjectionOptions): ProjectionData {
+    const projectedStatuses = new Map<string, TokenStatus>();
+    const deckCounts = new Map<string, { knownWords: number; totalWords: number }>();
+    let waniKaniKnownWords = 0;
+    let waniKaniTotalWords = 0;
+
+    for (const [tokenKey, tokenSnapshot] of tokenEntries) {
+        if (tokenSnapshot.ignored) continue;
+
+        const statuses = tokenStatusesForProjection(tokenKey, tokenSnapshot, options.dictionaryTokens);
+        if (
+            statuses.some(
+                (status) => projectedByAnki(status, options) || projectedByWaniKani(status, options.waniKaniLevel)
+            )
+        ) {
+            projectedStatuses.set(tokenKey, Math.max(tokenSnapshot.status, fullyKnownTokenStatus) as TokenStatus);
+        }
+
+        const statusesByDeck = new Map<string, (TokenStatusInfo & { cardId: number })[]>();
+        for (const status of statuses.filter(hasCardId)) {
+            const deckName = options.cardsInfo[status.cardId]?.deckName;
+            if (!deckName) continue;
+
+            const deckStatuses = statusesByDeck.get(deckName) ?? [];
+            deckStatuses.push(status);
+            statusesByDeck.set(deckName, deckStatuses);
+        }
+
+        for (const [deckName, statuses] of statusesByDeck.entries()) {
+            const status = statuses.some((status) => projectedByAnki(status, options))
+                ? fullyKnownTokenStatus
+                : getTokenStatus(statuses, options.dictionaryAnkiTreatSuspended);
+
+            const counts = deckCounts.get(deckName) ?? { knownWords: 0, totalWords: 0 };
+            counts.totalWords += 1;
+            if (isTokenStatusKnown(status)) counts.knownWords += 1;
+            deckCounts.set(deckName, counts);
+        }
+
+        const waniKaniStatuses = statuses.filter(hasWaniKani);
+        if (!waniKaniStatuses.length) continue;
+
+        const waniKaniStatus = waniKaniStatuses.some((status) => projectedByWaniKani(status, options.waniKaniLevel))
+            ? fullyKnownTokenStatus
+            : getTokenStatus(waniKaniStatuses, 'NORMAL');
+
+        waniKaniTotalWords += 1;
+        if (isTokenStatusKnown(waniKaniStatus)) waniKaniKnownWords += 1;
+    }
+
+    return {
+        projectedStatuses,
+        ankiDeckStats: Array.from(deckCounts.entries())
+            .map(([deckName, counts]) => ({ deckName, ...counts }))
+            .sort((left, right) => left.deckName.localeCompare(right.deckName)),
+        waniKaniStats:
+            waniKaniTotalWords > 0
+                ? { level: options.waniKaniLevel, knownWords: waniKaniKnownWords, totalWords: waniKaniTotalWords }
+                : undefined,
+    };
+}
+
 function promoteTokenStatus(status: TokenStatus): TokenStatus {
     return Math.min(status + 1, fullyKnownTokenStatus) as TokenStatus;
 }
@@ -857,16 +1004,76 @@ function promoteProjectedStatuses(
     }
 }
 
+function projectedRewatchSnapshot(
+    rewatch: number,
+    dictionaryKnownTokens: number,
+    tokens: ProcessedTokenSnapshots,
+    sentenceSnapshots: ProcessedSentenceSnapshot[],
+    currentKnownTokens: number,
+    consideredTokens: number,
+    projectedStatuses: Map<string, TokenStatus>,
+    projectionData: ProjectionData
+): DictionaryStatisticsRewatchSnapshot {
+    const tokenEntries = Array.from(tokens.entries());
+    const evaluatedProjectedSentences = sentenceSnapshots.map((sentenceSnapshot) =>
+        evaluateSentenceSnapshot(sentenceSnapshot, projectedStatuses)
+    );
+    const projectedSentenceTotals = sentenceTotals(evaluatedProjectedSentences);
+    const projectedSentenceBuckets = buildSentenceBucketData(evaluatedProjectedSentences, tokens);
+    const { averageWordsPerSentence, averageKnownWordsPerSentence } =
+        sentenceAveragesFromTotals(projectedSentenceTotals);
+    const projectedStatusCounts = emptyStatusCounts();
+    let projectedKnownTokens = 0;
+
+    for (const [tokenKey, token] of tokenEntries) {
+        if (token.ignored) continue;
+        const projectedStatus = projectedStatuses.get(tokenKey) ?? token.status;
+        const count = projectedStatusCounts.get(projectedStatus)!;
+        count.numUnique += 1;
+        count.numOccurrences += token.numOccurrences;
+        if (isTokenStatusKnown(projectedStatus)) projectedKnownTokens += 1;
+    }
+
+    const comprehensionPercent = comprehensionFromStatusOccurrences(projectedStatusCounts);
+
+    return {
+        rewatch,
+        numKnownTokens: projectedKnownTokens,
+        numDictionaryKnownTokens: dictionaryKnownTokens + (projectedKnownTokens - currentKnownTokens),
+        knownPercent: percent(projectedKnownTokens, consideredTokens),
+        comprehensionPercent,
+        averageWordsPerSentence,
+        averageKnownWordsPerSentence,
+        sentenceTotals: projectedSentenceTotals,
+        statusCounts: projectedStatusCounts,
+        sentenceBuckets: projectedSentenceBuckets,
+        ankiDeckStats: projectionData.ankiDeckStats,
+        waniKaniStats: projectionData.waniKaniStats,
+    };
+}
+
 function rewatchSnapshotsFromRaw(
     dictionaryKnownTokens: number,
     tokens: ProcessedTokenSnapshots,
     sentenceSnapshots: ProcessedSentenceSnapshot[],
     currentKnownTokens: number,
-    consideredTokens: number
+    consideredTokens: number,
+    projectionData: ProjectionData
 ): DictionaryStatisticsRewatchSnapshot[] {
     const tokenEntries = Array.from(tokens.entries());
-    const projectedStatuses = new Map<string, TokenStatus>();
-    const rewatchSnapshots: DictionaryStatisticsRewatchSnapshot[] = [];
+    const projectedStatuses = projectionData.projectedStatuses;
+    const rewatchSnapshots: DictionaryStatisticsRewatchSnapshot[] = [
+        projectedRewatchSnapshot(
+            0,
+            dictionaryKnownTokens,
+            tokens,
+            sentenceSnapshots,
+            currentKnownTokens,
+            consideredTokens,
+            projectedStatuses,
+            projectionData
+        ),
+    ];
 
     while (true) {
         promoteProjectedStatuses(tokenEntries, projectedStatuses);
@@ -890,39 +1097,18 @@ function rewatchSnapshotsFromRaw(
             }
         }
 
-        const evaluatedProjectedSentences = sentenceSnapshots.map((sentenceSnapshot) =>
-            evaluateSentenceSnapshot(sentenceSnapshot, projectedStatuses)
+        rewatchSnapshots.push(
+            projectedRewatchSnapshot(
+                rewatchSnapshots.length,
+                dictionaryKnownTokens,
+                tokens,
+                sentenceSnapshots,
+                currentKnownTokens,
+                consideredTokens,
+                projectedStatuses,
+                projectionData
+            )
         );
-        const projectedSentenceTotals = sentenceTotals(evaluatedProjectedSentences);
-        const projectedSentenceBuckets = buildSentenceBucketData(evaluatedProjectedSentences, tokens);
-        const { averageWordsPerSentence, averageKnownWordsPerSentence } =
-            sentenceAveragesFromTotals(projectedSentenceTotals);
-        const projectedStatusCounts = emptyStatusCounts();
-        let projectedKnownTokens = 0;
-
-        for (const [tokenKey, token] of tokenEntries) {
-            if (token.ignored) continue;
-            const projectedStatus = projectedStatuses.get(tokenKey) ?? token.status;
-            const count = projectedStatusCounts.get(projectedStatus)!;
-            count.numUnique += 1;
-            count.numOccurrences += token.numOccurrences;
-            if (isTokenStatusKnown(projectedStatus)) projectedKnownTokens += 1;
-        }
-
-        const comprehensionPercent = comprehensionFromStatusOccurrences(projectedStatusCounts);
-
-        rewatchSnapshots.push({
-            rewatch: rewatchSnapshots.length + 1,
-            numKnownTokens: projectedKnownTokens,
-            numDictionaryKnownTokens: dictionaryKnownTokens + (projectedKnownTokens - currentKnownTokens),
-            knownPercent: percent(projectedKnownTokens, consideredTokens),
-            comprehensionPercent,
-            averageWordsPerSentence,
-            averageKnownWordsPerSentence,
-            sentenceTotals: projectedSentenceTotals,
-            statusCounts: projectedStatusCounts,
-            sentenceBuckets: projectedSentenceBuckets,
-        });
     }
 
     return rewatchSnapshots;
@@ -930,16 +1116,47 @@ function rewatchSnapshotsFromRaw(
 
 function processDictionaryStatisticsTrackSnapshot(
     snapshot: DictionaryStatisticsSnapshot,
-    trackSnapshot: DictionaryStatisticsRawTrackSnapshot
+    trackSnapshot: DictionaryStatisticsRawTrackSnapshot,
+    projection: DictionaryStatisticsRewatchProjection = {}
 ): DictionaryStatisticsTrackSnapshot {
     const { dictionary, sentences } = trackSnapshot.stats;
     const sentenceSnapshots = processSentenceSnapshots(sentences, 'surface');
-    const dictionaryCounts = dictionaryCountsFromRaw(
-        dictionary,
-        snapshot.settings.dictionaryTracks[trackSnapshot.track]?.dictionaryAnkiTreatSuspended ?? 'NORMAL'
-    );
+    const dictionaryAnkiTreatSuspended =
+        snapshot.settings.dictionaryTracks[trackSnapshot.track]?.dictionaryAnkiTreatSuspended ?? 'NORMAL';
+    const dictionaryCounts = dictionaryCountsFromRaw(dictionary, dictionaryAnkiTreatSuspended);
 
     const sentenceTokens = mergeSentenceTokenSnapshots(sentenceSnapshots);
+    const tokenEntries = Array.from(sentenceTokens.entries());
+    const cardsInfo = snapshot.anki.cardsInfo ?? {};
+    const unknownAnkiCardIds =
+        snapshot.anki.unknownCards?.[trackSnapshot.track] ??
+        sortedUnknownAnkiCardIds(tokenEntries, dictionary.tokens, cardsInfo);
+    const requestedAnkiUnknownCards = projection.ankiUnknownCards ?? 0;
+    const ankiUnknownCards = Number.isFinite(requestedAnkiUnknownCards)
+        ? Math.max(0, Math.min(unknownAnkiCardIds.length, Math.floor(requestedAnkiUnknownCards)))
+        : 0;
+    const waniKaniLevel =
+        projection.waniKaniLevel !== undefined &&
+        Number.isFinite(projection.waniKaniLevel) &&
+        projection.waniKaniLevel > 0
+            ? Math.floor(projection.waniKaniLevel)
+            : undefined;
+    const projectionOptions = {
+        dictionaryTokens: dictionary.tokens,
+        cardsInfo,
+        dictionaryAnkiTreatSuspended,
+    };
+    const currentKnowledgeData = projectionData(tokenEntries, {
+        ...projectionOptions,
+        ankiCardIds: new Set<number>(),
+        ankiLearningOrAboveIsMature: false,
+    });
+    const projectedData = projectionData(tokenEntries, {
+        ...projectionOptions,
+        ankiCardIds: new Set(unknownAnkiCardIds.slice(0, ankiUnknownCards)),
+        ankiLearningOrAboveIsMature: projection.ankiLearningOrAboveIsMature ?? false,
+        waniKaniLevel,
+    });
     const sentenceTokenCounts = statusCountsAndFrequencies(sentenceTokens);
 
     const {
@@ -964,7 +1181,8 @@ function processDictionaryStatisticsTrackSnapshot(
         sentenceTokens,
         sentenceSnapshots,
         sentenceTokenCounts.numKnownTokens,
-        sentenceTokenCounts.consideredTokens
+        sentenceTokenCounts.consideredTokens,
+        projectedData
     );
 
     return {
@@ -989,7 +1207,10 @@ function processDictionaryStatisticsTrackSnapshot(
         statusCounts,
         frequencyBuckets,
         sentenceBuckets: currentSentenceBuckets,
+        ankiDeckStats: currentKnowledgeData.ankiDeckStats,
+        waniKaniStats: currentKnowledgeData.waniKaniStats,
         rewatchSnapshots,
+        totalUnknownAnkiCards: unknownAnkiCardIds.length,
     };
 }
 
@@ -1110,11 +1331,12 @@ export function selectedRewatchSnapshotForTrack(
     selectedRewatchesByTrack: Record<number, number>
 ) {
     if (!trackSnapshot.rewatchSnapshots.length) return;
-    const selectedRewatch = Math.min(
-        selectedRewatchesByTrack[trackSnapshot.track] ?? 1,
-        trackSnapshot.rewatchSnapshots.length
+    const maxRewatch = trackSnapshot.rewatchSnapshots[trackSnapshot.rewatchSnapshots.length - 1].rewatch;
+    const selectedRewatch = Math.min(selectedRewatchesByTrack[trackSnapshot.track] ?? 0, maxRewatch);
+    return (
+        trackSnapshot.rewatchSnapshots.find((rewatchSnapshot) => rewatchSnapshot.rewatch === selectedRewatch) ??
+        trackSnapshot.rewatchSnapshots[0]
     );
-    return trackSnapshot.rewatchSnapshots[selectedRewatch - 1];
 }
 
 export function sortDictionaryStatisticsSentenceBucketEntries(
@@ -1210,11 +1432,13 @@ export function sortDictionaryStatisticsSentenceBucketEntries(
 }
 
 export function processDictionaryStatisticsSnapshot(
-    snapshot?: DictionaryStatisticsSnapshot
+    snapshot?: DictionaryStatisticsSnapshot,
+    projectionsByTrack: DictionaryStatisticsRewatchProjectionsByTrack = {}
 ): DictionaryStatisticsTrackSnapshot[] {
     return (
-        snapshot?.snapshots.map((trackSnapshot) => processDictionaryStatisticsTrackSnapshot(snapshot, trackSnapshot)) ??
-        []
+        snapshot?.snapshots.map((trackSnapshot) =>
+            processDictionaryStatisticsTrackSnapshot(snapshot, trackSnapshot, projectionsByTrack[trackSnapshot.track])
+        ) ?? []
     );
 }
 

--- a/common/dictionary-statistics/dictionary-statistics-view.ts
+++ b/common/dictionary-statistics/dictionary-statistics-view.ts
@@ -14,7 +14,7 @@ import {
     DictionaryStatisticsWaniKaniReviewAssignmentsSnapshot,
     REVIEW_DUES,
 } from '@project/common/dictionary-statistics';
-import { TokenStatusInfo } from '@project/common/dictionary-db';
+import { TokenStatusInfo, WaniKaniTokenStatusInfo } from '@project/common/dictionary-db';
 import {
     dedupeTokenStatusInfos,
     getTokenStatus,
@@ -269,12 +269,17 @@ function hasCardId(status: TokenStatusInfo): status is TokenStatusInfo & { cardI
     return status.cardId !== undefined;
 }
 
-function hasAssignmentId<T extends TokenStatusInfo>(status: T): status is T & { assignmentId: number } {
-    return status.assignmentId !== undefined;
+type WaniKaniTokenStatus = TokenStatusInfo & { waniKani: WaniKaniTokenStatusInfo };
+type WaniKaniAssignmentTokenStatus = TokenStatusInfo & {
+    waniKani: WaniKaniTokenStatusInfo & { assignmentId: number };
+};
+
+function hasWaniKani(status: TokenStatusInfo): status is WaniKaniTokenStatus {
+    return status.waniKani !== undefined;
 }
 
-function hasSubjectId(status: TokenStatusInfo): status is TokenStatusInfo & { subjectId: number } {
-    return status.subjectId !== undefined;
+function hasAssignmentId(status: WaniKaniTokenStatus): status is WaniKaniAssignmentTokenStatus {
+    return status.waniKani.assignmentId !== undefined;
 }
 
 function incrementAnkiDueCounts(
@@ -291,14 +296,14 @@ function incrementAnkiDueCounts(
 
 function incrementWaniKaniDueCounts(
     counts: DictionaryStatisticsWaniKaniDueCounts,
-    tokenStatuses: (TokenStatusInfo & { assignmentId: number })[],
+    tokenStatuses: WaniKaniAssignmentTokenStatus[],
     dueByToday: Set<number>,
     dueByTomorrow: Set<number>,
     dueByWeek: Set<number>
 ) {
-    if (tokenStatuses.some(({ assignmentId }) => dueByToday.has(assignmentId))) counts.today += 1;
-    if (tokenStatuses.some(({ assignmentId }) => dueByTomorrow.has(assignmentId))) counts.tomorrow += 1;
-    if (tokenStatuses.some(({ assignmentId }) => dueByWeek.has(assignmentId))) counts.week += 1;
+    if (tokenStatuses.some(({ waniKani }) => dueByToday.has(waniKani.assignmentId))) counts.today += 1;
+    if (tokenStatuses.some(({ waniKani }) => dueByTomorrow.has(waniKani.assignmentId))) counts.tomorrow += 1;
+    if (tokenStatuses.some(({ waniKani }) => dueByWeek.has(waniKani.assignmentId))) counts.week += 1;
 }
 
 function waniKaniDueAssignmentSets(reviewAssignments?: DictionaryStatisticsWaniKaniReviewAssignmentsSnapshot) {
@@ -1363,7 +1368,7 @@ export function processDictionaryStatisticsWaniKaniTrackSnapshot(
         const token = dictionaryTokenForGroupingKey(tokenKey, rawTrackSnapshot.stats.dictionary.tokens);
         if (token?.states.includes(TokenState.IGNORED)) continue;
 
-        const tokenStatuses = (tokenSnapshot.externalCandidateStatuses ?? token?.statuses ?? []).filter(hasSubjectId);
+        const tokenStatuses = (tokenSnapshot.externalCandidateStatuses ?? token?.statuses ?? []).filter(hasWaniKani);
         if (!tokenStatuses.length) continue;
 
         incrementWaniKaniDueCounts(

--- a/common/dictionary-statistics/dictionary-statistics-view.ts
+++ b/common/dictionary-statistics/dictionary-statistics-view.ts
@@ -911,29 +911,28 @@ function tokenStatusesForProjection(
     return tokenSnapshot.externalCandidateStatuses ?? token?.externalCandidateStatuses ?? token?.statuses ?? [];
 }
 
+function sortAnkiCardIdsByDue(cardIds: number[], cardsInfo: DictionaryStatisticsSnapshot['anki']['cardsInfo']) {
+    return [...cardIds].sort((left, right) => {
+        const leftDue = cardsInfo[left]?.due ?? Number.POSITIVE_INFINITY;
+        const rightDue = cardsInfo[right]?.due ?? Number.POSITIVE_INFINITY;
+        return leftDue - rightDue || left - right;
+    });
+}
+
 function sortedUnknownAnkiCardIds(
     tokenEntries: [string, ProcessedTokenSnapshot][],
     dictionaryTokens: DictionaryStatisticsDictionaryTokens,
     cardsInfo: DictionaryStatisticsSnapshot['anki']['cardsInfo']
 ) {
-    const unknownCards = new Map<number, { cardId: number; due: number }>();
-
+    const unknownCards = new Set<number>();
     for (const [tokenKey, tokenSnapshot] of tokenEntries) {
         if (tokenSnapshot.ignored) continue;
-
         for (const status of tokenStatusesForProjection(tokenKey, tokenSnapshot, dictionaryTokens).filter(hasCardId)) {
             if (status.status !== TokenStatus.UNKNOWN) continue;
-
-            const due = cardsInfo[status.cardId]?.due ?? Number.POSITIVE_INFINITY;
-            const current = unknownCards.get(status.cardId);
-            if (current === undefined || due < current.due)
-                unknownCards.set(status.cardId, { cardId: status.cardId, due });
+            unknownCards.add(status.cardId);
         }
     }
-
-    return Array.from(unknownCards.values())
-        .sort((left, right) => left.due - right.due || left.cardId - right.cardId)
-        .map(({ cardId }) => cardId);
+    return sortAnkiCardIdsByDue(Array.from(unknownCards), cardsInfo);
 }
 
 interface ProjectionOptions {
@@ -1195,9 +1194,11 @@ function processDictionaryStatisticsTrackSnapshot(
     const aggregateTokenEntries = Array.from(aggregateTokens.entries());
     const sentenceFilterTokenEntries = Array.from(sentenceFilterTokens.entries());
     const cardsInfo = snapshot.anki.cardsInfo ?? {};
+    const snapshotUnknownAnkiCardIds = snapshot.anki.unknownCards?.[trackSnapshot.track];
     const unknownAnkiCardIds =
-        snapshot.anki.unknownCards?.[trackSnapshot.track] ??
-        sortedUnknownAnkiCardIds(aggregateTokenEntries, dictionary.tokens, cardsInfo);
+        snapshotUnknownAnkiCardIds === undefined
+            ? sortedUnknownAnkiCardIds(aggregateTokenEntries, dictionary.tokens, cardsInfo)
+            : sortAnkiCardIdsByDue(snapshotUnknownAnkiCardIds, cardsInfo);
     const requestedAnkiUnknownCards = projection.ankiUnknownCards ?? 0;
     const ankiUnknownCards = Number.isFinite(requestedAnkiUnknownCards)
         ? Math.max(0, Math.min(unknownAnkiCardIds.length, Math.floor(requestedAnkiUnknownCards)))

--- a/common/dictionary-statistics/dictionary-statistics-view.ts
+++ b/common/dictionary-statistics/dictionary-statistics-view.ts
@@ -836,6 +836,22 @@ function dictionaryCountsFromRaw(
     return { numKnownTokens, numIgnoredTokens };
 }
 
+function promoteTokenStatus(status: TokenStatus): TokenStatus {
+    return Math.min(status + 1, fullyKnownTokenStatus) as TokenStatus;
+}
+
+function promoteProjectedStatuses(
+    tokenEntries: [string, ProcessedTokenSnapshot][],
+    projectedStatuses: Map<string, TokenStatus>
+) {
+    for (const [tokenKey, token] of tokenEntries) {
+        if (token.ignored) continue;
+        const currentStatus = projectedStatuses.get(tokenKey) ?? token.status;
+        if (currentStatus <= TokenStatus.UNCOLLECTED || currentStatus >= fullyKnownTokenStatus) continue;
+        projectedStatuses.set(tokenKey, promoteTokenStatus(currentStatus));
+    }
+}
+
 function rewatchSnapshotsFromRaw(
     dictionaryKnownTokens: number,
     tokens: ProcessedTokenSnapshots,
@@ -844,14 +860,12 @@ function rewatchSnapshotsFromRaw(
     consideredTokens: number
 ): DictionaryStatisticsRewatchSnapshot[] {
     const tokenEntries = Array.from(tokens.entries());
-    const projectedStatuses = new Map<string, TokenStatus>(
-        tokenEntries
-            .filter(([, token]) => token.status === TokenStatus.UNKNOWN)
-            .map(([tokenKey]) => [tokenKey, TokenStatus.LEARNING])
-    );
+    const projectedStatuses = new Map<string, TokenStatus>();
     const rewatchSnapshots: DictionaryStatisticsRewatchSnapshot[] = [];
 
     while (true) {
+        promoteProjectedStatuses(tokenEntries, projectedStatuses);
+
         const tokensToPromote = new Set<string>();
         for (const sentenceSnapshot of sentenceSnapshots) {
             const evaluated = evaluateSentenceSnapshot(sentenceSnapshot, projectedStatuses);
@@ -866,8 +880,8 @@ function rewatchSnapshotsFromRaw(
 
         for (const tokenKey of Array.from(tokensToPromote).sort()) {
             const currentStatus = projectedStatuses.get(tokenKey) ?? tokens.get(tokenKey)?.status;
-            if (currentStatus !== undefined && currentStatus < TokenStatus.LEARNING) {
-                projectedStatuses.set(tokenKey, TokenStatus.LEARNING);
+            if (currentStatus !== undefined && currentStatus < fullyKnownTokenStatus) {
+                projectedStatuses.set(tokenKey, Math.max(promoteTokenStatus(currentStatus), TokenStatus.LEARNING));
             }
         }
 

--- a/common/dictionary-statistics/dictionary-statistics-view.ts
+++ b/common/dictionary-statistics/dictionary-statistics-view.ts
@@ -934,14 +934,13 @@ function processDictionaryStatisticsTrackSnapshot(
 ): DictionaryStatisticsTrackSnapshot {
     const { dictionary, sentences } = trackSnapshot.stats;
     const sentenceSnapshots = processSentenceSnapshots(sentences, 'surface');
-    const aggregateSentenceSnapshots = processSentenceSnapshots(sentences, 'lemma');
     const dictionaryCounts = dictionaryCountsFromRaw(
         dictionary,
         snapshot.settings.dictionaryTracks[trackSnapshot.track]?.dictionaryAnkiTreatSuspended ?? 'NORMAL'
     );
 
-    const aggregateTokens = mergeSentenceTokenSnapshots(aggregateSentenceSnapshots);
     const sentenceTokens = mergeSentenceTokenSnapshots(sentenceSnapshots);
+    const sentenceTokenCounts = statusCountsAndFrequencies(sentenceTokens);
 
     const {
         statusCounts,
@@ -950,11 +949,10 @@ function processDictionaryStatisticsTrackSnapshot(
         numIgnoredTokens,
         numIgnoredOccurrences,
         numKnownTokens,
-    } = statusCountsAndFrequencies(aggregateTokens);
+    } = sentenceTokenCounts;
     const evaluatedSentenceSnapshots = sentenceSnapshots.map((sentenceSnapshot) =>
         evaluateSentenceSnapshot(sentenceSnapshot)
     );
-    const sentenceTokenCounts = statusCountsAndFrequencies(sentenceTokens);
     const currentSentenceTotals = sentenceTotals(evaluatedSentenceSnapshots);
     const { averageWordsPerSentence, averageKnownWordsPerSentence } = sentenceAveragesFromTotals(currentSentenceTotals);
     const currentSentenceBuckets = buildSentenceBucketData(evaluatedSentenceSnapshots, sentenceTokens);
@@ -976,7 +974,7 @@ function processDictionaryStatisticsTrackSnapshot(
         statusColors: trackSnapshot.statusColors,
         numDictionaryKnownTokens: dictionaryCounts.numKnownTokens,
         numDictionaryIgnoredTokens: dictionaryCounts.numIgnoredTokens,
-        numUniqueTokens: aggregateTokens.size,
+        numUniqueTokens: sentenceTokens.size,
         consideredTokens,
         numIgnoredTokens,
         numIgnoredOccurrences,

--- a/common/dictionary-statistics/dictionary-statistics-view.ts
+++ b/common/dictionary-statistics/dictionary-statistics-view.ts
@@ -265,6 +265,8 @@ interface ProcessedSentenceSnapshot {
     tokens: ProcessedTokenSnapshots;
 }
 
+type TokenGrouping = 'surface' | 'lemma';
+
 type DictionaryStatisticsDictionaryTokens = DictionaryStatisticsRawTrackSnapshot['stats']['dictionary']['tokens'];
 
 interface EvaluatedSentenceSnapshot {
@@ -551,7 +553,7 @@ function mergeTokenSnapshot(
 
 function processSentenceSnapshots(
     sentences: DictionaryStatisticsSentences,
-    grouping: 'surface' | 'lemma'
+    grouping: TokenGrouping
 ): ProcessedSentenceSnapshot[] {
     const sentenceSnapshots: ProcessedSentenceSnapshot[] = [];
     for (const sentence of Object.values(sentences).sort((left, right) => left.index - right.index)) {
@@ -575,6 +577,41 @@ function processSentenceSnapshots(
         sentenceSnapshots.push({ sentence, tokens });
     }
     return sentenceSnapshots;
+}
+
+function surfaceProjectedStatusesForGrouping(
+    sentenceSnapshots: ProcessedSentenceSnapshot[],
+    projectedStatuses: Map<string, TokenStatus>,
+    grouping: TokenGrouping
+) {
+    const groupedStatuses = new Map<string, TokenStatus>();
+    for (const { sentence } of sentenceSnapshots) {
+        for (const token of sentence.tokenization?.tokens ?? []) {
+            const sourceKey = token.groupingKey;
+            const targetKey = grouping === 'lemma' ? (token.lemmasGroupingKey ?? token.groupingKey) : token.groupingKey;
+            if (!sourceKey || !targetKey || token.states.includes(TokenState.IGNORED)) continue;
+            const projectedStatus = projectedStatuses.get(sourceKey);
+            if (projectedStatus === undefined) continue;
+            const tokenText = sentence.text.substring(token.pos[0], token.pos[1]);
+            if (!HAS_LETTER_REGEX.test(tokenText)) continue;
+
+            groupedStatuses.set(
+                targetKey,
+                Math.max(groupedStatuses.get(targetKey) ?? projectedStatus, projectedStatus) as TokenStatus
+            );
+        }
+    }
+    return groupedStatuses;
+}
+
+function mergeProjectedStatuses(...projectedStatusMaps: Map<string, TokenStatus>[]) {
+    const mergedStatuses = new Map<string, TokenStatus>();
+    for (const projectedStatuses of projectedStatusMaps) {
+        for (const [tokenKey, status] of projectedStatuses.entries()) {
+            mergedStatuses.set(tokenKey, Math.max(mergedStatuses.get(tokenKey) ?? status, status) as TokenStatus);
+        }
+    }
+    return mergedStatuses;
 }
 
 function mergeSentenceTokenSnapshots(sentenceSnapshots: ProcessedSentenceSnapshot[]): ProcessedTokenSnapshots {
@@ -602,7 +639,7 @@ function evaluateSentenceSnapshot(
     for (const [tokenKey, token] of sentenceSnapshot.tokens.entries()) {
         if (token.ignored) continue;
 
-        const status = projectedStatuses?.get(tokenKey) ?? token.status;
+        const status = Math.max(projectedStatuses?.get(tokenKey) ?? token.status, token.status) as TokenStatus;
         numConsideredTokens += 1;
         consideredTokenKeys.push(tokenKey);
         const count = statusCounts.get(status)!;
@@ -1007,19 +1044,25 @@ function promoteProjectedStatuses(
 function projectedRewatchSnapshot(
     rewatch: number,
     dictionaryKnownTokens: number,
-    tokens: ProcessedTokenSnapshots,
-    sentenceSnapshots: ProcessedSentenceSnapshot[],
+    aggregateTokens: ProcessedTokenSnapshots,
+    aggregateSentenceSnapshots: ProcessedSentenceSnapshot[],
+    sentenceFilterTokens: ProcessedTokenSnapshots,
+    sentenceFilterSnapshots: ProcessedSentenceSnapshot[],
     currentKnownTokens: number,
     consideredTokens: number,
-    projectedStatuses: Map<string, TokenStatus>,
+    aggregateProjectedStatuses: Map<string, TokenStatus>,
+    sentenceFilterProjectedStatuses: Map<string, TokenStatus>,
     projectionData: ProjectionData
 ): DictionaryStatisticsRewatchSnapshot {
-    const tokenEntries = Array.from(tokens.entries());
-    const evaluatedProjectedSentences = sentenceSnapshots.map((sentenceSnapshot) =>
-        evaluateSentenceSnapshot(sentenceSnapshot, projectedStatuses)
+    const tokenEntries = Array.from(aggregateTokens.entries());
+    const evaluatedProjectedSentences = aggregateSentenceSnapshots.map((sentenceSnapshot) =>
+        evaluateSentenceSnapshot(sentenceSnapshot, aggregateProjectedStatuses)
+    );
+    const evaluatedSentenceFilters = sentenceFilterSnapshots.map((sentenceSnapshot) =>
+        evaluateSentenceSnapshot(sentenceSnapshot, sentenceFilterProjectedStatuses)
     );
     const projectedSentenceTotals = sentenceTotals(evaluatedProjectedSentences);
-    const projectedSentenceBuckets = buildSentenceBucketData(evaluatedProjectedSentences, tokens);
+    const projectedSentenceBuckets = buildSentenceBucketData(evaluatedSentenceFilters, sentenceFilterTokens);
     const { averageWordsPerSentence, averageKnownWordsPerSentence } =
         sentenceAveragesFromTotals(projectedSentenceTotals);
     const projectedStatusCounts = emptyStatusCounts();
@@ -1027,7 +1070,10 @@ function projectedRewatchSnapshot(
 
     for (const [tokenKey, token] of tokenEntries) {
         if (token.ignored) continue;
-        const projectedStatus = projectedStatuses.get(tokenKey) ?? token.status;
+        const projectedStatus = Math.max(
+            aggregateProjectedStatuses.get(tokenKey) ?? token.status,
+            token.status
+        ) as TokenStatus;
         const count = projectedStatusCounts.get(projectedStatus)!;
         count.numUnique += 1;
         count.numOccurrences += token.numOccurrences;
@@ -1054,33 +1100,44 @@ function projectedRewatchSnapshot(
 
 function rewatchSnapshotsFromRaw(
     dictionaryKnownTokens: number,
-    tokens: ProcessedTokenSnapshots,
-    sentenceSnapshots: ProcessedSentenceSnapshot[],
+    aggregateTokens: ProcessedTokenSnapshots,
+    aggregateSentenceSnapshots: ProcessedSentenceSnapshot[],
+    sentenceFilterTokens: ProcessedTokenSnapshots,
+    sentenceFilterSnapshots: ProcessedSentenceSnapshot[],
     currentKnownTokens: number,
     consideredTokens: number,
-    projectionData: ProjectionData
+    aggregateProjectionData: ProjectionData,
+    sentenceFilterProjectionData: ProjectionData
 ): DictionaryStatisticsRewatchSnapshot[] {
-    const tokenEntries = Array.from(tokens.entries());
-    const projectedStatuses = projectionData.projectedStatuses;
+    const tokenEntries = Array.from(sentenceFilterTokens.entries());
+    const sentenceFilterProjectedStatuses = sentenceFilterProjectionData.projectedStatuses;
+    const aggregateProjectedStatuses = () =>
+        mergeProjectedStatuses(
+            aggregateProjectionData.projectedStatuses,
+            surfaceProjectedStatusesForGrouping(sentenceFilterSnapshots, sentenceFilterProjectedStatuses, 'lemma')
+        );
     const rewatchSnapshots: DictionaryStatisticsRewatchSnapshot[] = [
         projectedRewatchSnapshot(
             0,
             dictionaryKnownTokens,
-            tokens,
-            sentenceSnapshots,
+            aggregateTokens,
+            aggregateSentenceSnapshots,
+            sentenceFilterTokens,
+            sentenceFilterSnapshots,
             currentKnownTokens,
             consideredTokens,
-            projectedStatuses,
-            projectionData
+            aggregateProjectedStatuses(),
+            sentenceFilterProjectedStatuses,
+            aggregateProjectionData
         ),
     ];
 
     while (true) {
-        promoteProjectedStatuses(tokenEntries, projectedStatuses);
+        promoteProjectedStatuses(tokenEntries, sentenceFilterProjectedStatuses);
 
         const tokensToPromote = new Set<string>();
-        for (const sentenceSnapshot of sentenceSnapshots) {
-            const evaluated = evaluateSentenceSnapshot(sentenceSnapshot, projectedStatuses);
+        for (const sentenceSnapshot of sentenceFilterSnapshots) {
+            const evaluated = evaluateSentenceSnapshot(sentenceSnapshot, sentenceFilterProjectedStatuses);
             const isIPlusOneUncollected =
                 evaluated.numConsideredTokens > 0 && evaluated.numKnownTokens === evaluated.numConsideredTokens - 1;
             if (!isIPlusOneUncollected) continue;
@@ -1091,9 +1148,13 @@ function rewatchSnapshotsFromRaw(
         if (!tokensToPromote.size) break;
 
         for (const tokenKey of Array.from(tokensToPromote).sort()) {
-            const currentStatus = projectedStatuses.get(tokenKey) ?? tokens.get(tokenKey)?.status;
+            const currentStatus =
+                sentenceFilterProjectedStatuses.get(tokenKey) ?? sentenceFilterTokens.get(tokenKey)?.status;
             if (currentStatus !== undefined && currentStatus < fullyKnownTokenStatus) {
-                projectedStatuses.set(tokenKey, Math.max(promoteTokenStatus(currentStatus), TokenStatus.LEARNING));
+                sentenceFilterProjectedStatuses.set(
+                    tokenKey,
+                    Math.max(promoteTokenStatus(currentStatus), TokenStatus.LEARNING) as TokenStatus
+                );
             }
         }
 
@@ -1101,12 +1162,15 @@ function rewatchSnapshotsFromRaw(
             projectedRewatchSnapshot(
                 rewatchSnapshots.length,
                 dictionaryKnownTokens,
-                tokens,
-                sentenceSnapshots,
+                aggregateTokens,
+                aggregateSentenceSnapshots,
+                sentenceFilterTokens,
+                sentenceFilterSnapshots,
                 currentKnownTokens,
                 consideredTokens,
-                projectedStatuses,
-                projectionData
+                aggregateProjectedStatuses(),
+                sentenceFilterProjectedStatuses,
+                aggregateProjectionData
             )
         );
     }
@@ -1120,17 +1184,20 @@ function processDictionaryStatisticsTrackSnapshot(
     projection: DictionaryStatisticsRewatchProjection = {}
 ): DictionaryStatisticsTrackSnapshot {
     const { dictionary, sentences } = trackSnapshot.stats;
-    const sentenceSnapshots = processSentenceSnapshots(sentences, 'surface');
+    const aggregateSentenceSnapshots = processSentenceSnapshots(sentences, 'lemma');
+    const sentenceFilterSnapshots = processSentenceSnapshots(sentences, 'surface');
     const dictionaryAnkiTreatSuspended =
         snapshot.settings.dictionaryTracks[trackSnapshot.track]?.dictionaryAnkiTreatSuspended ?? 'NORMAL';
     const dictionaryCounts = dictionaryCountsFromRaw(dictionary, dictionaryAnkiTreatSuspended);
 
-    const sentenceTokens = mergeSentenceTokenSnapshots(sentenceSnapshots);
-    const tokenEntries = Array.from(sentenceTokens.entries());
+    const aggregateTokens = mergeSentenceTokenSnapshots(aggregateSentenceSnapshots);
+    const sentenceFilterTokens = mergeSentenceTokenSnapshots(sentenceFilterSnapshots);
+    const aggregateTokenEntries = Array.from(aggregateTokens.entries());
+    const sentenceFilterTokenEntries = Array.from(sentenceFilterTokens.entries());
     const cardsInfo = snapshot.anki.cardsInfo ?? {};
     const unknownAnkiCardIds =
         snapshot.anki.unknownCards?.[trackSnapshot.track] ??
-        sortedUnknownAnkiCardIds(tokenEntries, dictionary.tokens, cardsInfo);
+        sortedUnknownAnkiCardIds(aggregateTokenEntries, dictionary.tokens, cardsInfo);
     const requestedAnkiUnknownCards = projection.ankiUnknownCards ?? 0;
     const ankiUnknownCards = Number.isFinite(requestedAnkiUnknownCards)
         ? Math.max(0, Math.min(unknownAnkiCardIds.length, Math.floor(requestedAnkiUnknownCards)))
@@ -1146,18 +1213,24 @@ function processDictionaryStatisticsTrackSnapshot(
         cardsInfo,
         dictionaryAnkiTreatSuspended,
     };
-    const currentKnowledgeData = projectionData(tokenEntries, {
+    const currentKnowledgeData = projectionData(aggregateTokenEntries, {
         ...projectionOptions,
         ankiCardIds: new Set<number>(),
         ankiLearningOrAboveIsMature: false,
     });
-    const projectedData = projectionData(tokenEntries, {
+    const aggregateProjectedData = projectionData(aggregateTokenEntries, {
         ...projectionOptions,
         ankiCardIds: new Set(unknownAnkiCardIds.slice(0, ankiUnknownCards)),
         ankiLearningOrAboveIsMature: projection.ankiLearningOrAboveIsMature ?? false,
         waniKaniLevel,
     });
-    const sentenceTokenCounts = statusCountsAndFrequencies(sentenceTokens);
+    const sentenceFilterProjectedData = projectionData(sentenceFilterTokenEntries, {
+        ...projectionOptions,
+        ankiCardIds: new Set(unknownAnkiCardIds.slice(0, ankiUnknownCards)),
+        ankiLearningOrAboveIsMature: projection.ankiLearningOrAboveIsMature ?? false,
+        waniKaniLevel,
+    });
+    const sentenceTokenCounts = statusCountsAndFrequencies(aggregateTokens);
 
     const {
         statusCounts,
@@ -1167,22 +1240,28 @@ function processDictionaryStatisticsTrackSnapshot(
         numIgnoredOccurrences,
         numKnownTokens,
     } = sentenceTokenCounts;
-    const evaluatedSentenceSnapshots = sentenceSnapshots.map((sentenceSnapshot) =>
+    const evaluatedSentenceSnapshots = aggregateSentenceSnapshots.map((sentenceSnapshot) =>
+        evaluateSentenceSnapshot(sentenceSnapshot)
+    );
+    const evaluatedSentenceFilters = sentenceFilterSnapshots.map((sentenceSnapshot) =>
         evaluateSentenceSnapshot(sentenceSnapshot)
     );
     const currentSentenceTotals = sentenceTotals(evaluatedSentenceSnapshots);
     const { averageWordsPerSentence, averageKnownWordsPerSentence } = sentenceAveragesFromTotals(currentSentenceTotals);
-    const currentSentenceBuckets = buildSentenceBucketData(evaluatedSentenceSnapshots, sentenceTokens);
+    const currentSentenceBuckets = buildSentenceBucketData(evaluatedSentenceFilters, sentenceFilterTokens);
     const sentenceComprehensionPoints = sentenceComprehensionPointsFromSentenceTotals(currentSentenceTotals);
-    const trackAllSentenceEntries = allSentenceEntries(evaluatedSentenceSnapshots, sentenceTokens);
+    const trackAllSentenceEntries = allSentenceEntries(evaluatedSentenceSnapshots, aggregateTokens);
     const comprehensionPercent = comprehensionFromStatusOccurrences(statusCounts);
     const rewatchSnapshots = rewatchSnapshotsFromRaw(
         dictionaryCounts.numKnownTokens,
-        sentenceTokens,
-        sentenceSnapshots,
+        aggregateTokens,
+        aggregateSentenceSnapshots,
+        sentenceFilterTokens,
+        sentenceFilterSnapshots,
         sentenceTokenCounts.numKnownTokens,
         sentenceTokenCounts.consideredTokens,
-        projectedData
+        aggregateProjectedData,
+        sentenceFilterProjectedData
     );
 
     return {
@@ -1192,7 +1271,7 @@ function processDictionaryStatisticsTrackSnapshot(
         statusColors: trackSnapshot.statusColors,
         numDictionaryKnownTokens: dictionaryCounts.numKnownTokens,
         numDictionaryIgnoredTokens: dictionaryCounts.numIgnoredTokens,
-        numUniqueTokens: sentenceTokens.size,
+        numUniqueTokens: aggregateTokens.size,
         consideredTokens,
         numIgnoredTokens,
         numIgnoredOccurrences,
@@ -1637,13 +1716,15 @@ function processSimplifiedDictionaryStatisticsTrackSnapshot(
     trackSnapshot: DictionaryStatisticsRawTrackSnapshot
 ): DictionarySimplifiedStatisticsTrackSnapshot {
     const { sentences } = trackSnapshot.stats;
-    const sentenceSnapshots = processSentenceSnapshots(sentences, 'surface');
-    const tokens = mergeSentenceTokenSnapshots(sentenceSnapshots);
-    const { statusCounts } = statusCountsAndFrequencies(tokens);
-    const evaluatedSentenceSnapshots = sentenceSnapshots.map((sentenceSnapshot) =>
+    const aggregateSentenceSnapshots = processSentenceSnapshots(sentences, 'lemma');
+    const sentenceFilterSnapshots = processSentenceSnapshots(sentences, 'surface');
+    const aggregateTokens = mergeSentenceTokenSnapshots(aggregateSentenceSnapshots);
+    const sentenceFilterTokens = mergeSentenceTokenSnapshots(sentenceFilterSnapshots);
+    const { statusCounts } = statusCountsAndFrequencies(aggregateTokens);
+    const evaluatedSentenceSnapshots = sentenceFilterSnapshots.map((sentenceSnapshot) =>
         evaluateSentenceSnapshot(sentenceSnapshot)
     );
-    const sentenceBuckets = buildSentenceBucketData(evaluatedSentenceSnapshots, tokens);
+    const sentenceBuckets = buildSentenceBucketData(evaluatedSentenceSnapshots, sentenceFilterTokens);
     const comprehensionPercent = comprehensionFromStatusOccurrences(statusCounts);
     const progress = trackSnapshot.progress;
     return { comprehensionPercent, sentenceBuckets, progress };

--- a/common/dictionary-statistics/dictionary-statistics-view.ts
+++ b/common/dictionary-statistics/dictionary-statistics-view.ts
@@ -11,7 +11,7 @@ import {
     DictionaryStatisticsSentence,
     DictionaryStatisticsSentences,
     DictionaryStatisticsSnapshot,
-    DictionaryStatisticsWaniKaniReviewAssignmentsSnapshot,
+    DictionaryStatisticsWaniKaniSnapshot,
     REVIEW_DUES,
 } from '@project/common/dictionary-statistics';
 import { TokenStatusInfo, WaniKaniTokenStatusInfo } from '@project/common/dictionary-db';
@@ -153,12 +153,17 @@ export interface DictionaryStatisticsSentenceBuckets {
 }
 
 export interface DictionaryStatisticsRewatchProjection {
-    ankiUnknownCards?: number;
+    ankiUnknownCardsByDeck?: Record<string, number>;
     ankiLearningOrAboveIsMature?: boolean;
     waniKaniLevel?: number;
 }
 
 export type DictionaryStatisticsRewatchProjectionsByTrack = Record<number, DictionaryStatisticsRewatchProjection>;
+
+export interface DictionaryStatisticsAnkiUnknownCardsByDeck {
+    deckName: string;
+    totalUnknownCards: number;
+}
 
 export interface DictionaryStatisticsAnkiDeckProjectionStats {
     deckName: string;
@@ -213,6 +218,7 @@ export interface DictionaryStatisticsTrackSnapshot {
     waniKaniStats?: DictionaryStatisticsWaniKaniProjectionStats;
     rewatchSnapshots: DictionaryStatisticsRewatchSnapshot[];
     totalUnknownAnkiCards: number;
+    unknownAnkiCardsByDeck: DictionaryStatisticsAnkiUnknownCardsByDeck[];
 }
 
 export interface DictionaryStatisticsAnkiDueCounts {
@@ -335,25 +341,26 @@ function incrementWaniKaniDueCounts(
     if (tokenStatuses.some(({ waniKani }) => dueByWeek.has(waniKani.assignmentId))) counts.week += 1;
 }
 
-function waniKaniDueAssignmentSets(reviewAssignments?: DictionaryStatisticsWaniKaniReviewAssignmentsSnapshot) {
+function waniKaniDueAssignmentSets(waniKaniSnapshot?: DictionaryStatisticsWaniKaniSnapshot) {
+    const dueByToday = new Set<number>();
+    const dueByTomorrow = new Set<number>();
+    const dueByWeek = new Set<number>();
+    if (!waniKaniSnapshot) return { dueByToday, dueByTomorrow, dueByWeek };
+
     const todayStart = utcStartOfToday();
     const todayEnd = todayStart.getTime() + (REVIEW_DUES[0] + 1) * MS_PER_DAY;
     const tomorrowEnd = todayStart.getTime() + (REVIEW_DUES[1] + 1) * MS_PER_DAY;
     const weekEnd = todayStart.getTime() + REVIEW_DUES[2] * MS_PER_DAY;
-    const dueByToday = new Set<number>();
-    const dueByTomorrow = new Set<number>();
-    const dueByWeek = new Set<number>();
-
-    for (const [assignmentIdString, assignment] of Object.entries(reviewAssignments ?? {})) {
+    for (const assignment of waniKaniSnapshot.assignments) {
         if (assignment.data.hidden) continue;
-        const assignmentId = Number(assignmentIdString);
+        if (waniKaniSnapshot.subjects[assignment.subjectId]?.data.hidden_at) continue;
         const availableAt = assignment.data.available_at;
-        if (availableAt === null) continue;
+        if (availableAt === null || availableAt === undefined) continue;
         const availableAtTime = Date.parse(availableAt);
-        if (!Number.isFinite(assignmentId) || !Number.isFinite(availableAtTime)) continue;
-        if (availableAtTime < todayEnd) dueByToday.add(assignmentId);
-        if (availableAtTime < tomorrowEnd) dueByTomorrow.add(assignmentId);
-        if (availableAtTime < weekEnd) dueByWeek.add(assignmentId);
+        if (!Number.isFinite(availableAtTime)) continue;
+        if (availableAtTime < todayEnd) dueByToday.add(assignment.assignmentId);
+        if (availableAtTime < tomorrowEnd) dueByTomorrow.add(assignment.assignmentId);
+        if (availableAtTime < weekEnd) dueByWeek.add(assignment.assignmentId);
     }
 
     return { dueByToday, dueByTomorrow, dueByWeek };
@@ -920,19 +927,57 @@ function sortAnkiCardIdsByDue(cardIds: number[], cardsInfo: DictionaryStatistics
 }
 
 function sortedUnknownAnkiCardIds(
-    tokenEntries: [string, ProcessedTokenSnapshot][],
-    dictionaryTokens: DictionaryStatisticsDictionaryTokens,
+    cardsStatus: DictionaryStatisticsSnapshot['anki']['cardsStatus'],
     cardsInfo: DictionaryStatisticsSnapshot['anki']['cardsInfo']
 ) {
-    const unknownCards = new Set<number>();
-    for (const [tokenKey, tokenSnapshot] of tokenEntries) {
-        if (tokenSnapshot.ignored) continue;
-        for (const status of tokenStatusesForProjection(tokenKey, tokenSnapshot, dictionaryTokens).filter(hasCardId)) {
-            if (status.status !== TokenStatus.UNKNOWN) continue;
-            unknownCards.add(status.cardId);
-        }
+    if (cardsStatus === undefined) return [];
+    const unknownCards = Object.entries(cardsStatus).flatMap(([cardId, status]) =>
+        status === TokenStatus.UNKNOWN ? [Number(cardId)] : []
+    );
+    return sortAnkiCardIdsByDue(unknownCards, cardsInfo);
+}
+
+interface UnknownAnkiCardsByDeck extends DictionaryStatisticsAnkiUnknownCardsByDeck {
+    cardIds: number[];
+}
+
+function groupUnknownAnkiCardIdsByDeck(
+    cardIds: number[],
+    cardsInfo: DictionaryStatisticsSnapshot['anki']['cardsInfo']
+): UnknownAnkiCardsByDeck[] {
+    const cardsByDeck = new Map<string, number[]>();
+    for (const cardId of cardIds) {
+        const deckName = cardsInfo[cardId]?.deckName;
+        if (!deckName) continue;
+
+        const deckCardIds = cardsByDeck.get(deckName);
+        if (deckCardIds) deckCardIds.push(cardId);
+        else cardsByDeck.set(deckName, [cardId]);
     }
-    return sortAnkiCardIdsByDue(Array.from(unknownCards), cardsInfo);
+
+    return Array.from(cardsByDeck.entries())
+        .map(([deckName, cardIds]) => ({ deckName, cardIds, totalUnknownCards: cardIds.length }))
+        .sort((left, right) => left.deckName.localeCompare(right.deckName));
+}
+
+function clampedProjectedAnkiUnknownCards(value: number | undefined, total: number) {
+    const requestedCards = value ?? 0;
+    return Number.isFinite(requestedCards) ? Math.max(0, Math.min(total, Math.floor(requestedCards))) : 0;
+}
+
+function projectedUnknownAnkiCardIds(
+    unknownAnkiCardsByDeck: UnknownAnkiCardsByDeck[],
+    projection: DictionaryStatisticsRewatchProjection
+) {
+    return new Set(
+        unknownAnkiCardsByDeck.flatMap(({ deckName, cardIds, totalUnknownCards }) => {
+            const count = clampedProjectedAnkiUnknownCards(
+                projection.ankiUnknownCardsByDeck?.[deckName],
+                totalUnknownCards
+            );
+            return cardIds.slice(0, count);
+        })
+    );
 }
 
 interface ProjectionOptions {
@@ -1194,15 +1239,9 @@ function processDictionaryStatisticsTrackSnapshot(
     const aggregateTokenEntries = Array.from(aggregateTokens.entries());
     const sentenceFilterTokenEntries = Array.from(sentenceFilterTokens.entries());
     const cardsInfo = snapshot.anki.cardsInfo ?? {};
-    const snapshotUnknownAnkiCardIds = snapshot.anki.unknownCards?.[trackSnapshot.track];
-    const unknownAnkiCardIds =
-        snapshotUnknownAnkiCardIds === undefined
-            ? sortedUnknownAnkiCardIds(aggregateTokenEntries, dictionary.tokens, cardsInfo)
-            : sortAnkiCardIdsByDue(snapshotUnknownAnkiCardIds, cardsInfo);
-    const requestedAnkiUnknownCards = projection.ankiUnknownCards ?? 0;
-    const ankiUnknownCards = Number.isFinite(requestedAnkiUnknownCards)
-        ? Math.max(0, Math.min(unknownAnkiCardIds.length, Math.floor(requestedAnkiUnknownCards)))
-        : 0;
+    const unknownAnkiCardIds = sortedUnknownAnkiCardIds(snapshot.anki.cardsStatus, cardsInfo);
+    const unknownAnkiCardsByDeck = groupUnknownAnkiCardIdsByDeck(unknownAnkiCardIds, cardsInfo);
+    const projectedAnkiCardIds = projectedUnknownAnkiCardIds(unknownAnkiCardsByDeck, projection);
     const waniKaniLevel =
         projection.waniKaniLevel !== undefined &&
         Number.isFinite(projection.waniKaniLevel) &&
@@ -1221,13 +1260,13 @@ function processDictionaryStatisticsTrackSnapshot(
     });
     const aggregateProjectedData = projectionData(aggregateTokenEntries, {
         ...projectionOptions,
-        ankiCardIds: new Set(unknownAnkiCardIds.slice(0, ankiUnknownCards)),
+        ankiCardIds: projectedAnkiCardIds,
         ankiLearningOrAboveIsMature: projection.ankiLearningOrAboveIsMature ?? false,
         waniKaniLevel,
     });
     const sentenceFilterProjectedData = projectionData(sentenceFilterTokenEntries, {
         ...projectionOptions,
-        ankiCardIds: new Set(unknownAnkiCardIds.slice(0, ankiUnknownCards)),
+        ankiCardIds: projectedAnkiCardIds,
         ankiLearningOrAboveIsMature: projection.ankiLearningOrAboveIsMature ?? false,
         waniKaniLevel,
     });
@@ -1291,6 +1330,10 @@ function processDictionaryStatisticsTrackSnapshot(
         waniKaniStats: currentKnowledgeData.waniKaniStats,
         rewatchSnapshots,
         totalUnknownAnkiCards: unknownAnkiCardIds.length,
+        unknownAnkiCardsByDeck: unknownAnkiCardsByDeck.map(({ deckName, totalUnknownCards }) => ({
+            deckName,
+            totalUnknownCards,
+        })),
     };
 }
 
@@ -1659,7 +1702,7 @@ export function processDictionaryStatisticsWaniKaniTrackSnapshot(
         };
     }
 
-    const { dueByToday, dueByTomorrow, dueByWeek } = waniKaniDueAssignmentSets(waniKaniSnapshot?.reviewAssignments);
+    const { dueByToday, dueByTomorrow, dueByWeek } = waniKaniDueAssignmentSets(waniKaniSnapshot);
     const sentenceSnapshots = processSentenceSnapshots(rawTrackSnapshot.stats.sentences, 'lemma');
     const tokens = mergeSentenceTokenSnapshots(sentenceSnapshots);
     const waniKaniTokenSnapshots: ProcessedTokenSnapshot[] = [];

--- a/common/dictionary-statistics/dictionary-statistics.ts
+++ b/common/dictionary-statistics/dictionary-statistics.ts
@@ -1,6 +1,10 @@
 import { Progress, Tokenization } from '@project/common';
 import { CardInfo } from '@project/common/anki';
-import { DictionaryProvider, TokenResults } from '@project/common/dictionary-db';
+import type {
+    DictionaryProvider,
+    DictionaryWaniKaniAssignmentRecordWithStatus,
+    TokenResults,
+} from '@project/common/dictionary-db';
 import {
     defaultSettings,
     dictionaryTrackEnabled,
@@ -10,7 +14,6 @@ import {
     TokenStatusConfig,
     TokenStatus,
 } from '@project/common/settings';
-import { WaniKaniAssignment } from '@project/common/wanikani';
 
 export const REVIEW_DUES = [0, 1, 7] as const; // 0 = due today, 1 = due within a day, 7 = due within a week
 
@@ -33,7 +36,10 @@ export interface DictionaryStatisticsAnkiSnapshot {
     dueCards: DictionaryStatisticsAnkiDueCardsSnapshot;
 }
 
-export type DictionaryStatisticsWaniKaniReviewAssignmentsSnapshot = Record<number, WaniKaniAssignment>;
+export type DictionaryStatisticsWaniKaniReviewAssignmentsSnapshot = Record<
+    number,
+    DictionaryWaniKaniAssignmentRecordWithStatus
+>;
 
 export interface DictionaryStatisticsWaniKaniSnapshot {
     available?: boolean;
@@ -165,7 +171,6 @@ export class DictionaryStatistics {
     async refreshDictionaryTokens(profile: string | undefined): Promise<void> {
         const startTime = Date.now();
         const dictionaryTracks = await this.settingsProvider.getSingle('dictionaryTracks');
-        for (const dt of dictionaryTracks) (dt as any).dictionaryWaniKaniApiToken = '';
         const settings = { dictionaryTracks };
         this.settings = settings;
         await Promise.all(

--- a/common/dictionary-statistics/dictionary-statistics.ts
+++ b/common/dictionary-statistics/dictionary-statistics.ts
@@ -3,6 +3,7 @@ import type {
     CardInfoForDB,
     DictionaryProvider,
     DictionaryWaniKaniAssignmentRecordWithStatus,
+    DictionaryWaniKaniSubjectRecord,
     TokenResults,
 } from '@project/common/dictionary-db';
 import {
@@ -28,24 +29,19 @@ export interface DictionaryStatisticsSentence {
 }
 
 export type DictionaryStatisticsAnkiDueCardsSnapshot = Record<number, number[]>; // [0, [...]] due today, [7, [...]] due within a week
-export type DictionaryStatisticsAnkiUnknownCardsSnapshot = Record<number, number[]>; // Unknown card ids per track
 
 export interface DictionaryStatisticsAnkiSnapshot {
     available?: boolean;
     progress?: Progress;
     cardsInfo: Record<number, CardInfoForDB>;
     dueCards: DictionaryStatisticsAnkiDueCardsSnapshot;
-    unknownCards?: DictionaryStatisticsAnkiUnknownCardsSnapshot;
+    cardsStatus?: Record<number, TokenStatus>;
 }
-
-export type DictionaryStatisticsWaniKaniReviewAssignmentsSnapshot = Record<
-    number,
-    DictionaryWaniKaniAssignmentRecordWithStatus
->;
 
 export interface DictionaryStatisticsWaniKaniSnapshot {
     available?: boolean;
-    reviewAssignments: DictionaryStatisticsWaniKaniReviewAssignmentsSnapshot;
+    assignments: DictionaryWaniKaniAssignmentRecordWithStatus[];
+    subjects: Record<number, DictionaryWaniKaniSubjectRecord>;
 }
 
 export type DictionaryStatisticsWaniKaniSnapshots = Record<number, DictionaryStatisticsWaniKaniSnapshot>;
@@ -101,7 +97,7 @@ export class DictionaryStatistics {
         this.mediaId = mediaId;
         this.rawTrackSnapshots = new Map();
         this.settings = { dictionaryTracks: defaultSettings.dictionaryTracks };
-        this.anki = { cardsInfo: {}, dueCards: {} };
+        this.anki = { cardsInfo: {}, dueCards: {}, cardsStatus: {} };
         this.waniKani = {};
         this.lastCancelledAt = 0;
     }
@@ -113,7 +109,7 @@ export class DictionaryStatistics {
     reset(): void {
         const startTime = Date.now();
         this.rawTrackSnapshots.clear();
-        this.anki = { cardsInfo: {}, dueCards: {} };
+        this.anki = { cardsInfo: {}, dueCards: {}, cardsStatus: {} };
         this.waniKani = {};
         void this._publish(undefined, startTime);
         this.lastCancelledAt = Date.now();
@@ -149,16 +145,6 @@ export class DictionaryStatistics {
     replaceAnkiSnapshot(anki: DictionaryStatisticsAnkiSnapshot): void {
         const startTime = Date.now();
         this.anki = anki;
-        if (!this.hasStatistics()) return;
-        void this._publish(this._snapshot(), startTime);
-    }
-
-    updateAnkiSnapshot(anki: Partial<DictionaryStatisticsAnkiSnapshot>): void {
-        const startTime = Date.now();
-        const startedAt = this.anki.progress?.startedAt ?? anki.progress?.startedAt ?? Date.now();
-        const progress = anki.progress ? { ...anki.progress, startedAt } : this.anki.progress;
-        const cardsInfo = anki.cardsInfo ? { ...this.anki.cardsInfo, ...anki.cardsInfo } : this.anki.cardsInfo;
-        this.anki = { ...this.anki, ...anki, progress, cardsInfo };
         if (!this.hasStatistics()) return;
         void this._publish(this._snapshot(), startTime);
     }

--- a/common/dictionary-statistics/dictionary-statistics.ts
+++ b/common/dictionary-statistics/dictionary-statistics.ts
@@ -28,12 +28,14 @@ export interface DictionaryStatisticsSentence {
 }
 
 export type DictionaryStatisticsAnkiDueCardsSnapshot = Record<number, number[]>; // [0, [...]] due today, [7, [...]] due within a week
+export type DictionaryStatisticsAnkiUnknownCardsSnapshot = Record<number, number[]>; // Unknown card ids per track, sorted by due date
 
 export interface DictionaryStatisticsAnkiSnapshot {
     available?: boolean;
     progress?: Progress;
     cardsInfo: Record<number, CardInfo>;
     dueCards: DictionaryStatisticsAnkiDueCardsSnapshot;
+    unknownCards?: DictionaryStatisticsAnkiUnknownCardsSnapshot;
 }
 
 export type DictionaryStatisticsWaniKaniReviewAssignmentsSnapshot = Record<

--- a/common/dictionary-statistics/dictionary-statistics.ts
+++ b/common/dictionary-statistics/dictionary-statistics.ts
@@ -1,6 +1,6 @@
 import { Progress, Tokenization } from '@project/common';
-import { CardInfo } from '@project/common/anki';
 import type {
+    CardInfoForDB,
     DictionaryProvider,
     DictionaryWaniKaniAssignmentRecordWithStatus,
     TokenResults,
@@ -28,12 +28,12 @@ export interface DictionaryStatisticsSentence {
 }
 
 export type DictionaryStatisticsAnkiDueCardsSnapshot = Record<number, number[]>; // [0, [...]] due today, [7, [...]] due within a week
-export type DictionaryStatisticsAnkiUnknownCardsSnapshot = Record<number, number[]>; // Unknown card ids per track, sorted by due date
+export type DictionaryStatisticsAnkiUnknownCardsSnapshot = Record<number, number[]>; // Unknown card ids per track
 
 export interface DictionaryStatisticsAnkiSnapshot {
     available?: boolean;
     progress?: Progress;
-    cardsInfo: Record<number, CardInfo>;
+    cardsInfo: Record<number, CardInfoForDB>;
     dueCards: DictionaryStatisticsAnkiDueCardsSnapshot;
     unknownCards?: DictionaryStatisticsAnkiUnknownCardsSnapshot;
 }

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",
@@ -663,15 +664,14 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -644,6 +644,7 @@
         "occurrences": "Occurrences",
         "sentenceStatistics": "Sentence statistics",
         "currentWatch": "Current watch",
+        "projected": "Projected",
         "projectedRewatch": "Projected rewatch",
         "rewatchSelect": "Rewatch",
         "rewatchOption": "Rewatch #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
-                "ankiStatistics": "How your Anki cards match up with the words in this media."
+                "ankiStatistics": "How your Anki cards match up with the words in this media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -644,6 +644,7 @@
         "occurrences": "Occurrences",
         "sentenceStatistics": "Sentence statistics",
         "currentWatch": "Current watch",
+        "projected": "Projected",
         "projectedRewatch": "Projected rewatch",
         "rewatchSelect": "Rewatch",
         "rewatchOption": "Rewatch #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
-                "ankiStatistics": "How your Anki cards match up with the words in this media."
+                "ankiStatistics": "How your Anki cards match up with the words in this media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature." 
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {
@@ -683,7 +694,7 @@
             "frequency": "Frequency: The rank-based frequency from your frequency dictionaries.",
             "occurrences": "Occurrences: The total number of times a word appears.",
             "sentenceStatistics": "How easily this content can be mined.",
-            "projectedRewatch": "Assumes all i+1 uncollected sentences were mined from the previous watch."
+            "projectedRewatch": "Assumes all i+1 uncollected sentences were mined from the previous watch and promotes all word status up one level each rewatch."
         }
     },
     "subtitlePlayer": {

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",
@@ -663,15 +664,14 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature." 
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature." 
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",
@@ -663,15 +664,14 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -644,6 +644,7 @@
         "occurrences": "Occurrences",
         "sentenceStatistics": "Sentence statistics",
         "currentWatch": "Current watch",
+        "projected": "Projected",
         "projectedRewatch": "Projected rewatch",
         "rewatchSelect": "Rewatch",
         "rewatchOption": "Rewatch #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
-                "ankiStatistics": "How your Anki cards match up with the words in this media."
+                "ankiStatistics": "How your Anki cards match up with the words in this media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",
@@ -663,15 +664,14 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -644,6 +644,7 @@
         "occurrences": "Occurrences",
         "sentenceStatistics": "Sentence statistics",
         "currentWatch": "Current watch",
+        "projected": "Projected",
         "projectedRewatch": "Projected rewatch",
         "rewatchSelect": "Rewatch",
         "rewatchOption": "Rewatch #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
-                "ankiStatistics": "How your Anki cards match up with the words in this media."
+                "ankiStatistics": "How your Anki cards match up with the words in this media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",
@@ -663,15 +664,14 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -644,6 +644,7 @@
         "occurrences": "Occurrences",
         "sentenceStatistics": "Sentence statistics",
         "currentWatch": "Current watch",
+        "projected": "Projected",
         "projectedRewatch": "Projected rewatch",
         "rewatchSelect": "Rewatch",
         "rewatchOption": "Rewatch #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
-                "ankiStatistics": "How your Anki cards match up with the words in this media."
+                "ankiStatistics": "How your Anki cards match up with the words in this media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",
@@ -663,15 +664,14 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -644,6 +644,7 @@
         "occurrences": "Occurrences",
         "sentenceStatistics": "Sentence statistics",
         "currentWatch": "Current watch",
+        "projected": "Projected",
         "projectedRewatch": "Projected rewatch",
         "rewatchSelect": "Rewatch",
         "rewatchOption": "Rewatch #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
-                "ankiStatistics": "How your Anki cards match up with the words in this media."
+                "ankiStatistics": "How your Anki cards match up with the words in this media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -644,6 +644,7 @@
         "occurrences": "Occorrenze",
         "sentenceStatistics": "Statistiche frasi",
         "currentWatch": "Visione corrente",
+        "projected": "Projected",
         "projectedRewatch": "Revisione proiettata",
         "rewatchSelect": "Revisione",
         "rewatchOption": "Revisione #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Sospese",
             "deckBreakdown": "Ripartizione per deck",
             "modelBreakdown": "Ripartizione per modello",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki deve essere in esecuzione per caricare le statistiche.",
             "noDeckBreakdown": "Nessuna carta Anki corrispondente trovata per questo media.",
             "info": {
-                "ankiStatistics": "Come le tue carte Anki si abbinano alle parole in questo media."
+                "ankiStatistics": "Come le tue carte Anki si abbinano alle parole in questo media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "Non ci sarà più estrazione dopo tutte le frasi i+1 di questa sessione.",
         "totalSentences": "Totale frasi",
         "knownSentences": "Frasi conosciute",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Statistiche Anki",
             "dueByToday": "In scadenza oggi",

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "Non ci sarà più estrazione dopo tutte le frasi i+1 di questa sessione.",
         "totalSentences": "Totale frasi",
         "knownSentences": "Frasi conosciute",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Statistiche Anki",
             "dueByToday": "In scadenza oggi",
@@ -663,15 +664,14 @@
             "suspended": "Sospese",
             "deckBreakdown": "Ripartizione per deck",
             "modelBreakdown": "Ripartizione per modello",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki deve essere in esecuzione per caricare le statistiche.",
             "noDeckBreakdown": "Nessuna carta Anki corrispondente trovata per questo media.",
             "info": {
                 "ankiStatistics": "Come le tue carte Anki si abbinano alle parole in questo media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -644,6 +644,7 @@
         "occurrences": "出現数",
         "sentenceStatistics": "文章統計",
         "currentWatch": "今回の視聴",
+        "projected": "Projected",
         "projectedRewatch": "次回の視聴",
         "rewatchSelect": "視聴数",
         "rewatchOption": "視聴 #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "休止中",
             "deckBreakdown": "デッキ内訳",
             "modelBreakdown": "モデル内訳",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "統計を処理するにはAnkiを起動してください。",
             "noDeckBreakdown": "現在のメディアに一致するAnkiカードは見つかりませんでした。",
             "info": {
-                "ankiStatistics": "メディア内の単語とAnkiカードの照合。"
+                "ankiStatistics": "メディア内の単語とAnkiカードの照合。",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "今回の視聴ですべてのi+1文章のマイニングが完了します。",
         "totalSentences": "合計文数",
         "knownSentences": "既知文数",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Ankiの統計",
             "dueByToday": "今日の復習",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "今回の視聴ですべてのi+1文章のマイニングが完了します。",
         "totalSentences": "合計文数",
         "knownSentences": "既知文数",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Ankiの統計",
             "dueByToday": "今日の復習",
@@ -663,15 +664,14 @@
             "suspended": "休止中",
             "deckBreakdown": "デッキ内訳",
             "modelBreakdown": "モデル内訳",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "統計を処理するにはAnkiを起動してください。",
             "noDeckBreakdown": "現在のメディアに一致するAnkiカードは見つかりませんでした。",
             "info": {
                 "ankiStatistics": "メディア内の単語とAnkiカードの照合。",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",
@@ -663,15 +664,14 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -644,6 +644,7 @@
         "occurrences": "Occurrences",
         "sentenceStatistics": "Sentence statistics",
         "currentWatch": "Current watch",
+        "projected": "Projected",
         "projectedRewatch": "Projected rewatch",
         "rewatchSelect": "Rewatch",
         "rewatchOption": "Rewatch #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
-                "ankiStatistics": "How your Anki cards match up with the words in this media."
+                "ankiStatistics": "How your Anki cards match up with the words in this media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",
@@ -663,15 +664,14 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -644,6 +644,7 @@
         "occurrences": "Occurrences",
         "sentenceStatistics": "Sentence statistics",
         "currentWatch": "Current watch",
+        "projected": "Projected",
         "projectedRewatch": "Projected rewatch",
         "rewatchSelect": "Rewatch",
         "rewatchOption": "Rewatch #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
-                "ankiStatistics": "How your Anki cards match up with the words in this media."
+                "ankiStatistics": "How your Anki cards match up with the words in this media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",
@@ -663,15 +664,14 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -644,6 +644,7 @@
         "occurrences": "Occurrences",
         "sentenceStatistics": "Sentence statistics",
         "currentWatch": "Current watch",
+        "projected": "Projected",
         "projectedRewatch": "Projected rewatch",
         "rewatchSelect": "Rewatch",
         "rewatchOption": "Rewatch #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
-                "ankiStatistics": "How your Anki cards match up with the words in this media."
+                "ankiStatistics": "How your Anki cards match up with the words in this media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "There will be no more mining after all i+1 sentences this session.",
         "totalSentences": "Total sentences",
         "knownSentences": "Known sentences",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki statistics",
             "dueByToday": "Due by today",
@@ -663,15 +664,14 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -644,6 +644,7 @@
         "occurrences": "Occurrences",
         "sentenceStatistics": "Sentence statistics",
         "currentWatch": "Current watch",
+        "projected": "Projected",
         "projectedRewatch": "Projected rewatch",
         "rewatchSelect": "Rewatch",
         "rewatchOption": "Rewatch #{{rewatch}}",
@@ -662,18 +663,28 @@
             "suspended": "Suspended",
             "deckBreakdown": "Deck breakdown",
             "modelBreakdown": "Model breakdown",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "Anki needs to be running to load statistics.",
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
-                "ankiStatistics": "How your Anki cards match up with the words in this media."
+                "ankiStatistics": "How your Anki cards match up with the words in this media.",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -644,6 +644,7 @@
         "occurrences": "出现次数",
         "sentenceStatistics": "句子挖掘价值分析",
         "currentWatch": "当前首刷",
+        "projected": "Projected",
         "projectedRewatch": "预计二刷",
         "rewatchSelect": "选择重播轮次",
         "rewatchOption": "第 {{rewatch}} 次重播",
@@ -662,18 +663,28 @@
             "suspended": "被暂停卡片",
             "deckBreakdown": "牌组分布",
             "modelBreakdown": "笔记类型占比",
+            "projectNewCards": "Treat upcoming new cards as mature",
+            "projectNewCardsHelper": "{{count}} new cards",
+            "projectReviewedCards": "Treat all reviewed cards as mature",
+            "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "需保持 Anki 运行以加载统计数据。",
             "noDeckBreakdown": "未在 Anki 中检索到属于此媒体的卡片。",
             "info": {
-                "ankiStatistics": "分析当前视频词汇在 Anki 库中的收录情况。"
+                "ankiStatistics": "分析当前视频词汇在 Anki 库中的收录情况。",
+                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
             }
         },
         "waniKani": {
             "waniKaniStatistics": "WaniKani statistics",
+            "projectLevel": "WaniKani level",
+            "projectedWords": "WaniKani known words",
+            "projectedLevel": "Level {{level}}",
+            "currentKnowledge": "Current WaniKani",
             "waniKaniNeedsToBeAvailable": "WaniKani statistics could not be loaded.",
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
-                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media."
+                "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
+                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
             }
         },
         "info": {

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -655,6 +655,7 @@
         "noMoreRewatches": "在本次学习中挖掘完所有 i+1 句子后，将不再有可挖掘内容。",
         "totalSentences": "台词总数",
         "knownSentences": "完全掌握句数",
+        "projectMature": "Treat upcoming as mature",
         "anki": {
             "ankiStatistics": "Anki 进度统计",
             "dueByToday": "今日到期",
@@ -663,15 +664,14 @@
             "suspended": "被暂停卡片",
             "deckBreakdown": "牌组分布",
             "modelBreakdown": "笔记类型占比",
-            "projectNewCards": "Treat upcoming new cards as mature",
-            "projectNewCardsHelper": "{{count}} new cards",
+            "newCardsCount": "{{count}} new cards",
             "projectReviewedCards": "Treat all reviewed cards as mature",
             "knownDeckWords": "Anki known words",
             "ankiNeedsToBeRunning": "需保持 Anki 运行以加载统计数据。",
             "noDeckBreakdown": "未在 Anki 中检索到属于此媒体的卡片。",
             "info": {
                 "ankiStatistics": "分析当前视频词汇在 Anki 库中的收录情况。",
-                "projectedCards": "Preview your stats by treating past cards or new cards (by due date) as Mature."
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -684,7 +684,7 @@
             "noWaniKaniBreakdown": "No matching WaniKani vocabulary was found for this media.",
             "info": {
                 "waniKaniStatistics": "How your upcoming WaniKani reviews match up with the words in this media.",
-                "projectedLevel": "Preview your stats by treating all words at this level as Mature."
+                "projectedLevel": "Preview your stats by treating all words at or below a level as Mature."
             }
         },
         "info": {

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -655,7 +655,7 @@
         "noMoreRewatches": "在本次学习中挖掘完所有 i+1 句子后，将不再有可挖掘内容。",
         "totalSentences": "台词总数",
         "knownSentences": "完全掌握句数",
-        "projectMature": "Treat upcoming as mature",
+        "projectMature": "Treat upcoming material as mature",
         "anki": {
             "ankiStatistics": "Anki 进度统计",
             "dueByToday": "今日到期",

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -14,7 +14,6 @@ import {
     TokenReading,
 } from '@project/common';
 import { Anki } from '@project/common/anki';
-import { WaniKani } from '@project/common/wanikani';
 import {
     ApplyStrategy,
     areDictionaryTracksEqual,
@@ -571,7 +570,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         }
     }
 
-    private async _refreshWaniKaniStatistics(settings: AsbplayerSettings): Promise<void> {
+    private async _refreshWaniKaniStatistics(profile: string | undefined): Promise<void> {
         if (!this.generateStatistics || this.statisticsBatchProcessedIndex < this._subtitles.length) return;
 
         const todayStart = utcStartOfToday();
@@ -585,28 +584,23 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             for (const tokenAssignmentIds of ts.tokenAssignmentIds.values()) {
                 for (const assignmentId of tokenAssignmentIds) assignmentIds.add(assignmentId);
             }
-
             if (!assignmentIds.size) {
                 waniKaniSnapshots[ts.track] = { available: true, reviewAssignments: {} };
                 continue;
             }
 
-            const apiToken = settings.dictionaryTracks[ts.track]?.dictionaryWaniKaniApiToken.trim();
-            if (!apiToken) {
-                waniKaniSnapshots[ts.track] = { available: false, reviewAssignments: {} };
-                continue;
-            }
-
             const reviewAssignments: DictionaryStatisticsWaniKaniSnapshot['reviewAssignments'] = {};
             try {
-                const waniKani = new WaniKani(apiToken);
-                const assignments = await waniKani.assignments({
-                    subjectTypes: ['vocabulary', 'kana_vocabulary'],
-                    availableBefore: reviewWindowEnd.toISOString(),
-                });
-                for (const assignment of assignments.data) {
-                    if (!assignmentIds.has(assignment.id)) continue;
-                    reviewAssignments[assignment.id] = assignment;
+                const assignments =
+                    (await this.dictionaryProvider.getRecords(profile, ts.track)).waniKaniAssignmentRecords?.[
+                        ts.track
+                    ] ?? {};
+                for (const assignment of Object.values(assignments)) {
+                    if (!assignmentIds.has(assignment.assignmentId)) continue;
+                    if (assignment.data.hidden || !assignment.data.available_at) continue;
+                    const availableAtTime = Date.parse(assignment.data.available_at);
+                    if (!Number.isFinite(availableAtTime) || availableAtTime >= reviewWindowEnd.getTime()) continue;
+                    reviewAssignments[assignment.assignmentId] = assignment;
                 }
                 waniKaniSnapshots[ts.track] = { available: true, reviewAssignments };
             } catch (e) {
@@ -625,16 +619,15 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         if (this.waniKaniRefreshing) return;
         try {
             this.waniKaniRefreshing = true;
-            const settings = await this.settingsProvider.getAll();
             if (
-                !settings.dictionaryTracks.some(
-                    (dt) => dictionaryStatusCollectionEnabled(dt) && Boolean(dt.dictionaryWaniKaniApiToken.trim())
+                !this.trackStates.some(
+                    (ts) => dictionaryStatusCollectionEnabled(ts.dt) && ts.dt.dictionaryWaniKaniApiToken.trim()
                 )
             ) {
                 return;
             }
             if (!this.waniKaniRefreshed) await this.dictionaryProvider.buildWaniKaniCache(profile); // Don't need to poll on tokensModified since users can't mine to it unlike Anki
-            if (!this.waniKaniStatisticsRefreshed) await this._refreshWaniKaniStatistics(settings);
+            if (!this.waniKaniStatisticsRefreshed) await this._refreshWaniKaniStatistics(profile);
         } catch (e) {
             this.waniKaniRefreshed = false;
             this.waniKaniStatisticsRefreshed = false;
@@ -1131,6 +1124,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                         this.generateStatisticsRequested = false;
                         this.ankiRefreshTrigger = true;
                         this.waniKaniStatisticsRefreshTrigger = true;
+                        this.waniKaniStatisticsRefreshed = false;
                     }
                 }
             }
@@ -1146,6 +1140,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 this.tokensForRefresh.clear();
                 this.ankiStatisticsRefreshAll = true;
                 this.waniKaniStatisticsRefreshTrigger = true;
+                this.waniKaniStatisticsRefreshed = false;
             }
             this.shouldCancelBuild = false;
             this.annotationsBuilding = false;

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -32,7 +32,13 @@ import {
     TokenStatus,
     TokenStyling,
 } from '@project/common/settings';
-import { TokenStatusInfo, DictionaryProvider, LemmaResults, TokenResults } from '@project/common/dictionary-db';
+import {
+    TokenStatusInfo,
+    DictionaryProvider,
+    LemmaResults,
+    TokenResults,
+    DictionaryRecordsResult,
+} from '@project/common/dictionary-db';
 import {
     DictionaryStatistics,
     DictionaryStatisticsAnkiDueCardsSnapshot,
@@ -709,35 +715,19 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         }
     }
 
-    private async _unknownAnkiCardsSnapshot(profile: string | undefined) {
-        const records = await this.dictionaryProvider.getRecords(profile, undefined);
-        const unknownCardIdsByTrack = new Map<number, Set<number>>();
-        const allUnknownCardIds = new Set<number>();
+    private async _unknownAnkiCardsSnapshot(records: DictionaryRecordsResult) {
+        const cardsInfo: DictionaryStatisticsAnkiSnapshot['cardsInfo'] = {};
+        const unknownCards: NonNullable<DictionaryStatisticsAnkiSnapshot['unknownCards']> = {};
         for (const [trackString, cardRecords] of Object.entries(records.ankiCardRecords)) {
             const track = Number(trackString);
             for (const cardRecord of Object.values(cardRecords)) {
                 if (cardRecord.status !== TokenStatus.UNKNOWN) continue;
-                const cardIds = unknownCardIdsByTrack.get(track);
-                if (cardIds) cardIds.add(cardRecord.cardId);
-                else unknownCardIdsByTrack.set(track, new Set([cardRecord.cardId]));
-                allUnknownCardIds.add(cardRecord.cardId);
+                let cardIds = unknownCards[track];
+                if (cardIds) cardIds.push(cardRecord.cardId);
+                else unknownCards[track] = [cardRecord.cardId];
+                cardsInfo[cardRecord.cardId] = cardRecord.data;
             }
         }
-        if (!allUnknownCardIds.size) return { cardsInfo: {}, unknownCards: {} };
-
-        const cardsInfoRes = await this.anki!.cardsInfo(Array.from(allUnknownCardIds));
-        const cardsInfo: DictionaryStatisticsAnkiSnapshot['cardsInfo'] = {};
-        for (const cardInfo of cardsInfoRes) cardsInfo[cardInfo.cardId] = cardInfo;
-
-        const unknownCards: NonNullable<DictionaryStatisticsAnkiSnapshot['unknownCards']> = {};
-        for (const [track, cardIds] of unknownCardIdsByTrack.entries()) {
-            unknownCards[track] = Array.from(cardIds).sort((left, right) => {
-                const leftDue = cardsInfo[left]?.due ?? Number.POSITIVE_INFINITY;
-                const rightDue = cardsInfo[right]?.due ?? Number.POSITIVE_INFINITY;
-                return leftDue - rightDue || left - right;
-            });
-        }
-
         return { cardsInfo, unknownCards };
     }
 
@@ -758,10 +748,14 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         }
         if (!this.generateStatistics) return;
 
-        const getCardsInfo = async (cardIds: number[]) => {
-            const cardsInfoArr = await this.anki!.cardsInfo(cardIds);
+        const getCardsInfo = async (cardIds: Set<number>, records: DictionaryRecordsResult) => {
             const cardsInfo: DictionaryStatisticsAnkiSnapshot['cardsInfo'] = {};
-            for (const cardInfo of cardsInfoArr) cardsInfo[cardInfo.cardId] = cardInfo;
+            for (const cardRecords of Object.values(records.ankiCardRecords)) {
+                for (const cardRecord of Object.values(cardRecords)) {
+                    if (!cardIds.has(cardRecord.cardId)) continue;
+                    cardsInfo[cardRecord.cardId] = cardRecord.data;
+                }
+            }
             for (const cardId of cardIds) cardIdsMap.set(cardId, true);
             for (const ts of this.trackStates) {
                 for (const tokenCardIds of ts.tokenCardIds.values()) {
@@ -777,14 +771,15 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         try {
             if (!this.anki) throw new Error('Anki not initialized');
 
-            const cardIds: number[] = [];
+            const cardIds = new Set<number>();
             if (refreshNewOnly) {
                 for (const [cardId, queried] of cardIdsMap) {
-                    if (!queried) cardIds.push(cardId);
+                    if (!queried) cardIds.add(cardId);
                 }
-                if (!cardIds.length) return;
+                if (!cardIds.size) return;
 
-                const cardsInfo = await getCardsInfo(cardIds);
+                const records = await this.dictionaryProvider.getRecords(profile, undefined);
+                const cardsInfo = await getCardsInfo(cardIds, records);
                 this.dictionaryStatistics.updateAnkiSnapshot({
                     available: true,
                     progress: {
@@ -795,9 +790,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     cardsInfo,
                 });
             } else {
-                for (const cardId of cardIdsMap.keys()) cardIds.push(cardId);
-                const unknownAnkiCardsSnapshot = await this._unknownAnkiCardsSnapshot(profile);
-                if (!cardIds.length) {
+                const records = await this.dictionaryProvider.getRecords(profile, undefined);
+                for (const cardId of cardIdsMap.keys()) cardIds.add(cardId);
+                const unknownAnkiCardsSnapshot = await this._unknownAnkiCardsSnapshot(records);
+                if (!cardIds.size) {
                     this.dictionaryStatistics.replaceAnkiSnapshot({
                         available: true,
                         cardsInfo: unknownAnkiCardsSnapshot.cardsInfo,
@@ -807,7 +803,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     return;
                 }
 
-                const cardsInfo = await getCardsInfo(cardIds);
+                const cardsInfo = await getCardsInfo(cardIds, records);
                 const dueCards: DictionaryStatisticsAnkiDueCardsSnapshot = {};
                 for (const due of REVIEW_DUES) dueCards[due] = await this.anki.findCardsDueBy(due, fields, decks);
                 this.dictionaryStatistics.replaceAnkiSnapshot({

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -5,6 +5,7 @@ import {
     DictionaryBuildAnkiCacheStateType,
     DictionaryBuildWaniKaniCacheState,
     DictionaryBuildWaniKaniCacheStateError,
+    DictionaryBuildWaniKaniCacheStateErrorCode,
     DictionaryBuildWaniKaniCacheStateType,
     Fetcher,
     RichSubtitleModel,
@@ -32,13 +33,7 @@ import {
     TokenStatus,
     TokenStyling,
 } from '@project/common/settings';
-import {
-    TokenStatusInfo,
-    DictionaryProvider,
-    LemmaResults,
-    TokenResults,
-    DictionaryRecordsResult,
-} from '@project/common/dictionary-db';
+import { TokenStatusInfo, DictionaryProvider, LemmaResults, TokenResults } from '@project/common/dictionary-db';
 import {
     DictionaryStatistics,
     DictionaryStatisticsAnkiDueCardsSnapshot,
@@ -52,10 +47,8 @@ import {
     HAS_LETTER_REGEX,
     inBatches,
     iterateOverStringInBlocks,
-    MS_PER_DAY,
     ONLY_ASCII_LETTERS_REGEX,
     areTokenizationsEqual,
-    utcStartOfToday,
     getTokenStatus,
     dedupeTokenStatusInfos,
     isKanaOnly,
@@ -71,7 +64,7 @@ const TOKEN_CACHE_STATISTICS_REFRESH_INTERVAL = 1000;
 let tokenCacheRefreshInterval = TOKEN_CACHE_DEFAULT_REFRESH_INTERVAL;
 const YOMITAN_RETRY_DELAY = 10000;
 const ANKI_REFRESH_INTERVAL = 10000; // We need to poll in-case the user mines to Anki outside of asbplayer (e.g directly from Yomitan), local requests so no rate concerns
-const WANIKANI_REFRESH_INTERVAL = 60000; // Only until the first successful refresh since users can't mine to it and it's an external server
+const WANIKANI_REFRESH_INTERVAL = 10000; // Only until the first successful refresh since users can't mine to it and it's an external server
 
 const ASB_TOKEN_CLASS = 'asb-token';
 const ASB_TOKEN_HIGHLIGHT_CLASS = 'asb-token-highlight';
@@ -100,8 +93,6 @@ interface TrackState {
     collectedExactForm: Map<string, TokenStatusResult>;
     collectedLemmaForm: Map<string, TokenStatusResult>;
     collectedAnyForm: Map<string, TokenStatusResult[]>;
-    tokenCardIds: Map<string, Map<number, boolean>>;
-    tokenAssignmentIds: Map<string, Set<number>>;
     tokenStates: Map<string, TokenState[]>;
     indexTokenOccurrences: Map<number, Map<string, number>>;
 }
@@ -299,18 +290,22 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
     private tokenToIndexesCache: Map<string, Set<number>>;
     private tokensForRefresh: Set<string>;
     private externalTokenReadings: Map<string, Map<number, TokenReading[]>>;
-    private ankiLastRefresh: number;
-    private ankiRefreshTrigger: boolean;
-    private ankiRefreshing: boolean;
-    private ankiRecentlyModifiedCardIds: Set<number>;
-    private ankiRecentlyModifiedFirstCheck: boolean;
-    private ankiStatisticsRefreshAll: boolean;
-    private ankiStatisticsRefreshNew: boolean;
-    private waniKaniRefreshing: boolean;
-    private waniKaniRefreshed: boolean;
-    private waniKaniStatisticsRefreshed: boolean;
-    private waniKaniStatisticsRefreshTrigger: boolean;
-    private waniKaniLastRefresh: number;
+    private ankiState: {
+        recentlyModifiedCardIds: Set<number>;
+        recentlyModifiedFirstCheck: boolean;
+        refreshing: boolean;
+        refreshed: boolean;
+        lastRefresh: number;
+        triggerRefresh: boolean;
+        statisticsRefreshed: boolean;
+    };
+    private waniKaniState: {
+        refreshing: boolean;
+        refreshed: boolean;
+        lastRefresh: number;
+        triggerRefresh: boolean;
+        statisticsRefreshed: boolean;
+    };
     private annotationsLastRefresh: number;
     private annotationsBuilding: boolean;
     private annotationsBuildingCurrentIndexes: Set<number>;
@@ -358,18 +353,22 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         this.tokenToIndexesCache = new Map();
         this.tokensForRefresh = new Set();
         this.externalTokenReadings = new Map();
-        this.ankiLastRefresh = Date.now();
-        this.ankiRefreshTrigger = false;
-        this.ankiRefreshing = false;
-        this.ankiRecentlyModifiedCardIds = new Set();
-        this.ankiRecentlyModifiedFirstCheck = true;
-        this.ankiStatisticsRefreshAll = false;
-        this.ankiStatisticsRefreshNew = false;
-        this.waniKaniRefreshing = false;
-        this.waniKaniRefreshed = false;
-        this.waniKaniStatisticsRefreshed = false;
-        this.waniKaniStatisticsRefreshTrigger = false;
-        this.waniKaniLastRefresh = Date.now();
+        this.ankiState = {
+            recentlyModifiedCardIds: new Set(),
+            recentlyModifiedFirstCheck: true,
+            refreshing: false,
+            refreshed: false,
+            lastRefresh: Date.now(),
+            triggerRefresh: false,
+            statisticsRefreshed: false,
+        };
+        this.waniKaniState = {
+            refreshing: false,
+            refreshed: false,
+            lastRefresh: Date.now(),
+            triggerRefresh: false,
+            statisticsRefreshed: false,
+        };
         this.annotationsLastRefresh = Date.now();
         this.annotationsBuilding = false;
         this.annotationsBuildingCurrentIndexes = new Set();
@@ -448,14 +447,16 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         this.statisticsBatchProcessedIndex = 0;
         this.statisticsProcessedSubtitleIndexesByTrack.clear();
         this.generateStatisticsRequested = false;
-        this.ankiRefreshTrigger = false;
-        this.ankiRecentlyModifiedCardIds.clear();
-        this.ankiRecentlyModifiedFirstCheck = true;
-        this.ankiStatisticsRefreshAll = false;
-        this.ankiStatisticsRefreshNew = false;
-        this.waniKaniRefreshed = false;
-        this.waniKaniStatisticsRefreshed = false;
-        this.waniKaniStatisticsRefreshTrigger = false;
+        this.ankiState.recentlyModifiedCardIds.clear();
+        this.ankiState.recentlyModifiedFirstCheck = true;
+        this.ankiState.refreshed = false;
+        this.ankiState.lastRefresh = Date.now();
+        this.ankiState.triggerRefresh = false;
+        this.ankiState.statisticsRefreshed = false;
+        this.waniKaniState.refreshed = false;
+        this.waniKaniState.lastRefresh = Date.now();
+        this.waniKaniState.triggerRefresh = false;
+        this.waniKaniState.statisticsRefreshed = false;
         this.annotationsLastRefresh = Date.now();
         this._subtitles.forEach(untokenize);
         this.buildLowerThreshold = 0;
@@ -511,6 +512,12 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         this.tokensWereModified(state.body?.modifiedTokens ?? []);
         if (state.type === DictionaryBuildAnkiCacheStateType.error) {
             const body = state.body as DictionaryBuildAnkiCacheStateError;
+            if (
+                body?.code === DictionaryBuildAnkiCacheStateErrorCode.noAnki ||
+                body?.code === DictionaryBuildAnkiCacheStateErrorCode.noYomitan
+            ) {
+                this.ankiState.statisticsRefreshed = false;
+            }
             if (body) {
                 console.error(
                     `Dictionary Anki cache build error (${body.code} - ${body.msg}): ${JSON.stringify(body.data ?? {})}`
@@ -519,27 +526,35 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 console.error(`Dictionary Anki cache build error: Unknown error`);
             }
             if (body?.code !== DictionaryBuildAnkiCacheStateErrorCode.concurrentBuild) {
-                this.ankiRecentlyModifiedCardIds.clear();
-                this.ankiRecentlyModifiedFirstCheck = false;
+                this.ankiState.recentlyModifiedCardIds.clear();
+                this.ankiState.recentlyModifiedFirstCheck = false;
             }
+        } else if (state.type === DictionaryBuildAnkiCacheStateType.stats) {
+            this.ankiState.statisticsRefreshed = false;
         }
     }
 
     buildWaniKaniCacheStateChange(state: DictionaryBuildWaniKaniCacheState) {
         this.tokensWereModified(state.body.modifiedTokens ?? []);
         if (state.type === DictionaryBuildWaniKaniCacheStateType.error) {
-            this.waniKaniRefreshed = false;
             const body = state.body as DictionaryBuildWaniKaniCacheStateError;
+            if (
+                body?.code === DictionaryBuildWaniKaniCacheStateErrorCode.invalidWaniKaniToken ||
+                body?.code === DictionaryBuildWaniKaniCacheStateErrorCode.noYomitan
+            ) {
+                this.waniKaniState.statisticsRefreshed = false;
+            }
             console.error(
                 `Dictionary WaniKani cache build error (${body.code} - ${body.msg}): ${JSON.stringify(body.data ?? {})}`
             );
         } else if (state.type === DictionaryBuildWaniKaniCacheStateType.stats) {
-            this.waniKaniRefreshed = true;
+            this.waniKaniState.statisticsRefreshed = false;
         }
     }
 
     ankiCardWasModified() {
-        this.ankiRefreshTrigger = true;
+        this.ankiState.triggerRefresh = true;
+        this.ankiState.statisticsRefreshed = false;
     }
 
     hoverOnly(track: number) {
@@ -569,36 +584,55 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         this.generateStatistics = true;
     }
 
+    private async _checkAnkiRecentlyModifiedCards(profile: string | undefined, fields: string[], decks: string[]) {
+        try {
+            if (!this.anki) throw new Error('Anki not initialized');
+            const cardIds = await this.anki.findRecentlyEditedOrReviewedCards(1, fields, decks); // Can't efficiently poll suspended status
+            if (
+                cardIds.length === this.ankiState.recentlyModifiedCardIds.size &&
+                cardIds.every((cardId) => this.ankiState.recentlyModifiedCardIds.has(cardId))
+            ) {
+                if (this.ankiState.recentlyModifiedFirstCheck) this.ankiState.recentlyModifiedFirstCheck = false;
+                return;
+            }
+            this.ankiState.recentlyModifiedCardIds = new Set(cardIds);
+            if (this.ankiState.recentlyModifiedFirstCheck) {
+                this.ankiState.recentlyModifiedFirstCheck = false;
+                return;
+            }
+            await this.dictionaryProvider.buildAnkiCache(profile, await this.settingsProvider.getAll());
+            this.ankiState.triggerRefresh = true;
+            this.ankiState.statisticsRefreshed = false;
+        } catch (e) {
+            console.error(`Error checking Anki recently modified cards:`, e);
+            this.anki = undefined;
+            this.ankiState.recentlyModifiedCardIds.clear();
+            this.ankiState.recentlyModifiedFirstCheck = false;
+        }
+    }
+
     private async _refreshAnki() {
         if (this.profile === null || !this.trackStates.length) return;
         const profile = this.profile;
 
-        if (this.ankiRefreshing) return;
+        if (this.ankiState.refreshing) return;
         try {
-            this.ankiRefreshing = true;
+            this.ankiState.refreshing = true;
             if (!this.anki) {
                 try {
                     const settings = await this.settingsProvider.getAll();
                     this.anki = new Anki(settings, this.fetcher);
                     const permission = (await this.anki.requestPermission()).permission;
                     if (permission !== 'granted') throw new Error(`permission ${permission}`);
-                    await this.dictionaryProvider.buildAnkiCache(profile, settings); // Keep cache updated without user action
-                    this.ankiStatisticsRefreshAll = true;
                 } catch (e) {
                     console.warn('Anki permission request failed:', e);
                     this.anki = undefined;
                 }
             }
 
-            const cardIdsMap = new Map<number, boolean>();
             const allFieldsSet = new Set<string>();
             for (const ts of this.trackStates) {
                 if (!dictionaryStatusCollectionEnabled(ts.dt)) continue;
-                for (const tokenCardIds of ts.tokenCardIds.values()) {
-                    for (const [cardId, queried] of tokenCardIds.entries()) {
-                        cardIdsMap.set(cardId, queried && cardIdsMap.get(cardId) !== false);
-                    }
-                }
                 for (const field of ts.dt.dictionaryAnkiWordFields.concat(ts.dt.dictionaryAnkiSentenceFields)) {
                     allFieldsSet.add(field);
                 }
@@ -615,62 +649,71 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             }
             const decks = Array.from(allDecksSet);
 
+            if (this.anki && !this.ankiState.refreshed) {
+                await this.dictionaryProvider.buildAnkiCache(profile, await this.settingsProvider.getAll()); // Keep cache updated without user action
+                this.ankiState.refreshed = true;
+            }
             await this._checkAnkiRecentlyModifiedCards(profile, fields, decks);
-            await this._refreshAnkiStatistics(profile, cardIdsMap, fields, decks);
+            await this._refreshAnkiStatistics(profile, fields, decks);
+        } catch (e) {
+            console.warn('Anki refresh failed:', e);
+            this.ankiState.refreshed = false;
         } finally {
-            this.ankiRefreshing = false;
+            this.ankiState.refreshing = false;
         }
     }
 
-    private async _refreshWaniKaniStatistics(profile: string | undefined): Promise<void> {
-        if (!this.generateStatistics || this.statisticsBatchProcessedIndex < this._subtitles.length) return;
+    private async _refreshAnkiStatistics(profile: string | undefined, fields: string[], decks: string[]) {
+        if (!this.generateStatistics) return;
+        if (this.ankiState.statisticsRefreshed) return;
 
-        const todayStart = utcStartOfToday();
-        const reviewWindowEnd = new Date(todayStart.getTime() + Math.max(...REVIEW_DUES) * MS_PER_DAY);
-        const waniKaniSnapshots: Record<number, DictionaryStatisticsWaniKaniSnapshot> = {};
-        this.waniKaniStatisticsRefreshed = true;
-        for (const ts of this.trackStates) {
-            if (!dictionaryStatusCollectionEnabled(ts.dt)) continue;
+        const startedAt = Date.now();
+        try {
+            if (!this.anki) throw new Error('Anki not initialized');
 
-            const assignmentIds = new Set<number>();
-            for (const tokenAssignmentIds of ts.tokenAssignmentIds.values()) {
-                for (const assignmentId of tokenAssignmentIds) assignmentIds.add(assignmentId);
-            }
-            if (!assignmentIds.size) {
-                waniKaniSnapshots[ts.track] = { available: true, reviewAssignments: {} };
-                continue;
-            }
-
-            const reviewAssignments: DictionaryStatisticsWaniKaniSnapshot['reviewAssignments'] = {};
-            try {
-                const assignments =
-                    (await this.dictionaryProvider.getRecords(profile, ts.track)).waniKaniAssignmentRecords?.[
-                        ts.track
-                    ] ?? {};
-                for (const assignment of Object.values(assignments)) {
-                    if (!assignmentIds.has(assignment.assignmentId)) continue;
-                    if (assignment.data.hidden || !assignment.data.available_at) continue;
-                    const availableAtTime = Date.parse(assignment.data.available_at);
-                    if (!Number.isFinite(availableAtTime) || availableAtTime >= reviewWindowEnd.getTime()) continue;
-                    reviewAssignments[assignment.assignmentId] = assignment;
+            const ankiCardRecords = (await this.dictionaryProvider.getRecords(profile, undefined)).ankiCardRecords;
+            const cardsInfo: DictionaryStatisticsAnkiSnapshot['cardsInfo'] = {};
+            const cardsStatus: NonNullable<DictionaryStatisticsAnkiSnapshot['cardsStatus']> = {};
+            for (const cardRecords of Object.values(ankiCardRecords)) {
+                for (const cardRecord of Object.values(cardRecords)) {
+                    cardsInfo[cardRecord.cardId] = cardRecord.data;
+                    cardsStatus[cardRecord.cardId] = cardRecord.status;
                 }
-                waniKaniSnapshots[ts.track] = { available: true, reviewAssignments };
-            } catch (e) {
-                this.waniKaniStatisticsRefreshed = false;
-                console.error(`Error refreshing WaniKani for Track${ts.track + 1} statistics:`, e);
-                waniKaniSnapshots[ts.track] = { available: false, reviewAssignments: {} };
             }
+            const dueCards: DictionaryStatisticsAnkiDueCardsSnapshot = {};
+            for (const due of REVIEW_DUES) dueCards[due] = await this.anki.findCardsDueBy(due, fields, decks);
+            const totalCards = Object.keys(cardsStatus).length;
+            this.dictionaryStatistics.replaceAnkiSnapshot({
+                available: true,
+                progress: {
+                    current: totalCards,
+                    total: totalCards,
+                    startedAt,
+                },
+                cardsInfo,
+                cardsStatus,
+                dueCards,
+            });
+            this.ankiState.statisticsRefreshed = true;
+        } catch (e) {
+            console.error('Error refreshing Anki for statistics:', e);
+            this.anki = undefined;
+            this.dictionaryStatistics.replaceAnkiSnapshot({
+                available: false,
+                cardsInfo: {},
+                cardsStatus: {},
+                dueCards: {},
+            });
         }
-        this.dictionaryStatistics.replaceWaniKaniSnapshots(waniKaniSnapshots);
     }
 
     private async _refreshWaniKani() {
         if (this.profile === null || !this.trackStates.length) return;
         const profile = this.profile;
 
-        if (this.waniKaniRefreshing) return;
+        if (this.waniKaniState.refreshing) return;
         try {
-            this.waniKaniRefreshing = true;
+            this.waniKaniState.refreshing = true;
             if (
                 !this.trackStates.some(
                     (ts) => dictionaryStatusCollectionEnabled(ts.dt) && ts.dt.dictionaryWaniKaniApiToken.trim()
@@ -678,160 +721,42 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             ) {
                 return;
             }
-            if (!this.waniKaniRefreshed) await this.dictionaryProvider.buildWaniKaniCache(profile); // Don't need to poll on tokensModified since users can't mine to it unlike Anki
-            if (!this.waniKaniStatisticsRefreshed) await this._refreshWaniKaniStatistics(profile);
+            if (!this.waniKaniState.refreshed) {
+                await this.dictionaryProvider.buildWaniKaniCache(profile); // Don't need to poll on tokensModified since users can't mine to it unlike Anki
+                this.waniKaniState.refreshed = true;
+            }
+            await this._refreshWaniKaniStatistics(profile);
         } catch (e) {
-            this.waniKaniRefreshed = false;
-            this.waniKaniStatisticsRefreshed = false;
+            this.waniKaniState.refreshed = false;
             console.warn('WaniKani refresh failed:', e);
         } finally {
-            this.waniKaniRefreshing = false;
+            this.waniKaniState.refreshing = false;
         }
     }
 
-    private async _checkAnkiRecentlyModifiedCards(profile: string | undefined, fields: string[], decks: string[]) {
-        try {
-            if (!this.anki) throw new Error('Anki not initialized');
-            const cardIds = await this.anki.findRecentlyEditedOrReviewedCards(1, fields, decks); // Can't efficiently poll suspended status
-            if (
-                cardIds.length === this.ankiRecentlyModifiedCardIds.size &&
-                cardIds.every((cardId) => this.ankiRecentlyModifiedCardIds.has(cardId))
-            ) {
-                if (this.ankiRecentlyModifiedFirstCheck) this.ankiRecentlyModifiedFirstCheck = false;
-                return;
-            }
-            this.ankiRecentlyModifiedCardIds = new Set(cardIds);
-            if (this.ankiRecentlyModifiedFirstCheck) {
-                this.ankiRecentlyModifiedFirstCheck = false;
-                return;
-            }
-            await this.dictionaryProvider.buildAnkiCache(profile, await this.settingsProvider.getAll());
-            this.ankiStatisticsRefreshAll = true;
-        } catch (e) {
-            console.error(`Error checking Anki recently modified cards:`, e);
-            this.anki = undefined;
-            this.ankiRecentlyModifiedCardIds.clear();
-            this.ankiRecentlyModifiedFirstCheck = false;
-        }
-    }
-
-    private async _unknownAnkiCardsSnapshot(records: DictionaryRecordsResult) {
-        const cardsInfo: DictionaryStatisticsAnkiSnapshot['cardsInfo'] = {};
-        const unknownCards: NonNullable<DictionaryStatisticsAnkiSnapshot['unknownCards']> = {};
-        for (const [trackString, cardRecords] of Object.entries(records.ankiCardRecords)) {
-            const track = Number(trackString);
-            for (const cardRecord of Object.values(cardRecords)) {
-                if (cardRecord.status !== TokenStatus.UNKNOWN) continue;
-                let cardIds = unknownCards[track];
-                if (cardIds) cardIds.push(cardRecord.cardId);
-                else unknownCards[track] = [cardRecord.cardId];
-                cardsInfo[cardRecord.cardId] = cardRecord.data;
-            }
-        }
-        return { cardsInfo, unknownCards };
-    }
-
-    private async _refreshAnkiStatistics(
-        profile: string | undefined,
-        cardIdsMap: Map<number, boolean>,
-        fields: string[],
-        decks: string[]
-    ) {
-        if (this.statisticsBatchProcessedIndex < this._subtitles.length) return; // Will need to re-query anki as tokens are processed.
-        let refreshNewOnly = true;
-        if (this.ankiStatisticsRefreshAll) {
-            this.ankiStatisticsRefreshAll = false;
-            this.ankiStatisticsRefreshNew = false;
-            refreshNewOnly = false;
-        } else if (this.ankiStatisticsRefreshNew) {
-            this.ankiStatisticsRefreshNew = false;
-        }
+    private async _refreshWaniKaniStatistics(profile: string | undefined): Promise<void> {
         if (!this.generateStatistics) return;
+        if (this.waniKaniState.statisticsRefreshed) return;
 
-        const getCardsInfo = async (cardIds: Set<number>, records: DictionaryRecordsResult) => {
-            const cardsInfo: DictionaryStatisticsAnkiSnapshot['cardsInfo'] = {};
-            for (const cardRecords of Object.values(records.ankiCardRecords)) {
-                for (const cardRecord of Object.values(cardRecords)) {
-                    if (!cardIds.has(cardRecord.cardId)) continue;
-                    cardsInfo[cardRecord.cardId] = cardRecord.data;
-                }
-            }
-            for (const cardId of cardIds) cardIdsMap.set(cardId, true);
-            for (const ts of this.trackStates) {
-                for (const tokenCardIds of ts.tokenCardIds.values()) {
-                    for (const cardId of cardIds) {
-                        if (tokenCardIds.has(cardId)) tokenCardIds.set(cardId, true);
-                    }
-                }
-            }
-            return cardsInfo;
-        };
+        const waniKaniSnapshots: Record<number, DictionaryStatisticsWaniKaniSnapshot> = {};
+        for (const ts of this.trackStates) {
+            if (!dictionaryStatusCollectionEnabled(ts.dt)) continue;
 
-        const startedAt = Date.now();
-        try {
-            if (!this.anki) throw new Error('Anki not initialized');
-
-            const cardIds = new Set<number>();
-            if (refreshNewOnly) {
-                for (const [cardId, queried] of cardIdsMap) {
-                    if (!queried) cardIds.add(cardId);
-                }
-                if (!cardIds.size) return;
-
-                const records = await this.dictionaryProvider.getRecords(profile, undefined);
-                const cardsInfo = await getCardsInfo(cardIds, records);
-                this.dictionaryStatistics.updateAnkiSnapshot({
+            try {
+                const records = await this.dictionaryProvider.getRecords(profile, ts.track);
+                waniKaniSnapshots[ts.track] = {
                     available: true,
-                    progress: {
-                        current: Array.from(cardIdsMap.values()).filter((queried) => queried).length,
-                        total: cardIdsMap.size,
-                        startedAt,
-                    },
-                    cardsInfo,
-                });
-            } else {
-                const records = await this.dictionaryProvider.getRecords(profile, undefined);
-                for (const cardId of cardIdsMap.keys()) cardIds.add(cardId);
-                const unknownAnkiCardsSnapshot = await this._unknownAnkiCardsSnapshot(records);
-                if (!cardIds.size) {
-                    this.dictionaryStatistics.replaceAnkiSnapshot({
-                        available: true,
-                        cardsInfo: unknownAnkiCardsSnapshot.cardsInfo,
-                        dueCards: {},
-                        unknownCards: unknownAnkiCardsSnapshot.unknownCards,
-                    });
-                    return;
-                }
-
-                const cardsInfo = await getCardsInfo(cardIds, records);
-                const dueCards: DictionaryStatisticsAnkiDueCardsSnapshot = {};
-                for (const due of REVIEW_DUES) dueCards[due] = await this.anki.findCardsDueBy(due, fields, decks);
-                this.dictionaryStatistics.replaceAnkiSnapshot({
-                    available: true,
-                    progress: {
-                        current: Array.from(cardIdsMap.values()).filter((queried) => queried).length,
-                        total: cardIdsMap.size,
-                        startedAt,
-                    },
-                    cardsInfo: { ...unknownAnkiCardsSnapshot.cardsInfo, ...cardsInfo },
-                    dueCards,
-                    unknownCards: unknownAnkiCardsSnapshot.unknownCards,
-                });
-            }
-        } catch (e) {
-            console.error('Error refreshing Anki for statistics:', e);
-            this.anki = undefined;
-            this.dictionaryStatistics.replaceAnkiSnapshot({
-                available: false,
-                cardsInfo: {},
-                dueCards: {},
-            });
-            for (const ts of this.trackStates) {
-                for (const tokenCardIds of ts.tokenCardIds.values()) {
-                    for (const cardId of tokenCardIds.keys()) tokenCardIds.set(cardId, false);
-                }
+                    assignments: Object.values(records.waniKaniAssignmentRecords?.[ts.track] ?? {}),
+                    subjects: records.waniKaniSubjectRecords?.[ts.track] ?? {},
+                };
+            } catch (e) {
+                console.error(`Error refreshing WaniKani for Track${ts.track + 1} statistics:`, e);
+                waniKaniSnapshots[ts.track] = { available: false, assignments: [], subjects: {} };
             }
         }
+        this.waniKaniState.statisticsRefreshed = true;
+        if (!Object.keys(waniKaniSnapshots).length) return;
+        this.dictionaryStatistics.replaceWaniKaniSnapshots(waniKaniSnapshots);
     }
 
     private _shouldAutoGenerateStatistics(dictionaryTracks: DictionaryTrack[]) {
@@ -922,21 +847,21 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 this.annotationsLastRefresh = Date.now();
             }
             if (
-                (this.ankiRefreshTrigger || Date.now() - this.ankiLastRefresh >= ANKI_REFRESH_INTERVAL) &&
-                !this.ankiRefreshing
+                (this.ankiState.triggerRefresh || Date.now() - this.ankiState.lastRefresh >= ANKI_REFRESH_INTERVAL) &&
+                !this.ankiState.refreshing
             ) {
                 void this._refreshAnki();
-                this.ankiLastRefresh = Date.now();
-                this.ankiRefreshTrigger = false;
+                this.ankiState.lastRefresh = Date.now();
+                this.ankiState.triggerRefresh = false;
             }
             if (
-                (this.waniKaniStatisticsRefreshTrigger ||
-                    Date.now() - this.waniKaniLastRefresh >= WANIKANI_REFRESH_INTERVAL) &&
-                !this.waniKaniRefreshing
+                (this.waniKaniState.triggerRefresh ||
+                    Date.now() - this.waniKaniState.lastRefresh >= WANIKANI_REFRESH_INTERVAL) &&
+                !this.waniKaniState.refreshing
             ) {
                 void this._refreshWaniKani();
-                this.waniKaniLastRefresh = Date.now();
-                this.waniKaniStatisticsRefreshTrigger = false;
+                this.waniKaniState.lastRefresh = Date.now();
+                this.waniKaniState.triggerRefresh = false;
             }
         }, 100);
     }
@@ -975,10 +900,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             this.annotationsBuilding = true;
             if (this.profile === null) {
                 const profile = (await this.settingsProvider.activeProfile())?.name;
-                if (this.profile === null) {
-                    this.profile = profile;
-                    this.ankiRefreshTrigger = true;
-                }
+                if (this.profile === null) this.profile = profile;
             }
             const profile = this.profile;
             if (!this.trackStates.length) {
@@ -990,8 +912,6 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     collectedExactForm: new Map(),
                     collectedLemmaForm: new Map(),
                     collectedAnyForm: new Map(),
-                    tokenCardIds: new Map(),
-                    tokenAssignmentIds: new Map(),
                     tokenStates: new Map(),
                     indexTokenOccurrences: new Map(),
                 }));
@@ -1042,8 +962,8 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                         this.statisticsProcessedSubtitleIndexesByTrack.set(ts.track, new Set());
                     }
                     void this.dictionaryStatistics.refreshDictionaryTokens(profile); // Init with dictionary token state
-                    this.ankiRefreshTrigger = true;
-                    this.ankiStatisticsRefreshAll = true;
+                    this.ankiState.triggerRefresh = true;
+                    this.waniKaniState.triggerRefresh = true;
                     tokenCacheRefreshInterval = TOKEN_CACHE_STATISTICS_REFRESH_INTERVAL;
                 }
             }
@@ -1204,9 +1124,6 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     this.statisticsBatchProcessedIndex = annotationsEndIndex;
                     if (annotationsEndIndex >= this.subtitles.length) {
                         this.generateStatisticsRequested = false;
-                        this.ankiRefreshTrigger = true;
-                        this.waniKaniStatisticsRefreshTrigger = true;
-                        this.waniKaniStatisticsRefreshed = false;
                     }
                 }
             }
@@ -1220,9 +1137,6 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 tokensRefreshed.every((token) => this.tokensForRefresh.has(token))
             ) {
                 this.tokensForRefresh.clear();
-                this.ankiStatisticsRefreshAll = true;
-                this.waniKaniStatisticsRefreshTrigger = true;
-                this.waniKaniStatisticsRefreshed = false;
             }
             this.shouldCancelBuild = false;
             this.annotationsBuilding = false;
@@ -1282,8 +1196,6 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     ts.collectedExactForm.delete(token);
                     ts.collectedLemmaForm.delete(token);
                     ts.collectedAnyForm.delete(token);
-                    ts.tokenCardIds.delete(token);
-                    ts.tokenAssignmentIds.delete(token);
                     ts.tokenStates.delete(token);
                 }
 
@@ -1384,13 +1296,9 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                         }
                     }
                 }
-                if (forExactFormQuery.size || forLemmaFormQuery.size || forAnyFormQuery.size) {
-                    this.ankiStatisticsRefreshNew = true;
-                }
             } catch (e) {
                 console.error(`Error building token and lemma map for track ${track}:`, e);
                 resetYomitan(ts);
-                this.ankiStatisticsRefreshNew = true; // In case of partial updates
             }
         }
     }
@@ -1617,36 +1525,6 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         }
     }
 
-    private _recordTokenStatusIdentifiers(
-        token: string,
-        ts: TrackState,
-        tokenStatusResult: ResolvedTokenStatusResult
-    ): void {
-        const cardIds = tokenStatusResult.externalCandidateStatuses?.flatMap((status) =>
-            status.cardId === undefined ? [] : [status.cardId]
-        );
-        if (cardIds?.length) {
-            let tokenCardIds = ts.tokenCardIds.get(token);
-            if (!tokenCardIds) {
-                tokenCardIds = new Map();
-                ts.tokenCardIds.set(token, tokenCardIds);
-            }
-            for (const cardId of cardIds) tokenCardIds.set(cardId, false);
-        }
-
-        const assignmentIds = tokenStatusResult.externalCandidateStatuses?.flatMap((status) =>
-            status.waniKani?.assignmentId === undefined ? [] : [status.waniKani.assignmentId]
-        );
-        if (assignmentIds?.length) {
-            let tokenAssignmentIds = ts.tokenAssignmentIds.get(token);
-            if (!tokenAssignmentIds) {
-                tokenAssignmentIds = new Set();
-                ts.tokenAssignmentIds.set(token, tokenAssignmentIds);
-            }
-            for (const assignmentId of assignmentIds) tokenAssignmentIds.add(assignmentId);
-        }
-    }
-
     private async _tokenStatus(trimmedToken: string, ts: TrackState): Promise<ResolvedTokenStatusResult | null> {
         if (!ts.yt) throw new Error('Yomitan uninitialized - cannot calculate token status');
         let tokenStatusResult: ResolvedTokenStatusResult | null;
@@ -1670,7 +1548,6 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             default:
                 throw new Error(`Unknown strategy priority: ${ts.dt.dictionaryTokenMatchStrategyPriority}`);
         }
-        if (tokenStatusResult) this._recordTokenStatusIdentifiers(trimmedToken, ts, tokenStatusResult);
         return tokenStatusResult;
     }
 

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -564,7 +564,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             const decks = Array.from(allDecksSet);
 
             await this._checkAnkiRecentlyModifiedCards(profile, fields, decks);
-            await this._refreshAnkiStatistics(cardIdsMap, fields, decks);
+            await this._refreshAnkiStatistics(profile, cardIdsMap, fields, decks);
         } finally {
             this.ankiRefreshing = false;
         }
@@ -663,7 +663,44 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         }
     }
 
-    private async _refreshAnkiStatistics(cardIdsMap: Map<number, boolean>, fields: string[], decks: string[]) {
+    private async _unknownAnkiCardsSnapshot(profile: string | undefined) {
+        const records = await this.dictionaryProvider.getRecords(profile, undefined);
+        const unknownCardIdsByTrack = new Map<number, Set<number>>();
+        const allUnknownCardIds = new Set<number>();
+        for (const [trackString, cardRecords] of Object.entries(records.ankiCardRecords)) {
+            const track = Number(trackString);
+            for (const cardRecord of Object.values(cardRecords)) {
+                if (cardRecord.status !== TokenStatus.UNKNOWN) continue;
+                const cardIds = unknownCardIdsByTrack.get(track);
+                if (cardIds) cardIds.add(cardRecord.cardId);
+                else unknownCardIdsByTrack.set(track, new Set([cardRecord.cardId]));
+                allUnknownCardIds.add(cardRecord.cardId);
+            }
+        }
+        if (!allUnknownCardIds.size) return { cardsInfo: {}, unknownCards: {} };
+
+        const cardsInfoRes = await this.anki!.cardsInfo(Array.from(allUnknownCardIds));
+        const cardsInfo: DictionaryStatisticsAnkiSnapshot['cardsInfo'] = {};
+        for (const cardInfo of cardsInfoRes) cardsInfo[cardInfo.cardId] = cardInfo;
+
+        const unknownCards: NonNullable<DictionaryStatisticsAnkiSnapshot['unknownCards']> = {};
+        for (const [track, cardIds] of unknownCardIdsByTrack.entries()) {
+            unknownCards[track] = Array.from(cardIds).sort((left, right) => {
+                const leftDue = cardsInfo[left]?.due ?? Number.POSITIVE_INFINITY;
+                const rightDue = cardsInfo[right]?.due ?? Number.POSITIVE_INFINITY;
+                return leftDue - rightDue || left - right;
+            });
+        }
+
+        return { cardsInfo, unknownCards };
+    }
+
+    private async _refreshAnkiStatistics(
+        profile: string | undefined,
+        cardIdsMap: Map<number, boolean>,
+        fields: string[],
+        decks: string[]
+    ) {
         if (this.statisticsBatchProcessedIndex < this._subtitles.length) return; // Will need to re-query anki as tokens are processed.
         let refreshNewOnly = true;
         if (this.ankiStatisticsRefreshAll) {
@@ -713,11 +750,13 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 });
             } else {
                 for (const cardId of cardIdsMap.keys()) cardIds.push(cardId);
+                const unknownAnkiCardsSnapshot = await this._unknownAnkiCardsSnapshot(profile);
                 if (!cardIds.length) {
                     this.dictionaryStatistics.replaceAnkiSnapshot({
                         available: true,
-                        cardsInfo: {},
+                        cardsInfo: unknownAnkiCardsSnapshot.cardsInfo,
                         dueCards: {},
+                        unknownCards: unknownAnkiCardsSnapshot.unknownCards,
                     });
                     return;
                 }
@@ -732,8 +771,9 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                         total: cardIdsMap.size,
                         startedAt,
                     },
-                    cardsInfo,
+                    cardsInfo: { ...unknownAnkiCardsSnapshot.cardsInfo, ...cardsInfo },
                     dueCards,
+                    unknownCards: unknownAnkiCardsSnapshot.unknownCards,
                 });
             }
         } catch (e) {

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -1558,7 +1558,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         }
 
         const assignmentIds = tokenStatusResult.externalCandidateStatuses?.flatMap((status) =>
-            status.assignmentId === undefined ? [] : [status.assignmentId]
+            status.waniKani?.assignmentId === undefined ? [] : [status.waniKani.assignmentId]
         );
         if (assignmentIds?.length) {
             let tokenAssignmentIds = ts.tokenAssignmentIds.get(token);

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -120,6 +120,51 @@ function shouldUseLemmasGroupingKey(source: DictionaryTokenSource | undefined, d
     return strategy === TokenMatchStrategy.ANY_FORM_COLLECTED || strategy === TokenMatchStrategy.LEMMA_FORM_COLLECTED;
 }
 
+/**
+ * Describes how lemmasForScript() and getAnyFormStatusResults() filter based on the dictionaryMatchAcrossScripts setting:
+ * If the tokens between subtitles and collection don't ever contain kana (not Japanese) then these checks do nothing.
+ * This feature (and multiple lemmas) currently only apply to Japanese but could be expanded for other languages.
+ *
+ * if dictionaryMatchAcrossScripts:
+ *   - Kana subtitles can match kanji in collection, could be homophones but text processing can't handle it so we allow it.
+ *   - Kanji subtitles only match with kanji in collection, prevents kana collected matches all kanji homophones.
+ * if not dictionaryMatchAcrossScripts:
+ *   - Never match across scripts, downside is if kanji is collected kana will need to be collected too.
+ *   - Essentially a strict mode where the user needs to collect all script forms of a word.
+ */
+async function lemmatizeForScript(trimmedToken: string, ts: TrackState): Promise<string[] | undefined> {
+    const lemmas = await ts.yt!.lemmatize(trimmedToken);
+    return lemmas === undefined ? undefined : lemmasForScript(trimmedToken, lemmas, ts.dt);
+}
+function lemmasForScript(trimmedToken: string, lemmas: string[], dt: DictionaryTrack): string[] {
+    const tokenIsKanaOnly = isKanaOnly(trimmedToken);
+    if (tokenIsKanaOnly && dt.dictionaryMatchAcrossScripts) return lemmas;
+    return lemmas.filter((lemma) => isKanaOnly(lemma) === tokenIsKanaOnly);
+}
+function getAnyFormStatusResults(
+    trimmedToken: string,
+    lemmas: string[],
+    ts: TrackState,
+    sourceMatches: (source: DictionaryTokenSource) => boolean
+): TokenStatusResult[] {
+    const anyFormStatusResults: TokenStatusResult[] = [];
+    for (const lemma of lemmas) {
+        const statusResults = ts.collectedAnyForm.get(lemma);
+        if (!statusResults) continue;
+        for (const statusResult of statusResults) {
+            if (!sourceMatches(statusResult.source)) continue;
+            const tokenIsKanaOnly = isKanaOnly(trimmedToken);
+            const collectedTokenIsKanaOnly = isKanaOnly(statusResult.token!);
+            if (ts.dt.dictionaryMatchAcrossScripts) {
+                if (tokenIsKanaOnly || !collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
+            } else {
+                if (tokenIsKanaOnly === collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
+            }
+        }
+    }
+    return anyFormStatusResults;
+}
+
 function groupingKeysForToken(
     trimmedToken: string,
     lemmas: string[],
@@ -128,8 +173,9 @@ function groupingKeysForToken(
 ): { groupingKey: string; lemmasGroupingKey?: string } {
     const groupingKey = trimmedToken;
     let lemmasGroupingKey: string | undefined;
-    if (lemmas.length && shouldUseLemmasGroupingKey(source, dt)) {
-        lemmasGroupingKey = `${JSON.stringify(Array.from(new Set(lemmas)).sort())}`;
+    const groupingLemmas = lemmasForScript(trimmedToken, lemmas, dt);
+    if (groupingLemmas.length && shouldUseLemmasGroupingKey(source, dt)) {
+        lemmasGroupingKey = `${JSON.stringify(Array.from(new Set(groupingLemmas)).sort())}`;
     }
     return { groupingKey, lemmasGroupingKey };
 }
@@ -1255,7 +1301,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                         .trim();
                     if (shouldQueryExactForm && !ts.collectedExactForm.has(token)) forExactFormQuery.add(token);
                     if (shouldQueryLemmaForm || shouldQueryAnyForm) {
-                        const lemmas = (await this._lemmasForScript(token, ts)) ?? [];
+                        const lemmas = (await lemmatizeForScript(token, ts)) ?? [];
                         if (shouldQueryLemmaForm) {
                             for (const lemma of lemmas) {
                                 if (!ts.collectedLemmaForm.has(lemma)) forLemmaFormQuery.add(lemma);
@@ -1632,48 +1678,6 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         return tokenStatusResult;
     }
 
-    /**
-     * Describes how lemmasForScript() and anyFormStatusResults() filter based on the dictionaryMatchAcrossScripts setting:
-     * If the tokens between subtitles and collection don't ever contain kana (not Japanese) then these checks do nothing.
-     * This feature (and multiple lemmas) currently only apply to Japanese but could be expanded for other languages.
-     *
-     * if dictionaryMatchAcrossScripts:
-     *   - Kana subtitles can match kanji in collection, could be homophones but text processing can't handle it so we allow it.
-     *   - Kanji subtitles only match with kanji in collection, prevents kana collected matches all kanji homophones.
-     * if not dictionaryMatchAcrossScripts:
-     *   - Never match across scripts, downside is if kanji is collected kana will need to be collected too.
-     *   - Essentially a strict mode where the user needs to collect all script forms of a word.
-     */
-    private async _lemmasForScript(trimmedToken: string, ts: TrackState): Promise<string[] | undefined> {
-        const lemmas = await ts.yt!.lemmatize(trimmedToken);
-        const tokenIsKanaOnly = isKanaOnly(trimmedToken);
-        if (tokenIsKanaOnly && ts.dt.dictionaryMatchAcrossScripts) return lemmas;
-        return lemmas?.filter((lemma) => isKanaOnly(lemma) === tokenIsKanaOnly);
-    }
-    private _anyFormStatusResults(
-        trimmedToken: string,
-        lemmas: string[],
-        ts: TrackState,
-        sourceMatches: (source: DictionaryTokenSource) => boolean
-    ): TokenStatusResult[] {
-        const anyFormStatusResults: TokenStatusResult[] = [];
-        for (const lemma of lemmas) {
-            const statusResults = ts.collectedAnyForm.get(lemma);
-            if (!statusResults) continue;
-            for (const statusResult of statusResults) {
-                if (!sourceMatches(statusResult.source)) continue;
-                const tokenIsKanaOnly = isKanaOnly(trimmedToken);
-                const collectedTokenIsKanaOnly = isKanaOnly(statusResult.token!);
-                if (ts.dt.dictionaryMatchAcrossScripts) {
-                    if (tokenIsKanaOnly || !collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
-                } else {
-                    if (tokenIsKanaOnly === collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
-                }
-            }
-        }
-        return anyFormStatusResults;
-    }
-
     private async _handlePriorityExact(
         trimmedToken: string,
         ts: TrackState
@@ -1685,7 +1689,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             }
         }
         if (shouldUseLemmaForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             const lemmaStatusResults: TokenStatusResult[] = [];
@@ -1698,10 +1702,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             if (lemmaStatusResults.length) return combineTokenStatusResults(lemmaStatusResults);
         }
         if (shouldUseAnyForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
-            const anyFormStatusResults = this._anyFormStatusResults(
+            const anyFormStatusResults = getAnyFormStatusResults(
                 trimmedToken,
                 lemmas,
                 ts,
@@ -1720,7 +1724,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) return tokenStatusResult;
         }
         if (shouldUseLemmaForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             const lemmaStatusResults: TokenStatusResult[] = [];
@@ -1733,10 +1737,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             if (lemmaStatusResults.length) return combineTokenStatusResults(lemmaStatusResults);
         }
         if (shouldUseAnyForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
-            const anyFormStatusResults = this._anyFormStatusResults(
+            const anyFormStatusResults = getAnyFormStatusResults(
                 trimmedToken,
                 lemmas,
                 ts,
@@ -1758,7 +1762,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         ts: TrackState
     ): Promise<ResolvedTokenStatusResult | null> {
         if (shouldUseLemmaForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             const lemmaStatusResults: TokenStatusResult[] = [];
@@ -1777,10 +1781,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             }
         }
         if (shouldUseAnyForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
-            const anyFormStatusResults = this._anyFormStatusResults(
+            const anyFormStatusResults = getAnyFormStatusResults(
                 trimmedToken,
                 lemmas,
                 ts,
@@ -1795,7 +1799,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             }
         }
         if (shouldUseLemmaForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             const lemmaStatusResults: TokenStatusResult[] = [];
@@ -1812,10 +1816,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) return tokenStatusResult;
         }
         if (shouldUseAnyForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
-            const anyFormStatusResults = this._anyFormStatusResults(
+            const anyFormStatusResults = getAnyFormStatusResults(
                 trimmedToken,
                 lemmas,
                 ts,
@@ -1846,7 +1850,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             }
         }
         if (shouldUseLemmaForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             for (const lemma of lemmas) {
@@ -1857,11 +1861,11 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             }
         }
         if (shouldUseAnyForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             tokenStatusResults.push(
-                ...this._anyFormStatusResults(
+                ...getAnyFormStatusResults(
                     trimmedToken,
                     lemmas,
                     ts,
@@ -1878,7 +1882,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             }
         }
         if (shouldUseLemmaForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             for (const lemma of lemmas) {
@@ -1889,11 +1893,11 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             }
         }
         if (shouldUseAnyForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await this._lemmasForScript(trimmedToken, ts);
+            const lemmas = await lemmatizeForScript(trimmedToken, ts);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             tokenStatusResults.push(
-                ...this._anyFormStatusResults(
+                ...getAnyFormStatusResults(
                     trimmedToken,
                     lemmas,
                     ts,

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -676,10 +676,22 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             const cardsStatus: NonNullable<DictionaryStatisticsAnkiSnapshot['cardsStatus']> = {};
             for (const cardRecords of Object.values(ankiCardRecords)) {
                 for (const cardRecord of Object.values(cardRecords)) {
-                    cardsInfo[cardRecord.cardId] = cardRecord.data;
+                    cardsInfo[cardRecord.cardId] = cardRecord.data!;
                     cardsStatus[cardRecord.cardId] = cardRecord.status;
                 }
             }
+
+            // Fallback to requesting from Anki if extension and therefore the db hasn't been updated
+            if (Object.keys(cardsInfo).length && !Object.values(cardsInfo)[0]) {
+                for (const cardInfo of await this.anki.cardsInfo(Object.keys(cardsInfo).map((id) => parseInt(id)))) {
+                    cardsInfo[cardInfo.cardId] = {
+                        deckName: cardInfo.deckName,
+                        modelName: cardInfo.modelName,
+                        due: cardInfo.due,
+                    };
+                }
+            }
+
             const dueCards: DictionaryStatisticsAnkiDueCardsSnapshot = {};
             for (const due of REVIEW_DUES) dueCards[due] = await this.anki.findCardsDueBy(due, fields, decks);
             const totalCards = Object.keys(cardsStatus).length;

--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -676,7 +676,15 @@ export function dedupeTokenStatusInfos(statuses: TokenStatusInfo[]): TokenStatus
     const seen = new Set<string>();
     const deduped: TokenStatusInfo[] = [];
     for (const status of statuses) {
-        const key = [status.cardId, status.subjectId, status.assignmentId, status.status, status.suspended].join(':');
+        const key = JSON.stringify([
+            status.cardId,
+            status.waniKani?.subjectId,
+            status.waniKani?.subjectLevel,
+            status.waniKani?.assignmentId,
+            status.waniKani?.availableAt,
+            status.status,
+            status.suspended,
+        ]);
         if (seen.has(key)) continue;
         seen.add(key);
         deduped.push(status);

--- a/common/wanikani/wanikani.ts
+++ b/common/wanikani/wanikani.ts
@@ -31,6 +31,7 @@ interface WaniKaniErrorResponse {
 export interface WaniKaniCollectionResult<T> {
     data: T[];
     dataUpdatedAt: string | null;
+    totalCount: number | null;
 }
 
 export interface WaniKaniUserData {
@@ -179,14 +180,16 @@ export class WaniKani {
     ): Promise<WaniKaniCollectionResult<T>> {
         const data: T[] = [];
         let dataUpdatedAt: string | null = null;
+        let totalCount: number | null = null;
         let nextUrl: string | null = this._url(path, params);
         while (nextUrl) {
             const page: WaniKaniCollection<T> = await this._getJson(nextUrl);
             if (!dataUpdatedAt) dataUpdatedAt = page.data_updated_at;
+            if (totalCount === null) totalCount = page.total_count;
             data.push(...page.data);
             nextUrl = page.pages.next_url;
         }
-        return { data, dataUpdatedAt };
+        return { data, dataUpdatedAt, totalCount };
     }
 
     private async _getJson<T>(url: string): Promise<T> {

--- a/common/wanikani/wanikani.ts
+++ b/common/wanikani/wanikani.ts
@@ -137,12 +137,10 @@ export class WaniKani {
     async assignments(options?: {
         subjectTypes?: WaniKaniSubjectType[];
         updatedAfter?: string;
-        availableBefore?: string;
     }): Promise<WaniKaniCollectionResult<WaniKaniAssignment>> {
         return this._getPaginated<WaniKaniAssignment>('/assignments', {
             subject_types: options?.subjectTypes?.join(','),
             updated_after: options?.updatedAfter,
-            available_before: options?.availableBefore,
         });
     }
 


### PR DESCRIPTION
_Anyone currently using the `WaniKani` features will need to [rebuild their Anki DB](https://docs.asbplayer.dev/docs/guides/annotation#clear-anki-word-database). The previous migration was updated to force a rebuild which will be fine for all users except those who used the unreleased WaniKani asbplayer._

---

The projected section can now project knowledge for `Anki` and `WaniKani`. This allows the user to select the number of `new` cards and their WaniKani level that asbplayer will use to project their stats for. This allows a user to see what their stats would be after completing their next `X new cards` (sorted by the order they will be introducted) or reaching a WaniKani level.

The projected rewatch now also promotes each status by one level in addition to collecting the i+1 sentences. Even though this feature makes a lot of assumptions, I think this one makes sense to do as well.

Optimized the runtime calls needed for statistics by storing more info in the db. The main api calls are `/user` to WaniKani so we can get the max level the user has and for the anki due dates since it's impossible to determine through `AnkiConnect`.

Finally some changes were made to how we group by lemmas for stats. If the user is using a strategy that groups by lemma, all stats will now follow suit except for the sentence filters. Those need to use the surface form otherwise the token styling will disagree with the filter.

Assisted-by: Copilot:GPT-5.5
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
