### PR TITLE
Fix sub detection on osnplus

### DIFF
--- a/common/components/StatisticsOverlay.tsx
+++ b/common/components/StatisticsOverlay.tsx
@@ -17,7 +17,6 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import CloseIcon from '@mui/icons-material/Close';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
-import StatisticsSentenceDetailsDialog from './StatisticsSentenceDetailsDialog';
 import LogoIcon from './LogoIcon';
 import LinearProgress from '@mui/material/LinearProgress';
 

--- a/extension/src/controllers/anki-ui-controller.ts
+++ b/extension/src/controllers/anki-ui-controller.ts
@@ -190,7 +190,7 @@ export default class AnkiUiController {
 
     private async _client(context: Binding) {
         this.frame.fetchOptions = {
-            videoSrc: context.video.src,
+            videoSrc: context.registeredVideoSrc,
             allowedFetchUrl: this._settings!.ankiConnectUrl,
         };
         this.frame.language = await context.settings.getSingle('language');
@@ -218,7 +218,7 @@ export default class AnkiUiController {
                                 command: 'open-asbplayer-settings',
                                 tutorial: this._inTutorial,
                             },
-                            src: context.video.src,
+                            src: context.registeredVideoSrc,
                         };
                         browser.runtime.sendMessage(openSettingsCommand);
                         return;
@@ -230,7 +230,7 @@ export default class AnkiUiController {
                                 command: 'copy-to-clipboard',
                                 dataUrl: copyToClipboardMessage.dataUrl,
                             },
-                            src: context.video.src,
+                            src: context.registeredVideoSrc,
                         };
                         browser.runtime.sendMessage(copyToClipboardCommand);
                         return;
@@ -243,7 +243,7 @@ export default class AnkiUiController {
                                 base64,
                                 extension,
                             },
-                            src: context.video.src,
+                            src: context.registeredVideoSrc,
                         };
                         const encodedBase64 = await browser.runtime.sendMessage(encodeMp3Command);
                         client.sendMessage({
@@ -259,7 +259,7 @@ export default class AnkiUiController {
                                 message: {
                                     command: 'settings-updated',
                                 },
-                                src: context.video.src,
+                                src: context.registeredVideoSrc,
                             };
                             browser.runtime.sendMessage(settingsUpdatedCommand);
                         });
@@ -275,7 +275,7 @@ export default class AnkiUiController {
                                 message: {
                                     command: 'settings-updated',
                                 },
-                                src: context.video.src,
+                                src: context.registeredVideoSrc,
                             };
                             browser.runtime.sendMessage(settingsUpdatedCommand);
                         });
@@ -284,7 +284,7 @@ export default class AnkiUiController {
                         const cardUpdatedDialogCommand: VideoToExtensionCommand<CardUpdatedDialogMessage> = {
                             sender: 'asbplayer-video',
                             message: message as CardUpdatedDialogMessage,
-                            src: context.video.src,
+                            src: context.registeredVideoSrc,
                         };
                         browser.runtime.sendMessage(cardUpdatedDialogCommand);
                         return;
@@ -292,7 +292,7 @@ export default class AnkiUiController {
                         const cardExportedDialogCommand: VideoToExtensionCommand<CardExportedDialogMessage> = {
                             sender: 'asbplayer-video',
                             message: message as CardExportedDialogMessage,
-                            src: context.video.src,
+                            src: context.registeredVideoSrc,
                         };
                         browser.runtime.sendMessage(cardExportedDialogCommand);
                         return;

--- a/extension/src/controllers/bulk-export-controller.ts
+++ b/extension/src/controllers/bulk-export-controller.ts
@@ -46,7 +46,7 @@ export default class BulkExportController {
                 request?.sender === 'asbplayer-extension-to-video' &&
                 request.message &&
                 request.message.command === 'card-exported' &&
-                request.src === this._context.video.src
+                request.src === this._context.registeredVideoSrc
             ) {
                 const exported = request.message as CardExportedMessage;
                 const isBulk = exported.isBulkExport;
@@ -127,7 +127,7 @@ export default class BulkExportController {
                 command: 'bulk-export-started',
                 total: this._queue.length,
             },
-            src: this._context.video.src,
+            src: this._context.registeredVideoSrc,
         };
         browser.runtime.sendMessage(startedMessage).catch(console.error);
 
@@ -154,7 +154,7 @@ export default class BulkExportController {
             message: {
                 command: 'bulk-export-cancelled',
             },
-            src: this._context.video.src,
+            src: this._context.registeredVideoSrc,
         };
         browser.runtime.sendMessage(cancelledMessage);
     }
@@ -218,7 +218,7 @@ export default class BulkExportController {
             message: {
                 command: 'bulk-export-completed',
             },
-            src: this._context.video.src,
+            src: this._context.registeredVideoSrc,
         };
         browser.runtime.sendMessage(completedMessage);
     }

--- a/extension/src/controllers/mobile-video-overlay-controller.ts
+++ b/extension/src/controllers/mobile-video-overlay-controller.ts
@@ -116,7 +116,10 @@ export class MobileVideoOverlayController {
             sender: Browser.runtime.MessageSender,
             sendResponse: (response?: any) => void
         ) => {
-            if (message.sender !== 'asbplayer-mobile-overlay-to-video' || message.src !== this._context.video.src) {
+            if (
+                message.sender !== 'asbplayer-mobile-overlay-to-video' ||
+                message.src !== this._context.registeredVideoSrc
+            ) {
                 return;
             }
 
@@ -153,7 +156,7 @@ export class MobileVideoOverlayController {
                 command: 'update-mobile-overlay-model',
                 model,
             },
-            src: this._context.video.src,
+            src: this._context.registeredVideoSrc,
         };
         browser.runtime.sendMessage(command);
     }
@@ -243,7 +246,7 @@ export class MobileVideoOverlayController {
         const height = smallScreen ? 64 : 108;
         const tooltips = !smallScreen;
         const width = Math.min(window.innerWidth, 410);
-        const src = encodeURIComponent(this._context.video.src);
+        const src = encodeURIComponent(this._context.registeredVideoSrc);
 
         return { width, height, anchor, src, tooltips };
     }

--- a/extension/src/controllers/subtitle-controller.ts
+++ b/extension/src/controllers/subtitle-controller.ts
@@ -38,6 +38,7 @@ import {
 } from '../services/element-overlay';
 import { v4 as uuidv4 } from 'uuid';
 import { DictionaryProvider } from '@project/common/dictionary-db';
+import Binding from '@/services/binding';
 
 const BOUNDING_BOX_PADDING = 25;
 
@@ -74,7 +75,7 @@ class VideoFetcher implements Fetcher {
 }
 
 export default class SubtitleController {
-    private readonly video: HTMLMediaElement;
+    private readonly context: Binding;
     private readonly dictionary: DictionaryProvider;
     private readonly settings: SettingsProvider;
 
@@ -125,8 +126,8 @@ export default class SubtitleController {
     onMouseOver?: (event: MouseEvent) => void;
     onMouseOut?: (event: MouseEvent) => void;
 
-    constructor(video: HTMLMediaElement, dictionary: DictionaryProvider, settings: SettingsProvider) {
-        this.video = video;
+    constructor(context: Binding, dictionary: DictionaryProvider, settings: SettingsProvider) {
+        this.context = context;
         this.dictionary = dictionary;
         this.settings = settings;
         this._preCacheDom = false;
@@ -161,10 +162,10 @@ export default class SubtitleController {
             this.dictionary,
             this.settings,
             subtitleCollectionOptions,
-            this.video.src,
+            this.context.registeredVideoSrc,
             (updatedSubtitles) => this._subtitleAnnotationsUpdated(updatedSubtitles),
-            () => this.video.currentTime * 1000,
-            new VideoFetcher(() => this.video.src)
+            () => this.context.video.currentTime * 1000,
+            new VideoFetcher(() => this.context.registeredVideoSrc)
         );
         this.seekableSubtitleCollection = new SubtitleCollection(subtitleCollectionOptions);
     }
@@ -319,7 +320,7 @@ export default class SubtitleController {
 
     private _elementOverlayParams() {
         const subtitleOverlayParams: ElementOverlayParams = {
-            targetElement: this.video,
+            targetElement: this.context.video,
             nonFullscreenContainerClassName: 'asbplayer-subtitles-container-bottom',
             nonFullscreenContentClassName: 'asbplayer-subtitles',
             fullscreenContainerClassName: 'asbplayer-subtitles-container-bottom',
@@ -330,7 +331,7 @@ export default class SubtitleController {
             onMouseOut: (event: MouseEvent) => this.onMouseOut?.(event),
         };
         const topSubtitleOverlayParams: ElementOverlayParams = {
-            targetElement: this.video,
+            targetElement: this.context.video,
             nonFullscreenContainerClassName: 'asbplayer-subtitles-container-top',
             nonFullscreenContentClassName: 'asbplayer-subtitles',
             fullscreenContainerClassName: 'asbplayer-subtitles-container-top',
@@ -343,7 +344,7 @@ export default class SubtitleController {
         const notificationOverlayParams: ElementOverlayParams =
             this._getSubtitleTrackAlignment(0) === 'bottom'
                 ? {
-                      targetElement: this.video,
+                      targetElement: this.context.video,
                       nonFullscreenContainerClassName: 'asbplayer-notification-container-top',
                       nonFullscreenContentClassName: 'asbplayer-notification',
                       fullscreenContainerClassName: 'asbplayer-notification-container-top',
@@ -354,7 +355,7 @@ export default class SubtitleController {
                       onMouseOut: (event: MouseEvent) => this.onMouseOut?.(event),
                   }
                 : {
-                      targetElement: this.video,
+                      targetElement: this.context.video,
                       nonFullscreenContainerClassName: 'asbplayer-notification-container-bottom',
                       nonFullscreenContentClassName: 'asbplayer-notification',
                       fullscreenContainerClassName: 'asbplayer-notification-container-bottom',
@@ -398,7 +399,7 @@ export default class SubtitleController {
                 command: 'subtitlesUpdated',
                 updatedSubtitles,
             },
-            src: this.video.src,
+            src: this.context.registeredVideoSrc,
         };
         browser.runtime.sendMessage(command);
     }
@@ -423,8 +424,8 @@ export default class SubtitleController {
 
             const showOffset = this.lastOffsetChangeTimestamp > 0 && Date.now() - this.lastOffsetChangeTimestamp < 1000;
             const offset = showOffset ? this._computeOffset() : 0;
-            const slice = this.subtitleAnnotations.subtitlesAt(this.video.currentTime * 1000);
-            const seekableSlice = this.seekableSubtitleCollection.subtitlesAt(this.video.currentTime * 1000);
+            const slice = this.subtitleAnnotations.subtitlesAt(this.context.video.currentTime * 1000);
+            const seekableSlice = this.seekableSubtitleCollection.subtitlesAt(this.context.video.currentTime * 1000);
 
             const showingSubtitles = this._findShowingSubtitles(slice);
 
@@ -525,7 +526,7 @@ export default class SubtitleController {
                         command: 'copy-to-clipboard',
                         dataUrl: `data:,${encodeURIComponent(text)}`,
                     },
-                    src: this.video.src,
+                    src: this.context.registeredVideoSrc,
                 };
 
                 browser.runtime.sendMessage(command);
@@ -549,7 +550,7 @@ export default class SubtitleController {
                         const className = this.subtitleClasses?.[subtitle.track] ?? '';
                         const imageScale =
                             ((this.subtitleSettings?.imageBasedSubtitleScaleFactor ?? 1) *
-                                this.video.getBoundingClientRect().width) /
+                                this.context.video.getBoundingClientRect().width) /
                             subtitle.textImage.screen.width;
                         const width = imageScale * subtitle.textImage.image.width;
 
@@ -624,7 +625,7 @@ export default class SubtitleController {
     }
 
     currentSubtitle(): [IndexedSubtitleModel | null, SubtitleModel[] | null] {
-        const now = 1000 * this.video.currentTime;
+        const now = 1000 * this.context.video.currentTime;
         let subtitle = null;
         let index = null;
 
@@ -685,7 +686,7 @@ export default class SubtitleController {
                     command: 'offset',
                     value: offset,
                 },
-                src: this.video.src,
+                src: this.context.registeredVideoSrc,
             };
 
             browser.runtime.sendMessage(command);

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -350,7 +350,7 @@ export default class VideoDataSyncController {
                         message: {
                             command: 'open-asbplayer-settings',
                         },
-                        src: this._context.video.src,
+                        src: this._context.registeredVideoSrc,
                     };
                     browser.runtime.sendMessage(openSettingsCommand);
                     return;
@@ -364,7 +364,7 @@ export default class VideoDataSyncController {
                         message: {
                             command: 'settings-updated',
                         },
-                        src: this._context.video.src,
+                        src: this._context.registeredVideoSrc,
                     };
                     browser.runtime.sendMessage(settingsUpdatedCommand);
                     return;

--- a/extension/src/controllers/video-select-controller.ts
+++ b/extension/src/controllers/video-select-controller.ts
@@ -95,7 +95,7 @@ export default class VideoSelectController {
         subtitleFiles?: SubtitleFile[]
     ) {
         if (targetSrc !== undefined) {
-            var binding = this._bindings.find((b) => b.video.src === targetSrc);
+            var binding = this._bindings.find((b) => b.registeredVideoSrc === targetSrc);
 
             if (binding !== undefined && binding.subscribed) {
                 if (subtitleFiles !== undefined) {
@@ -131,7 +131,7 @@ export default class VideoSelectController {
         const tabImageDataUrl = (await browser.runtime.sendMessage(captureVisibleTabCommand)) as string;
         const videoElementPromises: Promise<VideoElement>[] = this._bindings.map(async (b) => {
             return {
-                src: b.video.src,
+                src: b.registeredVideoSrc,
                 imageDataUrl: await b.cropAndResize(tabImageDataUrl),
             };
         });
@@ -158,7 +158,8 @@ export default class VideoSelectController {
                     client.updateState({ open: false });
                     this._frame.hide();
                     const binding = this._bindings.find(
-                        (b) => b.video.src === (message as VideoSelectModeConfirmMessage).selectedVideoElementSrc
+                        (b) =>
+                            b.registeredVideoSrc === (message as VideoSelectModeConfirmMessage).selectedVideoElementSrc
                     );
                     if (binding !== undefined) {
                         if (this._subtitleFiles === undefined) {

--- a/extension/src/entrypoints/osnplus-page.ts
+++ b/extension/src/entrypoints/osnplus-page.ts
@@ -2,7 +2,7 @@ import { inferTracksFromInterceptedMpd } from '@/pages/mpd-util';
 import { extractExtension } from '@/pages/util';
 
 export default defineUnlistedScript(() => {
-    inferTracksFromInterceptedMpd(/https:\/\/(.+\.)?osn\.com.+\.mpd/, (playlist, language) => {
+    inferTracksFromInterceptedMpd(/https:\/\/(.+\.)?.+\.mpd/, (playlist, language) => {
         const name = playlist.attributes?.NAME;
         return {
             label: name === undefined ? language : `${language} - ${name}`,

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -127,6 +127,8 @@ const startAudioRecordingErrorResponse: (e: any) => StartRecordingResponse = (e:
 };
 
 export default class Binding {
+    private readonly _fallbackVideoSrc = uuidv4();
+
     subscribed: boolean = false;
 
     ankiUiSavedState?: AnkiUiSavedState;
@@ -213,7 +215,7 @@ export default class Binding {
 
     constructor(video: HTMLMediaElement, hasPageScript: boolean, frameId?: string) {
         this.video = video;
-        this._registeredVideoSrc = video.src || uuidv4();
+        this._registeredVideoSrc = video.src || this._fallbackVideoSrc;
         this.hasPageScript = hasPageScript;
         this.dictionary = new DictionaryProvider(new ExtensionDictionaryStorage());
         this.settings = new SettingsProvider(new ExtensionSettingsStorage());
@@ -676,9 +678,7 @@ export default class Binding {
 
         if (this.hasPageScript) {
             this.videoChangeListener = () => {
-                if (this.video.src) {
-                    this._updateRegisteredVideoSrc(this.video.src);
-                }
+                this._updateRegisteredVideoSrc(this.video.src || this._fallbackVideoSrc);
                 this.videoDataSyncController.requestSubtitles();
                 this._resetSubtitles();
             };
@@ -686,9 +686,7 @@ export default class Binding {
         }
 
         this.heartbeatInterval = setInterval(() => {
-            if (this.video.src) {
-                this._updateRegisteredVideoSrc(this.video.src);
-            }
+            this._updateRegisteredVideoSrc(this.video.src || this._fallbackVideoSrc);
 
             const command: VideoToExtensionCommand<VideoHeartbeatMessage> = {
                 sender: 'asbplayer-video',

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -55,8 +55,6 @@ import {
 import { adjacentSubtitle } from '@project/common/key-binder';
 import PlayModeManager from '@project/common/app/services/play-mode-manager';
 import {
-    AutoCopyableTracks,
-    calculateAutoCopyableTracksValue,
     calculateSeekableTracksValue,
     extractAnkiSettings,
     isTrackSeekable,
@@ -95,6 +93,7 @@ import { pgsParserWorkerFactory } from './pgs-parser-worker-factory';
 import { DictionaryProvider } from '@project/common/dictionary-db/dictionary-provider';
 import { ExtensionDictionaryStorage } from './extension-dictionary-storage';
 import { HoveredToken } from '@project/common/subtitle-annotations';
+import { v4 as uuidv4 } from 'uuid';
 
 let netflix = false;
 document.addEventListener('asbplayer-netflix-enabled', (e) => {
@@ -199,7 +198,7 @@ export default class Binding {
         sendResponse: (response?: any) => void
     ) => void;
     private heartbeatInterval?: NodeJS.Timeout;
-    private registeredVideoSrc?: string;
+    private _registeredVideoSrc: string;
 
     // In the case of firefox, we need to avoid capturing the audio stream more than once,
     // so we keep a reference to the first one we capture here.
@@ -214,10 +213,11 @@ export default class Binding {
 
     constructor(video: HTMLMediaElement, hasPageScript: boolean, frameId?: string) {
         this.video = video;
+        this._registeredVideoSrc = video.src || uuidv4();
         this.hasPageScript = hasPageScript;
         this.dictionary = new DictionaryProvider(new ExtensionDictionaryStorage());
         this.settings = new SettingsProvider(new ExtensionSettingsStorage());
-        this.subtitleController = new SubtitleController(video, this.dictionary, this.settings);
+        this.subtitleController = new SubtitleController(this, this.dictionary, this.settings);
         this.videoDataSyncController = new VideoDataSyncController(this, this.settings);
         this.controlsController = new ControlsController(video);
         this.dragController = new DragController(video);
@@ -243,8 +243,11 @@ export default class Binding {
         this.postMinePlayback = PostMinePlayback.remember;
         this._synced = false;
         this.recordingMediaWithScreenshot = false;
-        this.registeredVideoSrc = video.src || undefined;
         this.frameId = frameId;
+    }
+
+    get registeredVideoSrc() {
+        return this._registeredVideoSrc;
     }
 
     get recordingMedia() {
@@ -500,7 +503,7 @@ export default class Binding {
                         command: 'readyState',
                         value: 4,
                     },
-                    src: this.video.src,
+                    src: this._registeredVideoSrc,
                 };
 
                 browser.runtime.sendMessage(command);
@@ -549,7 +552,7 @@ export default class Binding {
                 selectedAudioTrack: undefined,
                 playbackRate: this.video.playbackRate,
             },
-            src: this.video.src,
+            src: this._registeredVideoSrc,
         };
 
         browser.runtime.sendMessage(command);
@@ -563,7 +566,7 @@ export default class Binding {
                     command: 'play',
                     echo: false,
                 },
-                src: this.video.src,
+                src: this._registeredVideoSrc,
             };
 
             browser.runtime.sendMessage(command);
@@ -582,7 +585,7 @@ export default class Binding {
                     command: 'pause',
                     echo: false,
                 },
-                src: this.video.src,
+                src: this._registeredVideoSrc,
             };
 
             browser.runtime.sendMessage(command);
@@ -602,7 +605,7 @@ export default class Binding {
                     value: this.video.currentTime,
                     echo: false,
                 },
-                src: this.video.src,
+                src: this._registeredVideoSrc,
             };
             const readyStateCommand: VideoToExtensionCommand<ReadyStateFromVideoMessage> = {
                 sender: 'asbplayer-video',
@@ -610,7 +613,7 @@ export default class Binding {
                     command: 'readyState',
                     value: this.video.readyState,
                 },
-                src: this.video.src,
+                src: this._registeredVideoSrc,
             };
 
             browser.runtime.sendMessage(currentTimeCommand);
@@ -627,7 +630,7 @@ export default class Binding {
                     value: this.video.playbackRate,
                     echo: false,
                 },
-                src: this.video.src,
+                src: this._registeredVideoSrc,
             };
 
             browser.runtime.sendMessage(command);
@@ -673,7 +676,9 @@ export default class Binding {
 
         if (this.hasPageScript) {
             this.videoChangeListener = () => {
-                this._updateRegisteredVideoSrc(this.video.src || undefined);
+                if (this.video.src) {
+                    this._updateRegisteredVideoSrc(this.video.src);
+                }
                 this.videoDataSyncController.requestSubtitles();
                 this._resetSubtitles();
             };
@@ -681,9 +686,9 @@ export default class Binding {
         }
 
         this.heartbeatInterval = setInterval(() => {
-            const src = this.video.src || undefined;
-            this._updateRegisteredVideoSrc(src);
-            if (!src) return;
+            if (this.video.src) {
+                this._updateRegisteredVideoSrc(this.video.src);
+            }
 
             const command: VideoToExtensionCommand<VideoHeartbeatMessage> = {
                 sender: 'asbplayer-video',
@@ -694,7 +699,7 @@ export default class Binding {
                     syncedTimestamp: this._syncedTimestamp,
                     loadedSubtitles: this.subtitleController.subtitles.length > 0,
                 },
-                src,
+                src: this._registeredVideoSrc,
             };
 
             browser.runtime.sendMessage(command);
@@ -709,7 +714,7 @@ export default class Binding {
             sender: Browser.runtime.MessageSender,
             sendResponse: (response?: any) => void
         ) => {
-            if (request.sender === 'asbplayer-extension-to-video' && request.src === this.video.src) {
+            if (request.sender === 'asbplayer-extension-to-video' && request.src === this._registeredVideoSrc) {
                 switch (request.message.command) {
                     case 'init':
                         this._notifyReady();
@@ -1037,7 +1042,7 @@ export default class Binding {
                             command: 'ack-message',
                             messageId: request.message['messageId'],
                         },
-                        src: this.video.src,
+                        src: this._registeredVideoSrc,
                     };
                     browser.runtime.sendMessage(ackCommand);
                 }
@@ -1212,8 +1217,8 @@ export default class Binding {
         this.bulkExportController.unbind();
         this.subscribed = false;
 
-        this._notifyVideoDisappeared(this.registeredVideoSrc ?? (this.video.src || undefined));
-        this.registeredVideoSrc = undefined;
+        this._notifyVideoDisappeared(this._registeredVideoSrc);
+        this._registeredVideoSrc = '';
     }
 
     async _takeScreenshot() {
@@ -1232,7 +1237,7 @@ export default class Binding {
                 subtitleFileName: this.subtitleFileName(),
                 mediaTimestamp: this.video.currentTime * 1000,
             },
-            src: this.video.src,
+            src: this._registeredVideoSrc,
         };
 
         browser.runtime.sendMessage(command);
@@ -1312,7 +1317,7 @@ export default class Binding {
                 isBulkExport,
                 ...this._imageCaptureParams,
             },
-            src: this.video.src,
+            src: this._registeredVideoSrc,
         };
 
         browser.runtime.sendMessage(command);
@@ -1345,7 +1350,7 @@ export default class Binding {
                     ...this._imageCaptureParams,
                     ...this._surroundingSubtitlesAroundInterval(this.recordingMediaStartedTimestamp!, currentTimestamp),
                 },
-                src: this.video.src,
+                src: this._registeredVideoSrc,
             };
 
             browser.runtime.sendMessage(command);
@@ -1383,7 +1388,7 @@ export default class Binding {
                     imageDelay: this.imageDelay,
                     ...this._imageCaptureParams,
                 },
-                src: this.video.src,
+                src: this._registeredVideoSrc,
             };
 
             browser.runtime.sendMessage(command);
@@ -1434,7 +1439,7 @@ export default class Binding {
                 timestamp: start,
                 subtitleFileName: this.subtitleFileName(),
             },
-            src: this.video.src,
+            src: this._registeredVideoSrc,
         };
 
         browser.runtime.sendMessage(command);
@@ -1561,7 +1566,7 @@ export default class Binding {
                     withSyncedAsbplayerOnly,
                     withAsbplayerId,
                 },
-                src: this.video.src,
+                src: this._registeredVideoSrc,
             };
             browser.runtime.sendMessage(syncMessage);
         };
@@ -1663,14 +1668,14 @@ export default class Binding {
         this.mobileVideoOverlayController.disposeOverlay();
     }
 
-    private _updateRegisteredVideoSrc(src: string | undefined) {
-        if (src === this.registeredVideoSrc) return;
-        this._notifyVideoDisappeared(this.registeredVideoSrc);
-        this.registeredVideoSrc = src;
+    private _updateRegisteredVideoSrc(src: string) {
+        if (src === this._registeredVideoSrc) return;
+        this._notifyVideoDisappeared(this._registeredVideoSrc);
+        this._registeredVideoSrc = src;
     }
 
     private _notifyVideoDisappeared(src: string | undefined) {
-        if (!src) return;
+        if (src === undefined) return;
         const command: VideoToExtensionCommand<VideoDisappearedMessage> = {
             sender: 'asbplayer-video',
             message: {
@@ -1774,7 +1779,7 @@ export default class Binding {
                     base64,
                     extension: 'webm',
                 },
-                src: this.video.src,
+                src: this._registeredVideoSrc,
             };
             base64 = await browser.runtime.sendMessage(encodeMp3Command);
         }
@@ -1786,7 +1791,7 @@ export default class Binding {
                 base64,
                 requestId,
             },
-            src: this.video.src,
+            src: this._registeredVideoSrc,
         };
 
         browser.runtime.sendMessage(command);
@@ -1799,7 +1804,7 @@ export default class Binding {
                 command: 'requesting-active-tab-permission',
                 requesting,
             },
-            src: this.video.src,
+            src: this._registeredVideoSrc,
         };
 
         browser.runtime.sendMessage(command);

--- a/extension/src/services/key-bindings.ts
+++ b/extension/src/services/key-bindings.ts
@@ -173,7 +173,7 @@ export default class KeyBindings {
                     message: {
                         command: 'toggle-subtitles',
                     },
-                    src: context.video.src,
+                    src: context.registeredVideoSrc,
                 };
 
                 browser.runtime.sendMessage(toggleSubtitlesCommand);
@@ -251,7 +251,7 @@ export default class KeyBindings {
                     message: {
                         command: 'open-statistics',
                     },
-                    src: context.video.src,
+                    src: context.registeredVideoSrc,
                 };
 
                 browser.runtime.sendMessage(command);
@@ -270,7 +270,7 @@ export default class KeyBindings {
                         command: 'toggleSubtitleTrackInList',
                         track: track,
                     },
-                    src: context.video.src,
+                    src: context.registeredVideoSrc,
                 };
                 browser.runtime.sendMessage(command);
             },
@@ -347,7 +347,7 @@ export default class KeyBindings {
                             message: {
                                 command: 'settings-updated',
                             },
-                            src: context.video.src,
+                            src: context.registeredVideoSrc,
                         };
                         browser.runtime.sendMessage(settingsUpdatedCommand);
                     })
@@ -374,7 +374,7 @@ export default class KeyBindings {
                             message: {
                                 command: 'settings-updated',
                             },
-                            src: context.video.src,
+                            src: context.registeredVideoSrc,
                         };
                         browser.runtime.sendMessage(settingsUpdatedCommand);
                     })


### PR DESCRIPTION
This feels like a somewhat risky change and so would like another pair of eyes on it

- Main bug fix was a regex change for osnplus manifest file. This is easy.
- The riskier change was providing a default src string for video elements that don't have them. osnplus and twitch are examples of sites that don't assign a src string to the video element. The main reason for doing this was to ensure that video elements without src strings can be identified and distinguished from other video elements, and to avoid any possible bugs that might be caused by code assuming src strings should be nonempty.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
