### PR TITLE
Ignore capitalization when annotating words

### DIFF
--- a/common/dictionary-db/dictionary-db-anki.ts
+++ b/common/dictionary-db/dictionary-db-anki.ts
@@ -14,6 +14,7 @@ import {
     dictionaryStatusCollectionEnabled,
     DictionaryTokenSource,
     DictionaryTrack,
+    isAnkiSource,
     TokenState,
     TokenStatus,
 } from '@project/common/settings';
@@ -312,10 +313,6 @@ async function _getAnkiCardsByNoteIdBulk(
             }
             return cardRecordsByNoteId;
         });
-}
-
-function isAnkiSource(source: DictionaryTokenSource): boolean {
-    return source === DictionaryTokenSource.ANKI_WORD || source === DictionaryTokenSource.ANKI_SENTENCE;
 }
 
 /**

--- a/common/dictionary-db/dictionary-db.ts
+++ b/common/dictionary-db/dictionary-db.ts
@@ -4,12 +4,15 @@ import {
     AsbplayerSettings,
     DictionaryTokenSource,
     DictionaryTrack,
+    ExternalWordSource,
+    externalWordSourcePriority,
     getFullyKnownTokenStatus,
+    isExternalWordSource,
     SettingsProvider,
     TokenState,
     TokenStatus,
 } from '@project/common/settings';
-import { getTokenStatus, HAS_LETTER_REGEX } from '@project/common/util';
+import { getTokenStatus, HAS_LETTER_REGEX, normalizeToken } from '@project/common/util';
 import { WaniKaniAssignment, WaniKaniSpacedRepetitionSystem, WaniKaniSubject } from '@project/common/wanikani';
 import { Yomitan } from '@project/common/yomitan/yomitan';
 import Dexie from 'dexie';
@@ -20,6 +23,9 @@ import { CardInfo } from '@project/common/anki';
 /**
  * This file only contains the public interface functions and types.
  * Functions/types with a leading underscore are considered private to the db and its pipelines/helper functions, even if exported.
+ *
+ * IMPORTANT: You cannot use runtime exports (e.g functions) from this file freely in the rest of the codebase as it will prevent
+ * the extension from building correctly if it eventually gets compiled into a content script.
  */
 
 export const BUILD_MIN_EXPIRATION_MS = 5 * 60 * 1000; // 5 minutes
@@ -409,21 +415,27 @@ export class DictionaryDB {
         dictionaryAnkiTreatSuspended: TokenStatus | 'NORMAL'
     ): { record: DictionaryTokenRecord; statuses: TokenStatusInfo[]; status: TokenStatus } | undefined {
         let bestCandidate:
-            | { record: DictionaryTokenRecord; statuses: TokenStatusInfo[]; status: TokenStatus }
+            | {
+                  record: DictionaryTokenRecord & { source: ExternalWordSource };
+                  statuses: TokenStatusInfo[];
+                  status: TokenStatus;
+              }
             | undefined;
         for (const record of records) {
-            if (record.source === DictionaryTokenSource.LOCAL) continue;
-            if (record.source === DictionaryTokenSource.ANKI_SENTENCE) continue;
+            if (!isExternalWordSource(record.source)) continue;
             const statuses = this._statusesFromRecord(record, cardStatusMap, waniKaniSubjectStatusMap);
             const status = getTokenStatus(statuses, dictionaryAnkiTreatSuspended);
             if (
                 bestCandidate === undefined ||
                 status > bestCandidate.status ||
                 (status === bestCandidate.status &&
-                    _externalWordSourcePriority(record.source) >
-                        _externalWordSourcePriority(bestCandidate.record.source))
+                    externalWordSourcePriority(record.source) > externalWordSourcePriority(bestCandidate.record.source))
             ) {
-                bestCandidate = { record, statuses, status };
+                bestCandidate = {
+                    record: record as DictionaryTokenRecord & { source: ExternalWordSource },
+                    statuses,
+                    status,
+                };
             }
         }
         return bestCandidate;
@@ -539,9 +551,9 @@ export class DictionaryDB {
             [this.db.tokens, this.db.ankiCards, this.db.waniKaniAssignments, this.db.waniKaniSubjects, this.db.meta],
             async () => {
                 const records = await this.db.tokens
-                    .where('[profile+token]')
-                    .anyOf(tokens.map((token) => [profile, token]))
-                    .filter((r) => r.track === track || r.track === LOCAL_TOKEN_TRACK)
+                    .where('token')
+                    .anyOfIgnoreCase(tokens)
+                    .filter((r) => (r.track === track || r.track === LOCAL_TOKEN_TRACK) && r.profile === profile)
                     .toArray();
                 return this._tokenResultsFromRecords(profile, track, records, settings);
             }
@@ -576,7 +588,7 @@ export class DictionaryDB {
      */
     async getByLemmaBulk(inputProfile: string | undefined, track: number, lemmas: string[]): Promise<LemmaResults> {
         if (!lemmas.length) return {};
-        const lemmasSet = new Set(lemmas);
+        const normalizedLemmasSet = new Set(lemmas.map(normalizeToken));
         const profile = this._getProfile(inputProfile);
         const settings = await this.settingsProvider.getAll();
 
@@ -586,7 +598,7 @@ export class DictionaryDB {
             async () => {
                 return this.db.tokens
                     .where('lemmas')
-                    .anyOf(lemmas)
+                    .anyOfIgnoreCase(lemmas)
                     .distinct()
                     .filter((r) => (r.track === track || r.track === LOCAL_TOKEN_TRACK) && r.profile === profile)
                     .toArray()
@@ -595,7 +607,7 @@ export class DictionaryDB {
                         const lemmaRecordMap = new Map<string, DictionaryTokenRecord[]>();
                         for (const record of records) {
                             for (const lemma of record.lemmas) {
-                                if (!lemmasSet.has(lemma)) continue;
+                                if (!normalizedLemmasSet.has(normalizeToken(lemma))) continue;
                                 const val = lemmaRecordMap.get(lemma);
                                 if (val) val.push(record);
                                 else lemmaRecordMap.set(lemma, [record]);
@@ -1313,7 +1325,7 @@ export async function _gatherModifiedTokens(
     if (!modifiedTokens.size) return;
     return db.tokens
         .where('lemmas')
-        .anyOf(Array.from(modifiedTokens))
+        .anyOfIgnoreCase(Array.from(modifiedTokens))
         .distinct()
         .filter((r) => r.profile === profile)
         .toArray()
@@ -1334,7 +1346,7 @@ export async function _gatherModifiedTokensForTrack(
     if (!modifiedTokens.size) return;
     return db.tokens
         .where('lemmas')
-        .anyOf(Array.from(modifiedTokens))
+        .anyOfIgnoreCase(Array.from(modifiedTokens))
         .distinct()
         .filter((r) => r.profile === profile && r.track === track)
         .toArray()
@@ -1366,17 +1378,6 @@ function _applyStrategyToStates(currentStates: TokenState[], nextStates: TokenSt
             return Array.from(currentStateSet).sort((lhs, rhs) => lhs - rhs);
         default:
             throw new Error(`Unsupported applyStates value: "${applyStates}"`);
-    }
-}
-
-function _externalWordSourcePriority(source: DictionaryTokenSource): number {
-    switch (source) {
-        case DictionaryTokenSource.ANKI_WORD:
-            return 2;
-        case DictionaryTokenSource.WANIKANI:
-            return 1;
-        default:
-            return 0;
     }
 }
 

--- a/common/settings/settings.ts
+++ b/common/settings/settings.ts
@@ -119,6 +119,11 @@ export function externalWordSourcePriority(source: ExternalWordSource): number {
     }
 }
 
+export type WordSource = DictionaryTokenSource.LOCAL | ExternalWordSource;
+export function isWordSource(source: DictionaryTokenSource): source is WordSource {
+    return source === DictionaryTokenSource.LOCAL || isExternalWordSource(source);
+}
+
 /*
 These are all the possible scenarios which can result in a match. We don't need to support every possible combination,
 as some are not useful or inconsistent. Inconsistent meaning the order the user collects forms affects what future forms

--- a/common/settings/settings.ts
+++ b/common/settings/settings.ts
@@ -84,6 +84,41 @@ export enum DictionaryTokenSource {
     WANIKANI = 3,
 }
 
+export function dictionaryTokenSourcePriority(source: DictionaryTokenSource): number {
+    switch (source) {
+        case DictionaryTokenSource.LOCAL:
+            return 3;
+        case DictionaryTokenSource.ANKI_WORD:
+        case DictionaryTokenSource.WANIKANI:
+            return 2;
+        case DictionaryTokenSource.ANKI_SENTENCE:
+            return 1;
+        default:
+            throw new Error(`Unsupported DictionaryTokenSource: ${source}`);
+    }
+}
+
+export type AnkiSource = DictionaryTokenSource.ANKI_WORD | DictionaryTokenSource.ANKI_SENTENCE;
+export function isAnkiSource(source: DictionaryTokenSource): source is AnkiSource {
+    return source === DictionaryTokenSource.ANKI_WORD || source === DictionaryTokenSource.ANKI_SENTENCE;
+}
+
+export type ExternalWordSource = DictionaryTokenSource.ANKI_WORD | DictionaryTokenSource.WANIKANI;
+export function isExternalWordSource(source: DictionaryTokenSource): source is ExternalWordSource {
+    return source === DictionaryTokenSource.ANKI_WORD || source === DictionaryTokenSource.WANIKANI;
+}
+
+export function externalWordSourcePriority(source: ExternalWordSource): number {
+    switch (source) {
+        case DictionaryTokenSource.ANKI_WORD:
+            return 2;
+        case DictionaryTokenSource.WANIKANI:
+            return 1;
+        default:
+            throw new Error(`Unsupported DictionaryTokenSource: ${source}`);
+    }
+}
+
 /*
 These are all the possible scenarios which can result in a match. We don't need to support every possible combination,
 as some are not useful or inconsistent. Inconsistent meaning the order the user collects forms affects what future forms

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -35,6 +35,7 @@ import {
     TokenState,
     TokenStatus,
     TokenStyling,
+    isWordSource,
 } from '@project/common/settings';
 import { TokenStatusInfo, DictionaryProvider, LemmaResults, TokenResults } from '@project/common/dictionary-db';
 import {
@@ -340,6 +341,28 @@ class TokenCollection extends TokenCollectionBase<TokenStatusResult> {
         );
         this.ts.updateTokenStates(normalizedKey, states);
     }
+
+    private resolve(
+        normalizedTokens: string[],
+        sourceMatches: (source: DictionaryTokenSource) => boolean
+    ): TokenStatusResult[] {
+        const statusResults: TokenStatusResult[] = [];
+        for (const normalizedToken of normalizedTokens) {
+            const statusResult = this.collection.get(normalizedToken);
+            if (statusResult && sourceMatches(statusResult.source)) statusResults.push(statusResult);
+        }
+        return statusResults;
+    }
+
+    resolveForWord(normalizedTokens: string[]): TokenStatusResult[] {
+        if (!this.wordEnabled) return [];
+        return this.resolve(normalizedTokens, (source) => isWordSource(source));
+    }
+
+    resolveForSentence(normalizedTokens: string[]): TokenStatusResult[] {
+        if (!this.sentenceEnabled) return [];
+        return this.resolve(normalizedTokens, (source) => !isWordSource(source));
+    }
 }
 
 class TokenCollectionArray extends TokenCollectionBase<TokenStatusResult[]> {
@@ -372,12 +395,12 @@ class TokenCollectionArray extends TokenCollectionBase<TokenStatusResult[]> {
      * the token, only the lemmas. EXACT_FORM_COLLECTED and LEMMA_FORM_COLLECTED looks for an exact match with either the
      * surface form or lemma form so they don't need this extra filtering.
      */
-    getStatusResults(
-        trimmedToken: string,
+    private getStatusResults(
+        normalizedToken: string,
         normalizedLemmas: string[],
         sourceMatches: (source: DictionaryTokenSource) => boolean
     ): TokenStatusResult[] {
-        const tokenIsKanaOnly = isKanaOnly(trimmedToken);
+        const tokenIsKanaOnly = isKanaOnly(normalizedToken);
         const anyFormStatusResults: TokenStatusResult[] = [];
         for (const normalizedLemma of normalizedLemmas) {
             const statusResults = this.collection.get(normalizedLemma);
@@ -395,12 +418,44 @@ class TokenCollectionArray extends TokenCollectionBase<TokenStatusResult[]> {
         return anyFormStatusResults;
     }
 
-    tokenMatchesKey(normalizedToken: string, normalizedKey: string): boolean {
+    private tokenMatchesKey(normalizedToken: string, normalizedKey: string): boolean {
         return normalizedToken === normalizedKey;
     }
 
-    tokenMatchesAnyKey(normalizedToken: string, normalizedKeys: string[]): boolean {
+    private tokenMatchesAnyKey(normalizedToken: string, normalizedKeys: string[]): boolean {
         return normalizedKeys.some((normalizedKey) => this.tokenMatchesKey(normalizedToken, normalizedKey));
+    }
+
+    private resolve(
+        normalizedToken: string,
+        lemmas: string[],
+        sourceMatches: (source: DictionaryTokenSource) => boolean,
+        exactPriority: boolean | null
+    ): TokenStatusResult[] {
+        const statusResults = this.getStatusResults(normalizedToken, lemmas, sourceMatches);
+        if (!statusResults.length || exactPriority === null) return statusResults;
+        if (exactPriority === true) {
+            const exactMatches = statusResults.filter((r) => this.tokenMatchesKey(r.normalizedToken!, normalizedToken));
+            if (exactMatches.length) return exactMatches;
+            const lemmaMatches = statusResults.filter((r) => this.tokenMatchesAnyKey(r.normalizedToken!, lemmas));
+            if (lemmaMatches.length) return lemmaMatches;
+        } else if (exactPriority === false) {
+            const lemmaMatches = statusResults.filter((r) => this.tokenMatchesAnyKey(r.normalizedToken!, lemmas));
+            if (lemmaMatches.length) return lemmaMatches;
+            const exactMatches = statusResults.filter((r) => this.tokenMatchesKey(r.normalizedToken!, normalizedToken));
+            if (exactMatches.length) return exactMatches;
+        }
+        return statusResults;
+    }
+
+    resolveForWord(normalizedToken: string, lemmas: string[], exactPriority: boolean | null): TokenStatusResult[] {
+        if (!this.wordEnabled) return [];
+        return this.resolve(normalizedToken, lemmas, (source) => isWordSource(source), exactPriority);
+    }
+
+    resolveForSentence(normalizedToken: string, lemmas: string[], exactPriority: boolean | null): TokenStatusResult[] {
+        if (!this.sentenceEnabled) return [];
+        return this.resolve(normalizedToken, lemmas, (source) => !isWordSource(source), exactPriority);
     }
 }
 
@@ -1681,28 +1736,26 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         ts: TrackState
     ): Promise<ResolvedTokenStatusResult | null> {
         if (!ts.yt) throw new Error('Yomitan uninitialized - cannot calculate token status');
+        const lemmas = await ts.lemmatizeForScript(trimmedToken);
+        if (this.shouldCancelBuild) return null;
+        if (!lemmas) return null;
+
         let tokenStatusResult: ResolvedTokenStatusResult | null;
         switch (ts.dt.dictionaryTokenMatchStrategyPriority) {
             case TokenMatchStrategyPriority.EXACT:
-                tokenStatusResult = await this._handlePriorityExact(trimmedToken, normalizedToken, ts);
+                tokenStatusResult = await this._handlePriorityExact(normalizedToken, lemmas, ts);
                 break;
             case TokenMatchStrategyPriority.LEMMA:
-                tokenStatusResult = await this._handlePriorityLemma(trimmedToken, normalizedToken, ts);
+                tokenStatusResult = await this._handlePriorityLemma(normalizedToken, lemmas, ts);
                 break;
             case TokenMatchStrategyPriority.BEST_KNOWN:
-                tokenStatusResult = await this._handlePriorityKnown(
-                    trimmedToken,
-                    normalizedToken,
-                    ts,
-                    (tokenStatuses) => Math.max(...tokenStatuses)
+                tokenStatusResult = await this._handlePriorityKnown(normalizedToken, lemmas, ts, (tokenStatuses) =>
+                    Math.max(...tokenStatuses)
                 );
                 break;
             case TokenMatchStrategyPriority.LEAST_KNOWN:
-                tokenStatusResult = await this._handlePriorityKnown(
-                    trimmedToken,
-                    normalizedToken,
-                    ts,
-                    (tokenStatuses) => Math.min(...tokenStatuses)
+                tokenStatusResult = await this._handlePriorityKnown(normalizedToken, lemmas, ts, (tokenStatuses) =>
+                    Math.min(...tokenStatuses)
                 );
                 break;
             default:
@@ -1712,246 +1765,70 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
     }
 
     private async _handlePriorityExact(
-        trimmedToken: string,
         normalizedToken: string,
+        lemmas: string[],
         ts: TrackState
     ): Promise<ResolvedTokenStatusResult | null> {
-        if (ts.tokenCollectionExact.wordEnabled) {
-            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
-            if (tokenStatusResult && tokenStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
-                return tokenStatusResult;
-            }
-        }
-        if (ts.tokenCollectionLemma.wordEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            const lemmaStatusResults: TokenStatusResult[] = [];
-            for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
-                if (lemmaStatusResult && lemmaStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
-                    lemmaStatusResults.push(lemmaStatusResult);
-                }
-            }
-            if (lemmaStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaStatusResults);
-        }
-        if (ts.tokenCollectionAny.wordEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            const anyFormStatusResults = ts.tokenCollectionAny.getStatusResults(
-                trimmedToken,
-                lemmas,
-                (source) => source !== DictionaryTokenSource.ANKI_SENTENCE
-            );
-            if (anyFormStatusResults.length) {
-                const exactMatches = anyFormStatusResults.filter((r) =>
-                    ts.tokenCollectionAny.tokenMatchesKey(r.normalizedToken!, normalizedToken)
-                );
-                if (exactMatches.length) return TokenCollectionBase.resolveTokenStatusResults(exactMatches);
-                const lemmaMatches = anyFormStatusResults.filter((r) =>
-                    ts.tokenCollectionAny.tokenMatchesAnyKey(r.normalizedToken!, lemmas)
-                );
-                if (lemmaMatches.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaMatches);
-                return TokenCollectionBase.resolveTokenStatusResults(anyFormStatusResults);
-            }
-        }
-        if (ts.tokenCollectionExact.sentenceEnabled) {
-            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
-            if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) return tokenStatusResult;
-        }
-        if (ts.tokenCollectionLemma.sentenceEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            const lemmaStatusResults: TokenStatusResult[] = [];
-            for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
-                if (lemmaStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) {
-                    lemmaStatusResults.push(lemmaStatusResult);
-                }
-            }
-            if (lemmaStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaStatusResults);
-        }
-        if (ts.tokenCollectionAny.sentenceEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            const anyFormStatusResults = ts.tokenCollectionAny.getStatusResults(
-                trimmedToken,
-                lemmas,
-                (source) => source === DictionaryTokenSource.ANKI_SENTENCE
-            );
-            if (anyFormStatusResults.length) {
-                const exactMatches = anyFormStatusResults.filter((r) =>
-                    ts.tokenCollectionAny.tokenMatchesKey(r.normalizedToken!, normalizedToken)
-                );
-                if (exactMatches.length) return TokenCollectionBase.resolveTokenStatusResults(exactMatches);
-                const lemmaMatches = anyFormStatusResults.filter((r) =>
-                    ts.tokenCollectionAny.tokenMatchesAnyKey(r.normalizedToken!, lemmas)
-                );
-                if (lemmaMatches.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaMatches);
-                return TokenCollectionBase.resolveTokenStatusResults(anyFormStatusResults);
-            }
-        }
+        const statusResults: TokenStatusResult[] = [];
+
+        statusResults.push(...ts.tokenCollectionExact.resolveForWord([normalizedToken]));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+        statusResults.push(...ts.tokenCollectionLemma.resolveForWord(lemmas));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+        statusResults.push(...ts.tokenCollectionAny.resolveForWord(normalizedToken, lemmas, true));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+
+        statusResults.push(...ts.tokenCollectionExact.resolveForSentence([normalizedToken]));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+        statusResults.push(...ts.tokenCollectionLemma.resolveForSentence(lemmas));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+        statusResults.push(...ts.tokenCollectionAny.resolveForSentence(normalizedToken, lemmas, true));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+
         return { status: TokenStatus.UNCOLLECTED };
     }
 
     private async _handlePriorityLemma(
-        trimmedToken: string,
         normalizedToken: string,
+        lemmas: string[],
         ts: TrackState
     ): Promise<ResolvedTokenStatusResult | null> {
-        if (ts.tokenCollectionLemma.wordEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            const lemmaStatusResults: TokenStatusResult[] = [];
-            for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
-                if (lemmaStatusResult && lemmaStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
-                    lemmaStatusResults.push(lemmaStatusResult);
-                }
-            }
-            if (lemmaStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaStatusResults);
-        }
-        if (ts.tokenCollectionExact.wordEnabled) {
-            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
-            if (tokenStatusResult && tokenStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
-                return tokenStatusResult;
-            }
-        }
-        if (ts.tokenCollectionAny.wordEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            const anyFormStatusResults = ts.tokenCollectionAny.getStatusResults(
-                trimmedToken,
-                lemmas,
-                (source) => source !== DictionaryTokenSource.ANKI_SENTENCE
-            );
-            if (anyFormStatusResults.length) {
-                const lemmaMatches = anyFormStatusResults.filter((r) =>
-                    ts.tokenCollectionAny.tokenMatchesAnyKey(r.normalizedToken!, lemmas)
-                );
-                if (lemmaMatches.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaMatches);
-                const exactMatches = anyFormStatusResults.filter((r) =>
-                    ts.tokenCollectionAny.tokenMatchesKey(r.normalizedToken!, normalizedToken)
-                );
-                if (exactMatches.length) return TokenCollectionBase.resolveTokenStatusResults(exactMatches);
-                return TokenCollectionBase.resolveTokenStatusResults(anyFormStatusResults);
-            }
-        }
-        if (ts.tokenCollectionLemma.sentenceEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            const lemmaStatusResults: TokenStatusResult[] = [];
-            for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
-                if (lemmaStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) {
-                    lemmaStatusResults.push(lemmaStatusResult);
-                }
-            }
-            if (lemmaStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaStatusResults);
-        }
-        if (ts.tokenCollectionExact.sentenceEnabled) {
-            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
-            if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) return tokenStatusResult;
-        }
-        if (ts.tokenCollectionAny.sentenceEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            const anyFormStatusResults = ts.tokenCollectionAny.getStatusResults(
-                trimmedToken,
-                lemmas,
-                (source) => source === DictionaryTokenSource.ANKI_SENTENCE
-            );
-            if (anyFormStatusResults.length) {
-                const lemmaMatches = anyFormStatusResults.filter((r) =>
-                    ts.tokenCollectionAny.tokenMatchesAnyKey(r.normalizedToken!, lemmas)
-                );
-                if (lemmaMatches.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaMatches);
-                const exactMatches = anyFormStatusResults.filter((r) =>
-                    ts.tokenCollectionAny.tokenMatchesKey(r.normalizedToken!, normalizedToken)
-                );
-                if (exactMatches.length) return TokenCollectionBase.resolveTokenStatusResults(exactMatches);
-                return TokenCollectionBase.resolveTokenStatusResults(anyFormStatusResults);
-            }
-        }
+        const statusResults: TokenStatusResult[] = [];
+
+        statusResults.push(...ts.tokenCollectionLemma.resolveForWord(lemmas));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+        statusResults.push(...ts.tokenCollectionExact.resolveForWord([normalizedToken]));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+        statusResults.push(...ts.tokenCollectionAny.resolveForWord(normalizedToken, lemmas, false));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+
+        statusResults.push(...ts.tokenCollectionLemma.resolveForSentence(lemmas));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+        statusResults.push(...ts.tokenCollectionExact.resolveForSentence([normalizedToken]));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+        statusResults.push(...ts.tokenCollectionAny.resolveForSentence(normalizedToken, lemmas, false));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+
         return { status: TokenStatus.UNCOLLECTED };
     }
 
     private async _handlePriorityKnown(
-        trimmedToken: string,
         normalizedToken: string,
+        lemmas: string[],
         ts: TrackState,
         cmp: (tokenStatuses: TokenStatus[]) => TokenStatus
     ): Promise<ResolvedTokenStatusResult | null> {
-        const tokenStatusResults: TokenStatusResult[] = [];
+        const statusResults: TokenStatusResult[] = [];
 
-        if (ts.tokenCollectionExact.wordEnabled) {
-            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
-            if (tokenStatusResult && tokenStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
-                tokenStatusResults.push(tokenStatusResult);
-            }
-        }
-        if (ts.tokenCollectionLemma.wordEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
-                if (lemmaStatusResult && lemmaStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
-                    tokenStatusResults.push(lemmaStatusResult);
-                }
-            }
-        }
-        if (ts.tokenCollectionAny.wordEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            tokenStatusResults.push(
-                ...ts.tokenCollectionAny.getStatusResults(
-                    trimmedToken,
-                    lemmas,
-                    (source) => source !== DictionaryTokenSource.ANKI_SENTENCE
-                )
-            );
-        }
-        if (tokenStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(tokenStatusResults, cmp);
+        statusResults.push(...ts.tokenCollectionExact.resolveForWord([normalizedToken]));
+        statusResults.push(...ts.tokenCollectionLemma.resolveForWord(lemmas));
+        statusResults.push(...ts.tokenCollectionAny.resolveForWord(normalizedToken, lemmas, null));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults, cmp);
 
-        if (ts.tokenCollectionExact.sentenceEnabled) {
-            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
-            if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) {
-                tokenStatusResults.push(tokenStatusResult);
-            }
-        }
-        if (ts.tokenCollectionLemma.sentenceEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
-                if (lemmaStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) {
-                    tokenStatusResults.push(lemmaStatusResult);
-                }
-            }
-        }
-        if (ts.tokenCollectionAny.sentenceEnabled) {
-            const lemmas = await ts.lemmatizeForScript(trimmedToken);
-            if (this.shouldCancelBuild) return null;
-            if (!lemmas) return null;
-            tokenStatusResults.push(
-                ...ts.tokenCollectionAny.getStatusResults(
-                    trimmedToken,
-                    lemmas,
-                    (source) => source === DictionaryTokenSource.ANKI_SENTENCE
-                )
-            );
-        }
-        if (tokenStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(tokenStatusResults, cmp);
+        statusResults.push(...ts.tokenCollectionExact.resolveForSentence([normalizedToken]));
+        statusResults.push(...ts.tokenCollectionLemma.resolveForSentence(lemmas));
+        statusResults.push(...ts.tokenCollectionAny.resolveForSentence(normalizedToken, lemmas, null));
+        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults, cmp);
 
         return { status: TokenStatus.UNCOLLECTED };
     }

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -23,7 +23,10 @@ import {
     DictionaryTokenSource,
     DictionaryTrack,
     dictionaryTrackEnabled,
+    dictionaryTokenSourcePriority,
+    externalWordSourcePriority,
     getFullyKnownTokenStatus,
+    isExternalWordSource,
     SettingsProvider,
     TokenFrequencyAnnotation,
     TokenMatchStrategy,
@@ -52,6 +55,7 @@ import {
     getTokenStatus,
     dedupeTokenStatusInfos,
     isKanaOnly,
+    normalizeToken,
 } from '@project/common/util';
 import { Yomitan } from '@project/common/yomitan/yomitan';
 
@@ -129,9 +133,15 @@ function shouldUseLemmasGroupingKey(source: DictionaryTokenSource | undefined, d
  *   - Never match across scripts, downside is if kanji is collected kana will need to be collected too.
  *   - Essentially a strict mode where the user needs to collect all script forms of a word.
  */
-async function lemmatizeForScript(trimmedToken: string, ts: TrackState): Promise<string[] | undefined> {
-    const lemmas = await ts.yt!.lemmatize(trimmedToken);
-    return lemmas === undefined ? undefined : lemmasForScript(trimmedToken, lemmas, ts.dt);
+async function lemmatizeForScript(
+    trimmedToken: string,
+    ts: TrackState,
+    normalize = true
+): Promise<string[] | undefined> {
+    const rawLemmas = await ts.yt!.lemmatize(trimmedToken);
+    if (!rawLemmas) return;
+    const lemmas = lemmasForScript(trimmedToken, rawLemmas, ts.dt);
+    return normalize ? lemmas.map(normalizeToken) : lemmas;
 }
 function lemmasForScript(trimmedToken: string, lemmas: string[], dt: DictionaryTrack): string[] {
     const tokenIsKanaOnly = isKanaOnly(trimmedToken);
@@ -140,13 +150,13 @@ function lemmasForScript(trimmedToken: string, lemmas: string[], dt: DictionaryT
 }
 function getAnyFormStatusResults(
     trimmedToken: string,
-    lemmas: string[],
+    normalizedLemmas: string[],
     ts: TrackState,
     sourceMatches: (source: DictionaryTokenSource) => boolean
 ): TokenStatusResult[] {
     const anyFormStatusResults: TokenStatusResult[] = [];
-    for (const lemma of lemmas) {
-        const statusResults = ts.collectedAnyForm.get(lemma);
+    for (const normalizedLemma of normalizedLemmas) {
+        const statusResults = ts.collectedAnyForm.get(normalizedLemma);
         if (!statusResults) continue;
         for (const statusResult of statusResults) {
             if (!sourceMatches(statusResult.source)) continue;
@@ -160,6 +170,82 @@ function getAnyFormStatusResults(
         }
     }
     return anyFormStatusResults;
+}
+
+function compareTokenStatusResults(left: TokenStatusResult, right: TokenStatusResult): number {
+    const sourcePriority = dictionaryTokenSourcePriority(left.source) - dictionaryTokenSourcePriority(right.source);
+    if (sourcePriority !== 0) return sourcePriority;
+    const statusPriority = left.status - right.status;
+    if (statusPriority !== 0) return statusPriority;
+    if (isExternalWordSource(left.source) && isExternalWordSource(right.source)) {
+        return externalWordSourcePriority(left.source) - externalWordSourcePriority(right.source);
+    }
+    return 0;
+}
+
+function mergeTokenStatusResults(left: TokenStatusResult, right: TokenStatusResult): TokenStatusResult {
+    return {
+        ...(compareTokenStatusResults(left, right) >= 0 ? left : right),
+        externalCandidateStatuses: dedupeTokenStatusInfos([
+            ...(left.externalCandidateStatuses ?? []),
+            ...(right.externalCandidateStatuses ?? []),
+        ]),
+    };
+}
+
+function addCollectedAnyFormStatus(
+    collection: Map<string, TokenStatusResult[]>,
+    lemma: string,
+    statusResult: TokenStatusResult
+) {
+    const normalizedLemma = normalizeToken(lemma);
+    const statusResults = collection.get(normalizedLemma);
+    if (!statusResults) {
+        collection.set(normalizedLemma, [statusResult]);
+        return;
+    }
+    const duplicateIndex = statusResults.findIndex((r) => r.token === statusResult.token);
+    if (duplicateIndex === -1) {
+        statusResults.push(statusResult);
+    } else {
+        statusResults[duplicateIndex] = mergeTokenStatusResults(statusResults[duplicateIndex], statusResult);
+    }
+}
+
+function setTokenStates(collection: Map<string, TokenState[]>, normalizedLookupKey: string, states: TokenState[]) {
+    if (!states.length) return;
+    const tokenStates = collection.get(normalizedLookupKey);
+    if (!tokenStates) {
+        collection.set(normalizedLookupKey, states);
+        return;
+    }
+    for (const state of states) {
+        if (!tokenStates.includes(state)) tokenStates.push(state);
+    }
+}
+
+function addTokenIndex(collection: Map<string, Set<number>>, normalizedLookupKey: string, index: number) {
+    const indexes = collection.get(normalizedLookupKey);
+    if (indexes) indexes.add(index);
+    else collection.set(normalizedLookupKey, new Set([index]));
+}
+
+function addLookupQuery(queryMap: Map<string, string[]>, lookupKey: string, collection: Map<string, unknown>) {
+    const normalizedLookupKey = normalizeToken(lookupKey);
+    const queries = queryMap.get(normalizedLookupKey);
+    if (queries) {
+        if (!queries.includes(lookupKey)) queries.push(lookupKey); // Send all original forms for backwards compatibility with older extension db lookups
+        return;
+    }
+    if (!collection.has(normalizedLookupKey)) queryMap.set(normalizedLookupKey, [lookupKey]);
+}
+
+function tokenMatchesLookupKey(normalizedToken: string, normalizedLookupKey: string): boolean {
+    return normalizedToken === normalizedLookupKey;
+}
+
+function tokenMatchesAnyLookupKey(normalizedToken: string, normalizedLookupKeys: string[]): boolean {
+    return normalizedLookupKeys.some((lookupKey) => tokenMatchesLookupKey(normalizedToken, lookupKey));
 }
 
 function groupingKeysForToken(
@@ -505,7 +591,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
     }
 
     tokensWereModified(modifiedTokens: string[]) {
-        for (const token of modifiedTokens) this.tokensForRefresh.add(token);
+        for (const token of modifiedTokens) this.tokensForRefresh.add(normalizeToken(token));
     }
 
     buildAnkiCacheStateChange(state: DictionaryBuildAnkiCacheState) {
@@ -576,8 +662,8 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         const lemmas = await ts.yt.lemmatize(token);
         if (!lemmas) return;
         await this.dictionaryProvider.saveRecordLocalBulk(profile, [{ token, status, lemmas, states }], applyStates);
-        this.tokensForRefresh.add(token);
-        for (const lemma of lemmas) this.tokensForRefresh.add(lemma);
+        this.tokensForRefresh.add(normalizeToken(token));
+        for (const lemma of lemmas) this.tokensForRefresh.add(normalizeToken(lemma));
     }
 
     requestStatisticsGeneration() {
@@ -944,7 +1030,8 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     const yt = new Yomitan(ts.dt, this.fetcher, {
                         lemmaTokenFallback: true,
                         tokensWereModified: (token) => {
-                            for (const index of this.tokenToIndexesCache.get(token) ?? []) this.refreshCache.add(index);
+                            const indexes = this.tokenToIndexesCache.get(normalizeToken(token)) ?? [];
+                            for (const index of indexes) this.refreshCache.add(index);
                         },
                     });
                     await yt.version();
@@ -1211,25 +1298,25 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     ts.tokenStates.delete(token);
                 }
 
-                const forExactFormQuery = new Set<string>();
-                const forLemmaFormQuery = new Set<string>();
-                const forAnyFormQuery = new Set<string>();
+                const forExactFormQuery = new Map<string, string[]>();
+                const forLemmaFormQuery = new Map<string, string[]>();
+                const forAnyFormQuery = new Map<string, string[]>();
                 for (const tokenParts of tokenizeBulkRes) {
                     const token = tokenParts
                         .map((p) => p.text)
                         .join('')
                         .trim();
-                    if (shouldQueryExactForm && !ts.collectedExactForm.has(token)) forExactFormQuery.add(token);
+                    if (shouldQueryExactForm) addLookupQuery(forExactFormQuery, token, ts.collectedExactForm);
                     if (shouldQueryLemmaForm || shouldQueryAnyForm) {
-                        const lemmas = (await lemmatizeForScript(token, ts)) ?? [];
+                        const lemmas = (await lemmatizeForScript(token, ts, false)) ?? [];
                         if (shouldQueryLemmaForm) {
                             for (const lemma of lemmas) {
-                                if (!ts.collectedLemmaForm.has(lemma)) forLemmaFormQuery.add(lemma);
+                                addLookupQuery(forLemmaFormQuery, lemma, ts.collectedLemmaForm);
                             }
                         }
                         if (shouldQueryAnyForm) {
                             for (const lemma of lemmas) {
-                                if (!ts.collectedAnyForm.has(lemma)) forAnyFormQuery.add(lemma);
+                                addLookupQuery(forAnyFormQuery, lemma, ts.collectedAnyForm);
                             }
                         }
                     }
@@ -1238,13 +1325,17 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
 
                 const [exactFormResultMap, lemmaFormResultMap, anyFormResultsMap] = await Promise.all([
                     forExactFormQuery.size
-                        ? this.dictionaryProvider.getBulk(profile, track, Array.from(forExactFormQuery))
+                        ? this.dictionaryProvider.getBulk(profile, track, Array.from(forExactFormQuery.values()).flat())
                         : ({} as TokenResults),
                     forLemmaFormQuery.size
-                        ? this.dictionaryProvider.getBulk(profile, track, Array.from(forLemmaFormQuery))
+                        ? this.dictionaryProvider.getBulk(profile, track, Array.from(forLemmaFormQuery.values()).flat())
                         : ({} as TokenResults),
                     forAnyFormQuery.size
-                        ? this.dictionaryProvider.getByLemmaBulk(profile, track, Array.from(forAnyFormQuery))
+                        ? this.dictionaryProvider.getByLemmaBulk(
+                              profile,
+                              track,
+                              Array.from(forAnyFormQuery.values()).flat()
+                          )
                         : ({} as LemmaResults),
                 ]);
                 if (this.shouldCancelBuild) return;
@@ -1252,60 +1343,49 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 for (const [token, { states, statuses, externalCandidateStatuses, source }] of Object.entries(
                     exactFormResultMap
                 )) {
-                    ts.collectedExactForm.set(
-                        token,
-                        tokenStatusResult(
-                            statuses,
-                            ts.dt.dictionaryAnkiTreatSuspended,
-                            source,
-                            externalCandidateStatuses
-                        )
+                    const normalizedToken = normalizeToken(token);
+                    const statusResult = tokenStatusResult(
+                        statuses,
+                        ts.dt.dictionaryAnkiTreatSuspended,
+                        source,
+                        externalCandidateStatuses
                     );
-                    if (states.length) ts.tokenStates.set(token, states);
+                    const existing = ts.collectedExactForm.get(normalizedToken);
+                    ts.collectedExactForm.set(
+                        normalizedToken,
+                        existing ? mergeTokenStatusResults(existing, statusResult) : statusResult
+                    );
+                    setTokenStates(ts.tokenStates, normalizedToken, states);
                 }
                 for (const [lemma, { states, statuses, externalCandidateStatuses, source }] of Object.entries(
                     lemmaFormResultMap
                 )) {
-                    ts.collectedLemmaForm.set(
-                        lemma,
-                        tokenStatusResult(
-                            statuses,
-                            ts.dt.dictionaryAnkiTreatSuspended,
-                            source,
-                            externalCandidateStatuses
-                        )
+                    const normalizedLemma = normalizeToken(lemma);
+                    const statusResult = tokenStatusResult(
+                        statuses,
+                        ts.dt.dictionaryAnkiTreatSuspended,
+                        source,
+                        externalCandidateStatuses
                     );
-                    if (!states.length) continue;
-                    const tokenStates = ts.tokenStates.get(lemma);
-                    if (tokenStates) {
-                        for (const state of states) {
-                            if (!tokenStates.includes(state)) tokenStates.push(state);
-                        }
-                    } else {
-                        ts.tokenStates.set(lemma, states);
-                    }
+                    const existing = ts.collectedLemmaForm.get(normalizedLemma);
+                    ts.collectedLemmaForm.set(
+                        normalizedLemma,
+                        existing ? mergeTokenStatusResults(existing, statusResult) : statusResult
+                    );
+                    setTokenStates(ts.tokenStates, normalizedLemma, states);
                 }
                 for (const [lemma, lemmaResults] of Object.entries(anyFormResultsMap)) {
                     for (const { states, statuses, externalCandidateStatuses, source, token } of lemmaResults) {
-                        const lemmaCollected = ts.collectedAnyForm.get(lemma);
+                        const normalizedToken = normalizeToken(token);
                         const statusResult = tokenStatusResult(
                             statuses,
                             ts.dt.dictionaryAnkiTreatSuspended,
                             source,
                             externalCandidateStatuses,
-                            token
+                            normalizedToken
                         );
-                        if (lemmaCollected) lemmaCollected.push(statusResult);
-                        else ts.collectedAnyForm.set(lemma, [statusResult]);
-                        if (!states.length) continue;
-                        const tokenStates = ts.tokenStates.get(token);
-                        if (tokenStates) {
-                            for (const state of states) {
-                                if (!tokenStates.includes(state)) tokenStates.push(state);
-                            }
-                        } else {
-                            ts.tokenStates.set(token, states);
-                        }
+                        addCollectedAnyFormStatus(ts.collectedAnyForm, lemma, statusResult);
+                        setTokenStates(ts.tokenStates, normalizedToken, states);
                     }
                 }
             } catch (e) {
@@ -1370,10 +1450,9 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     promise = promise.then(async () => {
                         const tokenText = fullText.substring(existingToken.pos[0], existingToken.pos[1]);
                         const trimmedToken = tokenText.trim();
+                        const normalizedToken = normalizeToken(trimmedToken);
 
-                        const tokenToIndexes = this.tokenToIndexesCache.get(trimmedToken);
-                        if (tokenToIndexes) tokenToIndexes.add(index);
-                        else this.tokenToIndexesCache.set(trimmedToken, new Set([index]));
+                        addTokenIndex(this.tokenToIndexesCache, normalizedToken, index);
                         const lemmas = await ts.yt!.lemmatize(trimmedToken);
                         if (this.shouldCancelBuild) return;
                         if (!lemmas) {
@@ -1381,17 +1460,13 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                             this.erroredCache.add(index);
                             return;
                         }
-                        for (const lemma of lemmas) {
-                            const lemmaToIndexes = this.tokenToIndexesCache.get(lemma);
-                            if (lemmaToIndexes) lemmaToIndexes.add(index);
-                            else this.tokenToIndexesCache.set(lemma, new Set([index]));
-                        }
+                        for (const l of lemmas) addTokenIndex(this.tokenToIndexesCache, normalizeToken(l), index);
 
-                        const states = ts.tokenStates.get(trimmedToken) ?? [];
+                        const states = ts.tokenStates.get(normalizedToken) ?? [];
                         const tokenStatusResult =
                             states.includes(TokenState.IGNORED) || !HAS_LETTER_REGEX.test(trimmedToken)
                                 ? { status: getFullyKnownTokenStatus() }
-                                : ((await this._tokenStatus(trimmedToken, ts)) ?? { status: null });
+                                : ((await this._tokenStatus(trimmedToken, normalizedToken, ts)) ?? { status: null });
                         const status = tokenStatusResult.status;
                         const source = 'source' in tokenStatusResult ? tokenStatusResult.source : undefined;
                         const token: Token = {
@@ -1445,11 +1520,12 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 const tokenText = tokenParts.map((p) => p.text).join('');
                 reconstructedTextParts.push(tokenText);
                 const trimmedToken = tokenText.trim();
+                const normalizedToken = normalizeToken(trimmedToken);
 
                 // Build token
                 const token: InternalToken = {
                     pos: [baseIndex + currentOffset, baseIndex + currentOffset + tokenText.length],
-                    states: ts.tokenStates.get(trimmedToken) ?? [],
+                    states: ts.tokenStates.get(normalizedToken) ?? [],
                     __internal: true, // This token was generated by this class
                     readings: [],
                 };
@@ -1473,9 +1549,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     }
                 }
 
-                const tokenToIndexes = this.tokenToIndexesCache.get(trimmedToken);
-                if (tokenToIndexes) tokenToIndexes.add(index);
-                else this.tokenToIndexesCache.set(trimmedToken, new Set([index]));
+                addTokenIndex(this.tokenToIndexesCache, normalizedToken, index);
                 const lemmas = await ts.yt.lemmatize(trimmedToken);
                 if (this.shouldCancelBuild) return;
                 if (!lemmas) {
@@ -1483,11 +1557,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     token.status = null;
                     continue;
                 }
-                for (const lemma of lemmas) {
-                    const lemmaToIndexes = this.tokenToIndexesCache.get(lemma);
-                    if (lemmaToIndexes) lemmaToIndexes.add(index);
-                    else this.tokenToIndexesCache.set(lemma, new Set([index]));
-                }
+                for (const lemma of lemmas) addTokenIndex(this.tokenToIndexesCache, normalizeToken(lemma), index);
 
                 // Build token status
                 if (token.states.includes(TokenState.IGNORED) || !HAS_LETTER_REGEX.test(trimmedToken)) {
@@ -1502,7 +1572,9 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     token.lemmasGroupingKey = lemmasGroupingKey;
                     continue;
                 }
-                const tokenStatusResult = (await this._tokenStatus(trimmedToken, ts)) ?? { status: null };
+                const tokenStatusResult = (await this._tokenStatus(trimmedToken, normalizedToken, ts)) ?? {
+                    status: null,
+                };
                 const source = 'source' in tokenStatusResult ? tokenStatusResult.source : undefined;
                 token.status = tokenStatusResult.status;
                 const { groupingKey, lemmasGroupingKey } = groupingKeysForToken(trimmedToken, lemmas, source, ts.dt);
@@ -1537,24 +1609,34 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         }
     }
 
-    private async _tokenStatus(trimmedToken: string, ts: TrackState): Promise<ResolvedTokenStatusResult | null> {
+    private async _tokenStatus(
+        trimmedToken: string,
+        normalizedToken: string,
+        ts: TrackState
+    ): Promise<ResolvedTokenStatusResult | null> {
         if (!ts.yt) throw new Error('Yomitan uninitialized - cannot calculate token status');
         let tokenStatusResult: ResolvedTokenStatusResult | null;
         switch (ts.dt.dictionaryTokenMatchStrategyPriority) {
             case TokenMatchStrategyPriority.EXACT:
-                tokenStatusResult = await this._handlePriorityExact(trimmedToken, ts);
+                tokenStatusResult = await this._handlePriorityExact(trimmedToken, normalizedToken, ts);
                 break;
             case TokenMatchStrategyPriority.LEMMA:
-                tokenStatusResult = await this._handlePriorityLemma(trimmedToken, ts);
+                tokenStatusResult = await this._handlePriorityLemma(trimmedToken, normalizedToken, ts);
                 break;
             case TokenMatchStrategyPriority.BEST_KNOWN:
-                tokenStatusResult = await this._handlePriorityKnown(trimmedToken, ts, (tokenStatuses) =>
-                    Math.max(...tokenStatuses)
+                tokenStatusResult = await this._handlePriorityKnown(
+                    trimmedToken,
+                    normalizedToken,
+                    ts,
+                    (tokenStatuses) => Math.max(...tokenStatuses)
                 );
                 break;
             case TokenMatchStrategyPriority.LEAST_KNOWN:
-                tokenStatusResult = await this._handlePriorityKnown(trimmedToken, ts, (tokenStatuses) =>
-                    Math.min(...tokenStatuses)
+                tokenStatusResult = await this._handlePriorityKnown(
+                    trimmedToken,
+                    normalizedToken,
+                    ts,
+                    (tokenStatuses) => Math.min(...tokenStatuses)
                 );
                 break;
             default:
@@ -1565,10 +1647,11 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
 
     private async _handlePriorityExact(
         trimmedToken: string,
+        normalizedToken: string,
         ts: TrackState
     ): Promise<ResolvedTokenStatusResult | null> {
         if (shouldUseExactForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(trimmedToken);
+            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
             if (tokenStatusResult && tokenStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
                 return tokenStatusResult;
             }
@@ -1597,15 +1680,17 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 (source) => source !== DictionaryTokenSource.ANKI_SENTENCE
             );
             if (anyFormStatusResults.length) {
-                const exactMatches = anyFormStatusResults.filter((r) => r.token === trimmedToken);
+                const exactMatches = anyFormStatusResults.filter((r) =>
+                    tokenMatchesLookupKey(r.token!, normalizedToken)
+                );
                 if (exactMatches.length) return combineTokenStatusResults(exactMatches);
-                const lemmaMatches = anyFormStatusResults.filter((r) => lemmas.includes(r.token!));
+                const lemmaMatches = anyFormStatusResults.filter((r) => tokenMatchesAnyLookupKey(r.token!, lemmas));
                 if (lemmaMatches.length) return combineTokenStatusResults(lemmaMatches);
                 return combineTokenStatusResults(anyFormStatusResults);
             }
         }
         if (shouldUseExactForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(trimmedToken);
+            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
             if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) return tokenStatusResult;
         }
         if (shouldUseLemmaForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
@@ -1632,9 +1717,11 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 (source) => source === DictionaryTokenSource.ANKI_SENTENCE
             );
             if (anyFormStatusResults.length) {
-                const exactMatches = anyFormStatusResults.filter((r) => r.token === trimmedToken);
+                const exactMatches = anyFormStatusResults.filter((r) =>
+                    tokenMatchesLookupKey(r.token!, normalizedToken)
+                );
                 if (exactMatches.length) return combineTokenStatusResults(exactMatches);
-                const lemmaMatches = anyFormStatusResults.filter((r) => lemmas.includes(r.token!));
+                const lemmaMatches = anyFormStatusResults.filter((r) => tokenMatchesAnyLookupKey(r.token!, lemmas));
                 if (lemmaMatches.length) return combineTokenStatusResults(lemmaMatches);
                 return combineTokenStatusResults(anyFormStatusResults);
             }
@@ -1644,6 +1731,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
 
     private async _handlePriorityLemma(
         trimmedToken: string,
+        normalizedToken: string,
         ts: TrackState
     ): Promise<ResolvedTokenStatusResult | null> {
         if (shouldUseLemmaForm(ts.dt.dictionaryTokenMatchStrategy)) {
@@ -1660,7 +1748,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             if (lemmaStatusResults.length) return combineTokenStatusResults(lemmaStatusResults);
         }
         if (shouldUseExactForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(trimmedToken);
+            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
             if (tokenStatusResult && tokenStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
                 return tokenStatusResult;
             }
@@ -1676,9 +1764,11 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 (source) => source !== DictionaryTokenSource.ANKI_SENTENCE
             );
             if (anyFormStatusResults.length) {
-                const lemmaMatches = anyFormStatusResults.filter((r) => lemmas.includes(r.token!));
+                const lemmaMatches = anyFormStatusResults.filter((r) => tokenMatchesAnyLookupKey(r.token!, lemmas));
                 if (lemmaMatches.length) return combineTokenStatusResults(lemmaMatches);
-                const exactMatches = anyFormStatusResults.filter((r) => r.token === trimmedToken);
+                const exactMatches = anyFormStatusResults.filter((r) =>
+                    tokenMatchesLookupKey(r.token!, normalizedToken)
+                );
                 if (exactMatches.length) return combineTokenStatusResults(exactMatches);
                 return combineTokenStatusResults(anyFormStatusResults);
             }
@@ -1697,7 +1787,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             if (lemmaStatusResults.length) return combineTokenStatusResults(lemmaStatusResults);
         }
         if (shouldUseExactForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(trimmedToken);
+            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
             if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) return tokenStatusResult;
         }
         if (shouldUseAnyForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
@@ -1711,9 +1801,11 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 (source) => source === DictionaryTokenSource.ANKI_SENTENCE
             );
             if (anyFormStatusResults.length) {
-                const lemmaMatches = anyFormStatusResults.filter((r) => lemmas.includes(r.token!));
+                const lemmaMatches = anyFormStatusResults.filter((r) => tokenMatchesAnyLookupKey(r.token!, lemmas));
                 if (lemmaMatches.length) return combineTokenStatusResults(lemmaMatches);
-                const exactMatches = anyFormStatusResults.filter((r) => r.token === trimmedToken);
+                const exactMatches = anyFormStatusResults.filter((r) =>
+                    tokenMatchesLookupKey(r.token!, normalizedToken)
+                );
                 if (exactMatches.length) return combineTokenStatusResults(exactMatches);
                 return combineTokenStatusResults(anyFormStatusResults);
             }
@@ -1723,13 +1815,14 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
 
     private async _handlePriorityKnown(
         trimmedToken: string,
+        normalizedToken: string,
         ts: TrackState,
         cmp: (tokenStatuses: TokenStatus[]) => TokenStatus
     ): Promise<ResolvedTokenStatusResult | null> {
         const tokenStatusResults: TokenStatusResult[] = [];
 
         if (shouldUseExactForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(trimmedToken);
+            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
             if (tokenStatusResult && tokenStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
                 tokenStatusResults.push(tokenStatusResult);
             }
@@ -1761,7 +1854,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         if (tokenStatusResults.length) return combineTokenStatusResults(tokenStatusResults, cmp);
 
         if (shouldUseExactForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(trimmedToken);
+            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
             if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) {
                 tokenStatusResults.push(tokenStatusResult);
             }

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -76,230 +76,331 @@ const ASB_READING_CLASS = 'asb-reading';
 const ASB_FREQUENCY_CLASS = 'asb-frequency';
 // const ASB_FREQUENCY_HOVER_CLASS = 'asb-frequency-hover';
 
+/**
+ * Contains all information specific to a track
+ */
+class TrackState {
+    readonly track: number;
+    readonly dt: DictionaryTrack;
+    readonly yt: Yomitan | undefined;
+    readonly ytLastResetAt: number;
+    readonly tokenCollectionExact: TokenCollection;
+    readonly tokenCollectionLemma: TokenCollection;
+    readonly tokenCollectionAny: TokenCollectionArray;
+    readonly tokenStates: Map<string, TokenState[]>;
+    readonly indexTokenOccurrences: Map<number, Map<string, number>>;
+
+    constructor(track: number, dt: DictionaryTrack) {
+        this.track = track;
+        this.dt = dt;
+        this.yt = undefined;
+        this.ytLastResetAt = 0;
+        this.tokenCollectionExact = new TokenCollection(this, TokenMatchStrategy.EXACT_FORM_COLLECTED);
+        this.tokenCollectionLemma = new TokenCollection(this, TokenMatchStrategy.LEMMA_FORM_COLLECTED);
+        this.tokenCollectionAny = new TokenCollectionArray(this, TokenMatchStrategy.ANY_FORM_COLLECTED);
+        this.tokenStates = new Map();
+        this.indexTokenOccurrences = new Map();
+    }
+
+    updateDictionaryTrack(dt: DictionaryTrack) {
+        (this.dt as DictionaryTrack) = dt;
+    }
+
+    updateYomitan(yt: Yomitan | undefined) {
+        (this.yt as Yomitan | undefined) = yt;
+    }
+
+    resetYomitan() {
+        (this.ytLastResetAt as number) = Date.now();
+        if (!this.yt) return;
+        this.yt.resetCache();
+        this.updateYomitan(undefined);
+    }
+
+    /**
+     * The logic will need to be revisited if new states are added.
+     * It also currently relies on the fact that only local tokens can have states.
+     */
+    updateTokenStates(normalizedToken: string, states: TokenState[]): void {
+        if (!states.length) return;
+        const existingStates = this.tokenStates.get(normalizedToken);
+        if (!existingStates) {
+            this.tokenStates.set(normalizedToken, states);
+            return;
+        }
+        for (const state of states) {
+            if (!existingStates.includes(state)) existingStates.push(state);
+        }
+    }
+
+    /**
+     * How to filter based on the dictionaryMatchAcrossScripts setting:
+     * If the tokens between subtitles and collection don't ever contain kana (not Japanese) then these checks do nothing.
+     * This feature (and multiple lemmas) currently only apply to Japanese but could be expanded for other languages.
+     *
+     * if dictionaryMatchAcrossScripts:
+     *   - Kana subtitles can match kanji in collection, could be homophones but text processing can't handle it so we allow it.
+     *   - Kanji subtitles only match with kanji in collection, prevents kana collected matches all kanji homophones.
+     * if not dictionaryMatchAcrossScripts:
+     *   - Never match across scripts, downside is if kanji is collected kana will need to be collected too.
+     *   - Essentially a strict mode where the user needs to collect all script forms of a word.
+     */
+    private lemmasForScript(trimmedToken: string, lemmas: string[]): string[] {
+        const tokenIsKanaOnly = isKanaOnly(trimmedToken);
+        if (tokenIsKanaOnly && this.dt.dictionaryMatchAcrossScripts) return lemmas;
+        return lemmas.filter((lemma) => isKanaOnly(lemma) === tokenIsKanaOnly);
+    }
+
+    async lemmatizeForScript(trimmedToken: string, normalize = true) {
+        const rawLemmas = await this.yt!.lemmatize(trimmedToken);
+        if (!rawLemmas) return;
+        const lemmas = this.lemmasForScript(trimmedToken, rawLemmas);
+        return normalize ? lemmas.map(normalizeToken) : lemmas;
+    }
+
+    groupingKeysForToken(
+        trimmedToken: string,
+        lemmas: string[],
+        source: DictionaryTokenSource | undefined
+    ): { groupingKey: string; lemmasGroupingKey?: string } {
+        const groupingKey = trimmedToken;
+        let lemmasGroupingKey: string | undefined;
+
+        const strategy =
+            source === DictionaryTokenSource.ANKI_SENTENCE
+                ? this.dt.dictionaryAnkiSentenceTokenMatchStrategy
+                : this.dt.dictionaryTokenMatchStrategy;
+        if (
+            strategy === TokenMatchStrategy.ANY_FORM_COLLECTED ||
+            strategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED ||
+            strategy === TokenMatchStrategy.LEMMA_FORM_COLLECTED
+        ) {
+            const groupingLemmas = this.lemmasForScript(trimmedToken, lemmas);
+            if (groupingLemmas.length) lemmasGroupingKey = JSON.stringify(Array.from(new Set(groupingLemmas)).sort());
+        }
+
+        return { groupingKey, lemmasGroupingKey };
+    }
+}
+
+/**
+ * The processed data from the db.
+ */
 interface TokenStatusResult {
     status: TokenStatus;
     source: DictionaryTokenSource;
-    token?: string; // For any form filtering
+    normalizedToken?: string; // For ANY_FORM_COLLECTED to prefer exact, then lemma, then any form.
     externalCandidateStatuses?: TokenStatusInfo[];
 }
 
+/**
+ * The final status after applying strategies.
+ */
 interface ResolvedTokenStatusResult {
     status: TokenStatus;
     source?: DictionaryTokenSource;
     externalCandidateStatuses?: TokenStatusInfo[];
 }
 
-interface TrackState {
-    track: number;
-    dt: DictionaryTrack;
-    yt: Yomitan | undefined;
-    ytLastResetAt: number;
-    collectedExactForm: Map<string, TokenStatusResult>;
-    collectedLemmaForm: Map<string, TokenStatusResult>;
-    collectedAnyForm: Map<string, TokenStatusResult[]>;
-    tokenStates: Map<string, TokenState[]>;
-    indexTokenOccurrences: Map<number, Map<string, number>>;
-}
-
-function shouldUseExactForm(s: TokenMatchStrategy): boolean {
-    return s === TokenMatchStrategy.EXACT_FORM_COLLECTED || s === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
-}
-
-function shouldUseLemmaForm(s: TokenMatchStrategy): boolean {
-    return s === TokenMatchStrategy.LEMMA_FORM_COLLECTED || s === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
-}
-
-function shouldUseAnyForm(s: TokenMatchStrategy): boolean {
-    return s === TokenMatchStrategy.ANY_FORM_COLLECTED;
-}
-
-function shouldUseLemmasGroupingKey(source: DictionaryTokenSource | undefined, dt: DictionaryTrack): boolean {
-    const strategy =
-        source === DictionaryTokenSource.ANKI_SENTENCE
-            ? dt.dictionaryAnkiSentenceTokenMatchStrategy
-            : dt.dictionaryTokenMatchStrategy;
-    return strategy === TokenMatchStrategy.ANY_FORM_COLLECTED || strategy === TokenMatchStrategy.LEMMA_FORM_COLLECTED;
-}
-
 /**
- * Describes how lemmasForScript() and getAnyFormStatusResults() filter based on the dictionaryMatchAcrossScripts setting:
- * If the tokens between subtitles and collection don't ever contain kana (not Japanese) then these checks do nothing.
- * This feature (and multiple lemmas) currently only apply to Japanese but could be expanded for other languages.
- *
- * if dictionaryMatchAcrossScripts:
- *   - Kana subtitles can match kanji in collection, could be homophones but text processing can't handle it so we allow it.
- *   - Kanji subtitles only match with kanji in collection, prevents kana collected matches all kanji homophones.
- * if not dictionaryMatchAcrossScripts:
- *   - Never match across scripts, downside is if kanji is collected kana will need to be collected too.
- *   - Essentially a strict mode where the user needs to collect all script forms of a word.
+ * Contains the tokens from the db depending on strategy configured.
  */
-async function lemmatizeForScript(
-    trimmedToken: string,
-    ts: TrackState,
-    normalize = true
-): Promise<string[] | undefined> {
-    const rawLemmas = await ts.yt!.lemmatize(trimmedToken);
-    if (!rawLemmas) return;
-    const lemmas = lemmasForScript(trimmedToken, rawLemmas, ts.dt);
-    return normalize ? lemmas.map(normalizeToken) : lemmas;
+class TokenCollectionBase<T = TokenStatusResult | TokenStatusResult[]> {
+    protected readonly collection: Map<string, T>;
+    protected readonly ts: TrackState;
+    readonly enabled: boolean;
+    readonly wordEnabled: boolean;
+    readonly sentenceEnabled: boolean;
+
+    constructor(
+        ts: TrackState,
+        classType:
+            | TokenMatchStrategy.EXACT_FORM_COLLECTED
+            | TokenMatchStrategy.LEMMA_FORM_COLLECTED
+            | TokenMatchStrategy.ANY_FORM_COLLECTED
+    ) {
+        this.collection = new Map();
+        this.ts = ts;
+        switch (classType) {
+            case TokenMatchStrategy.EXACT_FORM_COLLECTED:
+                this.wordEnabled =
+                    ts.dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.EXACT_FORM_COLLECTED ||
+                    ts.dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
+                this.sentenceEnabled =
+                    ts.dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.EXACT_FORM_COLLECTED ||
+                    ts.dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
+                break;
+            case TokenMatchStrategy.LEMMA_FORM_COLLECTED:
+                this.wordEnabled =
+                    ts.dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.LEMMA_FORM_COLLECTED ||
+                    ts.dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
+                this.sentenceEnabled =
+                    ts.dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.LEMMA_FORM_COLLECTED ||
+                    ts.dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
+                break;
+            case TokenMatchStrategy.ANY_FORM_COLLECTED:
+                this.wordEnabled = ts.dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.ANY_FORM_COLLECTED;
+                this.sentenceEnabled =
+                    ts.dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.ANY_FORM_COLLECTED;
+                break;
+            default:
+                throw new Error(`Unsupported TokenMatchStrategy: ${classType}`);
+        }
+        this.enabled = this.wordEnabled || this.sentenceEnabled;
+    }
+
+    get(normalizedKey: string): T | undefined {
+        return this.collection.get(normalizedKey);
+    }
+
+    delete(normalizedKey: string): boolean {
+        return this.collection.delete(normalizedKey);
+    }
+
+    addQuery(queryMap: Map<string, string[]>, key: string): void {
+        const normalizedKey = normalizeToken(key);
+        const queries = queryMap.get(normalizedKey);
+        if (queries) {
+            if (!queries.includes(key)) queries.push(key); // Send all original forms for backwards compatibility with older extension db lookups
+            return;
+        }
+        if (!this.collection.has(normalizedKey)) queryMap.set(normalizedKey, [key]);
+    }
+
+    getAllQueries(queryMap: Map<string, string[]>): string[] {
+        return Array.from(queryMap.values()).flat();
+    }
+
+    protected tokenStatusResult(
+        statuses: TokenStatusInfo[],
+        source: DictionaryTokenSource,
+        externalCandidateStatuses?: TokenStatusInfo[],
+        normalizedToken?: string
+    ): TokenStatusResult {
+        const candidateStatuses = externalCandidateStatuses ?? statuses;
+        return {
+            status: getTokenStatus(statuses, this.ts.dt.dictionaryAnkiTreatSuspended),
+            source,
+            normalizedToken,
+            externalCandidateStatuses: candidateStatuses.length ? candidateStatuses : undefined,
+        };
+    }
+
+    private compareTokenStatusResults(left: TokenStatusResult, right: TokenStatusResult): number {
+        const sourcePriority = dictionaryTokenSourcePriority(left.source) - dictionaryTokenSourcePriority(right.source);
+        if (sourcePriority !== 0) return sourcePriority;
+        const statusPriority = left.status - right.status;
+        if (statusPriority !== 0) return statusPriority;
+        if (isExternalWordSource(left.source) && isExternalWordSource(right.source)) {
+            return externalWordSourcePriority(left.source) - externalWordSourcePriority(right.source);
+        }
+        return 0;
+    }
+
+    protected mergeTokenStatusResults(left: TokenStatusResult, right: TokenStatusResult): TokenStatusResult {
+        return {
+            ...(this.compareTokenStatusResults(left, right) >= 0 ? left : right),
+            externalCandidateStatuses: dedupeTokenStatusInfos([
+                ...(left.externalCandidateStatuses ?? []),
+                ...(right.externalCandidateStatuses ?? []),
+            ]),
+        };
+    }
+
+    static resolveTokenStatusResults(
+        tokenStatusResults: TokenStatusResult[],
+        cmp: (tokenStatuses: TokenStatus[]) => TokenStatus = (tokenStatuses) => Math.max(...tokenStatuses)
+    ): ResolvedTokenStatusResult {
+        const status = cmp(tokenStatusResults.map((result) => result.status));
+        const selectedResult = tokenStatusResults.find((result) => result.status === status)!;
+        return {
+            status: selectedResult.status,
+            source: selectedResult.source,
+            externalCandidateStatuses: dedupeTokenStatusInfos(
+                tokenStatusResults.flatMap((result) => result.externalCandidateStatuses ?? [])
+            ),
+        };
+    }
 }
-function lemmasForScript(trimmedToken: string, lemmas: string[], dt: DictionaryTrack): string[] {
-    const tokenIsKanaOnly = isKanaOnly(trimmedToken);
-    if (tokenIsKanaOnly && dt.dictionaryMatchAcrossScripts) return lemmas;
-    return lemmas.filter((lemma) => isKanaOnly(lemma) === tokenIsKanaOnly);
+
+class TokenCollection extends TokenCollectionBase<TokenStatusResult> {
+    add(
+        statuses: TokenStatusInfo[],
+        source: DictionaryTokenSource,
+        externalCandidateStatuses: TokenStatusInfo[] | undefined,
+        key: string,
+        states: TokenState[]
+    ): void {
+        const statusResult = this.tokenStatusResult(statuses, source, externalCandidateStatuses);
+        const normalizedKey = normalizeToken(key);
+        const existing = this.collection.get(normalizedKey);
+        this.collection.set(
+            normalizedKey,
+            existing ? super.mergeTokenStatusResults(existing, statusResult) : statusResult
+        );
+        this.ts.updateTokenStates(normalizedKey, states);
+    }
 }
-function getAnyFormStatusResults(
-    trimmedToken: string,
-    normalizedLemmas: string[],
-    ts: TrackState,
-    sourceMatches: (source: DictionaryTokenSource) => boolean
-): TokenStatusResult[] {
-    const anyFormStatusResults: TokenStatusResult[] = [];
-    for (const normalizedLemma of normalizedLemmas) {
-        const statusResults = ts.collectedAnyForm.get(normalizedLemma);
-        if (!statusResults) continue;
-        for (const statusResult of statusResults) {
-            if (!sourceMatches(statusResult.source)) continue;
-            const tokenIsKanaOnly = isKanaOnly(trimmedToken);
-            const collectedTokenIsKanaOnly = isKanaOnly(statusResult.token!);
-            if (ts.dt.dictionaryMatchAcrossScripts) {
-                if (tokenIsKanaOnly || !collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
-            } else {
-                if (tokenIsKanaOnly === collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
+
+class TokenCollectionArray extends TokenCollectionBase<TokenStatusResult[]> {
+    add(
+        statuses: TokenStatusInfo[],
+        source: DictionaryTokenSource,
+        externalCandidateStatuses: TokenStatusInfo[] | undefined,
+        normalizedKey: string,
+        states: TokenState[],
+        token: string
+    ): void {
+        const normalizedToken = normalizeToken(token);
+        const statusResult = this.tokenStatusResult(statuses, source, externalCandidateStatuses, normalizedToken);
+        const statusResults = this.collection.get(normalizedKey);
+        if (!statusResults) {
+            this.collection.set(normalizedKey, [statusResult]);
+            return;
+        }
+        const duplicateIndex = statusResults.findIndex((r) => r.normalizedToken === statusResult.normalizedToken);
+        if (duplicateIndex === -1) {
+            statusResults.push(statusResult);
+        } else {
+            statusResults[duplicateIndex] = super.mergeTokenStatusResults(statusResults[duplicateIndex], statusResult);
+        }
+        this.ts.updateTokenStates(normalizedToken, states);
+    }
+
+    /**
+     * Need to check ANY_FORM_COLLECTED results against dictionaryMatchAcrossScripts explicitly since we never checked
+     * the token, only the lemmas. EXACT_FORM_COLLECTED and LEMMA_FORM_COLLECTED looks for an exact match with either the
+     * surface form or lemma form so they don't need this extra filtering.
+     */
+    getStatusResults(
+        trimmedToken: string,
+        normalizedLemmas: string[],
+        sourceMatches: (source: DictionaryTokenSource) => boolean
+    ): TokenStatusResult[] {
+        const tokenIsKanaOnly = isKanaOnly(trimmedToken);
+        const anyFormStatusResults: TokenStatusResult[] = [];
+        for (const normalizedLemma of normalizedLemmas) {
+            const statusResults = this.collection.get(normalizedLemma);
+            if (!statusResults) continue;
+            for (const statusResult of statusResults) {
+                if (!sourceMatches(statusResult.source)) continue;
+                const collectedTokenIsKanaOnly = isKanaOnly(statusResult.normalizedToken!);
+                if (this.ts.dt.dictionaryMatchAcrossScripts) {
+                    if (tokenIsKanaOnly || !collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
+                } else {
+                    if (tokenIsKanaOnly === collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
+                }
             }
         }
+        return anyFormStatusResults;
     }
-    return anyFormStatusResults;
-}
 
-function compareTokenStatusResults(left: TokenStatusResult, right: TokenStatusResult): number {
-    const sourcePriority = dictionaryTokenSourcePriority(left.source) - dictionaryTokenSourcePriority(right.source);
-    if (sourcePriority !== 0) return sourcePriority;
-    const statusPriority = left.status - right.status;
-    if (statusPriority !== 0) return statusPriority;
-    if (isExternalWordSource(left.source) && isExternalWordSource(right.source)) {
-        return externalWordSourcePriority(left.source) - externalWordSourcePriority(right.source);
+    tokenMatchesKey(normalizedToken: string, normalizedKey: string): boolean {
+        return normalizedToken === normalizedKey;
     }
-    return 0;
-}
 
-function mergeTokenStatusResults(left: TokenStatusResult, right: TokenStatusResult): TokenStatusResult {
-    return {
-        ...(compareTokenStatusResults(left, right) >= 0 ? left : right),
-        externalCandidateStatuses: dedupeTokenStatusInfos([
-            ...(left.externalCandidateStatuses ?? []),
-            ...(right.externalCandidateStatuses ?? []),
-        ]),
-    };
-}
-
-function addCollectedAnyFormStatus(
-    collection: Map<string, TokenStatusResult[]>,
-    lemma: string,
-    statusResult: TokenStatusResult
-) {
-    const normalizedLemma = normalizeToken(lemma);
-    const statusResults = collection.get(normalizedLemma);
-    if (!statusResults) {
-        collection.set(normalizedLemma, [statusResult]);
-        return;
-    }
-    const duplicateIndex = statusResults.findIndex((r) => r.token === statusResult.token);
-    if (duplicateIndex === -1) {
-        statusResults.push(statusResult);
-    } else {
-        statusResults[duplicateIndex] = mergeTokenStatusResults(statusResults[duplicateIndex], statusResult);
-    }
-}
-
-function setTokenStates(collection: Map<string, TokenState[]>, normalizedLookupKey: string, states: TokenState[]) {
-    if (!states.length) return;
-    const tokenStates = collection.get(normalizedLookupKey);
-    if (!tokenStates) {
-        collection.set(normalizedLookupKey, states);
-        return;
-    }
-    for (const state of states) {
-        if (!tokenStates.includes(state)) tokenStates.push(state);
-    }
-}
-
-function addTokenIndex(collection: Map<string, Set<number>>, normalizedLookupKey: string, index: number) {
-    const indexes = collection.get(normalizedLookupKey);
-    if (indexes) indexes.add(index);
-    else collection.set(normalizedLookupKey, new Set([index]));
-}
-
-function addLookupQuery(queryMap: Map<string, string[]>, lookupKey: string, collection: Map<string, unknown>) {
-    const normalizedLookupKey = normalizeToken(lookupKey);
-    const queries = queryMap.get(normalizedLookupKey);
-    if (queries) {
-        if (!queries.includes(lookupKey)) queries.push(lookupKey); // Send all original forms for backwards compatibility with older extension db lookups
-        return;
-    }
-    if (!collection.has(normalizedLookupKey)) queryMap.set(normalizedLookupKey, [lookupKey]);
-}
-
-function tokenMatchesLookupKey(normalizedToken: string, normalizedLookupKey: string): boolean {
-    return normalizedToken === normalizedLookupKey;
-}
-
-function tokenMatchesAnyLookupKey(normalizedToken: string, normalizedLookupKeys: string[]): boolean {
-    return normalizedLookupKeys.some((lookupKey) => tokenMatchesLookupKey(normalizedToken, lookupKey));
-}
-
-function groupingKeysForToken(
-    trimmedToken: string,
-    lemmas: string[],
-    source: DictionaryTokenSource | undefined,
-    dt: DictionaryTrack
-): { groupingKey: string; lemmasGroupingKey?: string } {
-    const groupingKey = trimmedToken;
-    let lemmasGroupingKey: string | undefined;
-    const groupingLemmas = lemmasForScript(trimmedToken, lemmas, dt);
-    if (groupingLemmas.length && shouldUseLemmasGroupingKey(source, dt)) {
-        lemmasGroupingKey = `${JSON.stringify(Array.from(new Set(groupingLemmas)).sort())}`;
-    }
-    return { groupingKey, lemmasGroupingKey };
-}
-
-function tokenStatusResult(
-    statuses: TokenStatusInfo[],
-    dictionaryAnkiTreatSuspended: TokenStatus | 'NORMAL',
-    source: DictionaryTokenSource,
-    externalCandidateStatuses?: TokenStatusInfo[],
-    token?: string
-): TokenStatusResult {
-    const candidateStatuses = externalCandidateStatuses ?? statuses;
-    return {
-        status: getTokenStatus(statuses, dictionaryAnkiTreatSuspended),
-        source,
-        token,
-        externalCandidateStatuses: candidateStatuses.length ? candidateStatuses : undefined,
-    };
-}
-
-function combineTokenStatusResults(
-    tokenStatusResults: TokenStatusResult[],
-    cmp: (tokenStatuses: TokenStatus[]) => TokenStatus = (tokenStatuses) => Math.max(...tokenStatuses)
-): ResolvedTokenStatusResult {
-    const status = cmp(tokenStatusResults.map((result) => result.status));
-    const selectedResult = tokenStatusResults.find((result) => result.status === status)!;
-    return {
-        status: selectedResult.status,
-        source: selectedResult.source,
-        externalCandidateStatuses: dedupeTokenStatusInfos(
-            tokenStatusResults.flatMap((result) => result.externalCandidateStatuses ?? [])
-        ),
-    };
-}
-
-function applyExternalCandidateStatuses(
-    token: Token,
-    tokenStatusResult: ResolvedTokenStatusResult | { status: TokenStatus | null }
-) {
-    if ('externalCandidateStatuses' in tokenStatusResult && tokenStatusResult.externalCandidateStatuses !== undefined) {
-        token.externalCandidateStatuses = tokenStatusResult.externalCandidateStatuses;
+    tokenMatchesAnyKey(normalizedToken: string, normalizedKeys: string[]): boolean {
+        return normalizedKeys.some((normalizedKey) => this.tokenMatchesKey(normalizedToken, normalizedKey));
     }
 }
 
@@ -341,13 +442,6 @@ function originalTokenization(tokenization: Tokenization | undefined): Tokenizat
                     states: [],
                 })) ?? [],
     };
-}
-
-function resetYomitan(ts: TrackState) {
-    ts.ytLastResetAt = Date.now();
-    if (!ts.yt) return;
-    ts.yt.resetCache();
-    ts.yt = undefined;
 }
 
 export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
@@ -525,7 +619,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         if (this.annotationsBuilding) this.shouldCancelBuild = true;
         this.profile = null;
         this.anki = undefined;
-        this.trackStates.forEach(resetYomitan);
+        this.trackStates.forEach((ts) => ts.resetYomitan());
         this.trackStates = [];
         this.showingSubtitles = undefined;
         this.showingNeedsRefreshCount = 0;
@@ -577,7 +671,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             const newDt = settings.dictionaryTracks[ts.track];
             if (newDt && dictionaryTrackEnabled(newDt)) continue; // We will be processing, keep current richText on screen until then
             subtitlesToReset.push(...this._subtitles.filter((s) => s.track === ts.track));
-            ts.dt = newDt;
+            ts.updateDictionaryTrack(newDt);
         }
         if (subtitlesToReset.length) {
             for (const s of subtitlesToReset) {
@@ -1002,17 +1096,9 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             }
             const profile = this.profile;
             if (!this.trackStates.length) {
-                this.trackStates = (await this.settingsProvider.getSingle('dictionaryTracks')).map((dt, track) => ({
-                    track,
-                    dt,
-                    yt: undefined,
-                    ytLastResetAt: 0,
-                    collectedExactForm: new Map(),
-                    collectedLemmaForm: new Map(),
-                    collectedAnyForm: new Map(),
-                    tokenStates: new Map(),
-                    indexTokenOccurrences: new Map(),
-                }));
+                this.trackStates = (await this.settingsProvider.getSingle('dictionaryTracks')).map(
+                    (dt, track) => new TrackState(track, dt)
+                );
                 if (this.generateStatistics === undefined) {
                     this.generateStatistics = this._shouldAutoGenerateStatistics(this.trackStates.map((ts) => ts.dt));
                 }
@@ -1035,10 +1121,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                         },
                     });
                     await yt.version();
-                    ts.yt = yt;
+                    ts.updateYomitan(yt);
                 } catch (e) {
                     console.error(`YomitanTrack${ts.track + 1} version request failed:`, e);
-                    resetYomitan(ts);
+                    ts.resetYomitan();
                 }
             }
 
@@ -1214,7 +1300,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             if (this.tokenRequestFailedForTracks.size) {
                 tokensRefreshed = [];
                 updateThresholds = false;
-                for (const track of this.tokenRequestFailedForTracks) resetYomitan(this.trackStates[track]);
+                for (const track of this.tokenRequestFailedForTracks) this.trackStates[track].resetYomitan();
                 this.tokenRequestFailedForTracks.clear();
             } else if (!this.shouldCancelBuild && !skipTracks.length) {
                 if (builtNewTokenization) this._inferFrequencyModesFromTokenOccurrences();
@@ -1281,20 +1367,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 if (!dictionaryStatusCollectionEnabled(ts.dt)) continue; // Still want to bulk tokenize if TokenReadingAnnotation.ALWAYS but no coloring
                 if (this.shouldCancelBuild) return;
 
-                const shouldQueryExactForm =
-                    shouldUseExactForm(ts.dt.dictionaryTokenMatchStrategy) ||
-                    shouldUseExactForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy);
-                const shouldQueryLemmaForm =
-                    shouldUseLemmaForm(ts.dt.dictionaryTokenMatchStrategy) ||
-                    shouldUseLemmaForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy);
-                const shouldQueryAnyForm =
-                    shouldUseAnyForm(ts.dt.dictionaryTokenMatchStrategy) ||
-                    shouldUseAnyForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy);
-
                 for (const token of this.tokensForRefresh) {
-                    ts.collectedExactForm.delete(token);
-                    ts.collectedLemmaForm.delete(token);
-                    ts.collectedAnyForm.delete(token);
+                    ts.tokenCollectionExact.delete(token);
+                    ts.tokenCollectionLemma.delete(token);
+                    ts.tokenCollectionAny.delete(token);
                     ts.tokenStates.delete(token);
                 }
 
@@ -1306,17 +1382,17 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                         .map((p) => p.text)
                         .join('')
                         .trim();
-                    if (shouldQueryExactForm) addLookupQuery(forExactFormQuery, token, ts.collectedExactForm);
-                    if (shouldQueryLemmaForm || shouldQueryAnyForm) {
-                        const lemmas = (await lemmatizeForScript(token, ts, false)) ?? [];
-                        if (shouldQueryLemmaForm) {
+                    if (ts.tokenCollectionExact.enabled) ts.tokenCollectionExact.addQuery(forExactFormQuery, token);
+                    if (ts.tokenCollectionLemma.enabled || ts.tokenCollectionAny.enabled) {
+                        const lemmas = (await ts.lemmatizeForScript(token, false)) ?? [];
+                        if (ts.tokenCollectionLemma.enabled) {
                             for (const lemma of lemmas) {
-                                addLookupQuery(forLemmaFormQuery, lemma, ts.collectedLemmaForm);
+                                ts.tokenCollectionLemma.addQuery(forLemmaFormQuery, lemma);
                             }
                         }
-                        if (shouldQueryAnyForm) {
+                        if (ts.tokenCollectionAny.enabled) {
                             for (const lemma of lemmas) {
-                                addLookupQuery(forAnyFormQuery, lemma, ts.collectedAnyForm);
+                                ts.tokenCollectionAny.addQuery(forAnyFormQuery, lemma);
                             }
                         }
                     }
@@ -1325,16 +1401,24 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
 
                 const [exactFormResultMap, lemmaFormResultMap, anyFormResultsMap] = await Promise.all([
                     forExactFormQuery.size
-                        ? this.dictionaryProvider.getBulk(profile, track, Array.from(forExactFormQuery.values()).flat())
+                        ? this.dictionaryProvider.getBulk(
+                              profile,
+                              track,
+                              ts.tokenCollectionExact.getAllQueries(forExactFormQuery)
+                          )
                         : ({} as TokenResults),
                     forLemmaFormQuery.size
-                        ? this.dictionaryProvider.getBulk(profile, track, Array.from(forLemmaFormQuery.values()).flat())
+                        ? this.dictionaryProvider.getBulk(
+                              profile,
+                              track,
+                              ts.tokenCollectionLemma.getAllQueries(forLemmaFormQuery)
+                          )
                         : ({} as TokenResults),
                     forAnyFormQuery.size
                         ? this.dictionaryProvider.getByLemmaBulk(
                               profile,
                               track,
-                              Array.from(forAnyFormQuery.values()).flat()
+                              ts.tokenCollectionAny.getAllQueries(forAnyFormQuery)
                           )
                         : ({} as LemmaResults),
                 ]);
@@ -1343,54 +1427,21 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 for (const [token, { states, statuses, externalCandidateStatuses, source }] of Object.entries(
                     exactFormResultMap
                 )) {
-                    const normalizedToken = normalizeToken(token);
-                    const statusResult = tokenStatusResult(
-                        statuses,
-                        ts.dt.dictionaryAnkiTreatSuspended,
-                        source,
-                        externalCandidateStatuses
-                    );
-                    const existing = ts.collectedExactForm.get(normalizedToken);
-                    ts.collectedExactForm.set(
-                        normalizedToken,
-                        existing ? mergeTokenStatusResults(existing, statusResult) : statusResult
-                    );
-                    setTokenStates(ts.tokenStates, normalizedToken, states);
+                    ts.tokenCollectionExact.add(statuses, source, externalCandidateStatuses, token, states);
                 }
                 for (const [lemma, { states, statuses, externalCandidateStatuses, source }] of Object.entries(
                     lemmaFormResultMap
                 )) {
-                    const normalizedLemma = normalizeToken(lemma);
-                    const statusResult = tokenStatusResult(
-                        statuses,
-                        ts.dt.dictionaryAnkiTreatSuspended,
-                        source,
-                        externalCandidateStatuses
-                    );
-                    const existing = ts.collectedLemmaForm.get(normalizedLemma);
-                    ts.collectedLemmaForm.set(
-                        normalizedLemma,
-                        existing ? mergeTokenStatusResults(existing, statusResult) : statusResult
-                    );
-                    setTokenStates(ts.tokenStates, normalizedLemma, states);
+                    ts.tokenCollectionLemma.add(statuses, source, externalCandidateStatuses, lemma, states);
                 }
                 for (const [lemma, lemmaResults] of Object.entries(anyFormResultsMap)) {
                     for (const { states, statuses, externalCandidateStatuses, source, token } of lemmaResults) {
-                        const normalizedToken = normalizeToken(token);
-                        const statusResult = tokenStatusResult(
-                            statuses,
-                            ts.dt.dictionaryAnkiTreatSuspended,
-                            source,
-                            externalCandidateStatuses,
-                            normalizedToken
-                        );
-                        addCollectedAnyFormStatus(ts.collectedAnyForm, lemma, statusResult);
-                        setTokenStates(ts.tokenStates, normalizedToken, states);
+                        ts.tokenCollectionAny.add(statuses, source, externalCandidateStatuses, lemma, states, token);
                     }
                 }
             } catch (e) {
                 console.error(`Error building token and lemma map for track ${track}:`, e);
-                resetYomitan(ts);
+                ts.resetYomitan();
             }
         }
     }
@@ -1452,7 +1503,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                         const trimmedToken = tokenText.trim();
                         const normalizedToken = normalizeToken(trimmedToken);
 
-                        addTokenIndex(this.tokenToIndexesCache, normalizedToken, index);
+                        const indexes = this.tokenToIndexesCache.get(normalizedToken);
+                        if (indexes) indexes.add(index);
+                        else this.tokenToIndexesCache.set(normalizedToken, new Set([index]));
+
                         const lemmas = await ts.yt!.lemmatize(trimmedToken);
                         if (this.shouldCancelBuild) return;
                         if (!lemmas) {
@@ -1460,7 +1514,12 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                             this.erroredCache.add(index);
                             return;
                         }
-                        for (const l of lemmas) addTokenIndex(this.tokenToIndexesCache, normalizeToken(l), index);
+                        for (const lemma of lemmas) {
+                            const normalizedLemma = normalizeToken(lemma);
+                            const indexes = this.tokenToIndexesCache.get(normalizedLemma);
+                            if (indexes) indexes.add(index);
+                            else this.tokenToIndexesCache.set(normalizedLemma, new Set([index]));
+                        }
 
                         const states = ts.tokenStates.get(normalizedToken) ?? [];
                         const tokenStatusResult =
@@ -1477,9 +1536,11 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                             })),
                             status,
                             states,
-                            ...groupingKeysForToken(trimmedToken, lemmas, source, ts.dt),
+                            ...ts.groupingKeysForToken(trimmedToken, lemmas, source),
                         };
-                        applyExternalCandidateStatuses(token, tokenStatusResult);
+                        if ('externalCandidateStatuses' in tokenStatusResult) {
+                            token.externalCandidateStatuses = tokenStatusResult.externalCandidateStatuses;
+                        }
                         if (token.status === null) this.erroredCache.add(index);
                         await this._updateFrequency(token, trimmedToken, index, ts);
                         if (this.shouldCancelBuild) return;
@@ -1522,6 +1583,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 const trimmedToken = tokenText.trim();
                 const normalizedToken = normalizeToken(trimmedToken);
 
+                const indexes = this.tokenToIndexesCache.get(normalizedToken);
+                if (indexes) indexes.add(index);
+                else this.tokenToIndexesCache.set(normalizedToken, new Set([index]));
+
                 // Build token
                 const token: InternalToken = {
                     pos: [baseIndex + currentOffset, baseIndex + currentOffset + tokenText.length],
@@ -1549,7 +1614,6 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     }
                 }
 
-                addTokenIndex(this.tokenToIndexesCache, normalizedToken, index);
                 const lemmas = await ts.yt.lemmatize(trimmedToken);
                 if (this.shouldCancelBuild) return;
                 if (!lemmas) {
@@ -1557,17 +1621,17 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                     token.status = null;
                     continue;
                 }
-                for (const lemma of lemmas) addTokenIndex(this.tokenToIndexesCache, normalizeToken(lemma), index);
+                for (const lemma of lemmas) {
+                    const normalizedLemma = normalizeToken(lemma);
+                    const indexes = this.tokenToIndexesCache.get(normalizedLemma);
+                    if (indexes) indexes.add(index);
+                    else this.tokenToIndexesCache.set(normalizedLemma, new Set([index]));
+                }
 
                 // Build token status
                 if (token.states.includes(TokenState.IGNORED) || !HAS_LETTER_REGEX.test(trimmedToken)) {
                     token.status = getFullyKnownTokenStatus();
-                    const { groupingKey, lemmasGroupingKey } = groupingKeysForToken(
-                        trimmedToken,
-                        lemmas,
-                        undefined,
-                        ts.dt
-                    );
+                    const { groupingKey, lemmasGroupingKey } = ts.groupingKeysForToken(trimmedToken, lemmas, undefined);
                     token.groupingKey = groupingKey;
                     token.lemmasGroupingKey = lemmasGroupingKey;
                     continue;
@@ -1577,10 +1641,12 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 };
                 const source = 'source' in tokenStatusResult ? tokenStatusResult.source : undefined;
                 token.status = tokenStatusResult.status;
-                const { groupingKey, lemmasGroupingKey } = groupingKeysForToken(trimmedToken, lemmas, source, ts.dt);
+                const { groupingKey, lemmasGroupingKey } = ts.groupingKeysForToken(trimmedToken, lemmas, source);
                 token.groupingKey = groupingKey;
                 token.lemmasGroupingKey = lemmasGroupingKey;
-                applyExternalCandidateStatuses(token, tokenStatusResult);
+                if ('externalCandidateStatuses' in tokenStatusResult) {
+                    token.externalCandidateStatuses = tokenStatusResult.externalCandidateStatuses;
+                }
                 if (token.status === null) this.erroredCache.add(index);
                 await this._updateFrequency(token, trimmedToken, index, ts);
                 if (this.shouldCancelBuild) return;
@@ -1650,80 +1716,82 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         normalizedToken: string,
         ts: TrackState
     ): Promise<ResolvedTokenStatusResult | null> {
-        if (shouldUseExactForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
+        if (ts.tokenCollectionExact.wordEnabled) {
+            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
             if (tokenStatusResult && tokenStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
                 return tokenStatusResult;
             }
         }
-        if (shouldUseLemmaForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionLemma.wordEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             const lemmaStatusResults: TokenStatusResult[] = [];
             for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.collectedLemmaForm.get(lemma);
+                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
                 if (lemmaStatusResult && lemmaStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
                     lemmaStatusResults.push(lemmaStatusResult);
                 }
             }
-            if (lemmaStatusResults.length) return combineTokenStatusResults(lemmaStatusResults);
+            if (lemmaStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaStatusResults);
         }
-        if (shouldUseAnyForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionAny.wordEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
-            const anyFormStatusResults = getAnyFormStatusResults(
+            const anyFormStatusResults = ts.tokenCollectionAny.getStatusResults(
                 trimmedToken,
                 lemmas,
-                ts,
                 (source) => source !== DictionaryTokenSource.ANKI_SENTENCE
             );
             if (anyFormStatusResults.length) {
                 const exactMatches = anyFormStatusResults.filter((r) =>
-                    tokenMatchesLookupKey(r.token!, normalizedToken)
+                    ts.tokenCollectionAny.tokenMatchesKey(r.normalizedToken!, normalizedToken)
                 );
-                if (exactMatches.length) return combineTokenStatusResults(exactMatches);
-                const lemmaMatches = anyFormStatusResults.filter((r) => tokenMatchesAnyLookupKey(r.token!, lemmas));
-                if (lemmaMatches.length) return combineTokenStatusResults(lemmaMatches);
-                return combineTokenStatusResults(anyFormStatusResults);
+                if (exactMatches.length) return TokenCollectionBase.resolveTokenStatusResults(exactMatches);
+                const lemmaMatches = anyFormStatusResults.filter((r) =>
+                    ts.tokenCollectionAny.tokenMatchesAnyKey(r.normalizedToken!, lemmas)
+                );
+                if (lemmaMatches.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaMatches);
+                return TokenCollectionBase.resolveTokenStatusResults(anyFormStatusResults);
             }
         }
-        if (shouldUseExactForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
+        if (ts.tokenCollectionExact.sentenceEnabled) {
+            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
             if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) return tokenStatusResult;
         }
-        if (shouldUseLemmaForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionLemma.sentenceEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             const lemmaStatusResults: TokenStatusResult[] = [];
             for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.collectedLemmaForm.get(lemma);
+                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
                 if (lemmaStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) {
                     lemmaStatusResults.push(lemmaStatusResult);
                 }
             }
-            if (lemmaStatusResults.length) return combineTokenStatusResults(lemmaStatusResults);
+            if (lemmaStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaStatusResults);
         }
-        if (shouldUseAnyForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionAny.sentenceEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
-            const anyFormStatusResults = getAnyFormStatusResults(
+            const anyFormStatusResults = ts.tokenCollectionAny.getStatusResults(
                 trimmedToken,
                 lemmas,
-                ts,
                 (source) => source === DictionaryTokenSource.ANKI_SENTENCE
             );
             if (anyFormStatusResults.length) {
                 const exactMatches = anyFormStatusResults.filter((r) =>
-                    tokenMatchesLookupKey(r.token!, normalizedToken)
+                    ts.tokenCollectionAny.tokenMatchesKey(r.normalizedToken!, normalizedToken)
                 );
-                if (exactMatches.length) return combineTokenStatusResults(exactMatches);
-                const lemmaMatches = anyFormStatusResults.filter((r) => tokenMatchesAnyLookupKey(r.token!, lemmas));
-                if (lemmaMatches.length) return combineTokenStatusResults(lemmaMatches);
-                return combineTokenStatusResults(anyFormStatusResults);
+                if (exactMatches.length) return TokenCollectionBase.resolveTokenStatusResults(exactMatches);
+                const lemmaMatches = anyFormStatusResults.filter((r) =>
+                    ts.tokenCollectionAny.tokenMatchesAnyKey(r.normalizedToken!, lemmas)
+                );
+                if (lemmaMatches.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaMatches);
+                return TokenCollectionBase.resolveTokenStatusResults(anyFormStatusResults);
             }
         }
         return { status: TokenStatus.UNCOLLECTED };
@@ -1734,80 +1802,82 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         normalizedToken: string,
         ts: TrackState
     ): Promise<ResolvedTokenStatusResult | null> {
-        if (shouldUseLemmaForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionLemma.wordEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             const lemmaStatusResults: TokenStatusResult[] = [];
             for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.collectedLemmaForm.get(lemma);
+                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
                 if (lemmaStatusResult && lemmaStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
                     lemmaStatusResults.push(lemmaStatusResult);
                 }
             }
-            if (lemmaStatusResults.length) return combineTokenStatusResults(lemmaStatusResults);
+            if (lemmaStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaStatusResults);
         }
-        if (shouldUseExactForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
+        if (ts.tokenCollectionExact.wordEnabled) {
+            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
             if (tokenStatusResult && tokenStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
                 return tokenStatusResult;
             }
         }
-        if (shouldUseAnyForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionAny.wordEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
-            const anyFormStatusResults = getAnyFormStatusResults(
+            const anyFormStatusResults = ts.tokenCollectionAny.getStatusResults(
                 trimmedToken,
                 lemmas,
-                ts,
                 (source) => source !== DictionaryTokenSource.ANKI_SENTENCE
             );
             if (anyFormStatusResults.length) {
-                const lemmaMatches = anyFormStatusResults.filter((r) => tokenMatchesAnyLookupKey(r.token!, lemmas));
-                if (lemmaMatches.length) return combineTokenStatusResults(lemmaMatches);
-                const exactMatches = anyFormStatusResults.filter((r) =>
-                    tokenMatchesLookupKey(r.token!, normalizedToken)
+                const lemmaMatches = anyFormStatusResults.filter((r) =>
+                    ts.tokenCollectionAny.tokenMatchesAnyKey(r.normalizedToken!, lemmas)
                 );
-                if (exactMatches.length) return combineTokenStatusResults(exactMatches);
-                return combineTokenStatusResults(anyFormStatusResults);
+                if (lemmaMatches.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaMatches);
+                const exactMatches = anyFormStatusResults.filter((r) =>
+                    ts.tokenCollectionAny.tokenMatchesKey(r.normalizedToken!, normalizedToken)
+                );
+                if (exactMatches.length) return TokenCollectionBase.resolveTokenStatusResults(exactMatches);
+                return TokenCollectionBase.resolveTokenStatusResults(anyFormStatusResults);
             }
         }
-        if (shouldUseLemmaForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionLemma.sentenceEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             const lemmaStatusResults: TokenStatusResult[] = [];
             for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.collectedLemmaForm.get(lemma);
+                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
                 if (lemmaStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) {
                     lemmaStatusResults.push(lemmaStatusResult);
                 }
             }
-            if (lemmaStatusResults.length) return combineTokenStatusResults(lemmaStatusResults);
+            if (lemmaStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaStatusResults);
         }
-        if (shouldUseExactForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
+        if (ts.tokenCollectionExact.sentenceEnabled) {
+            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
             if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) return tokenStatusResult;
         }
-        if (shouldUseAnyForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionAny.sentenceEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
-            const anyFormStatusResults = getAnyFormStatusResults(
+            const anyFormStatusResults = ts.tokenCollectionAny.getStatusResults(
                 trimmedToken,
                 lemmas,
-                ts,
                 (source) => source === DictionaryTokenSource.ANKI_SENTENCE
             );
             if (anyFormStatusResults.length) {
-                const lemmaMatches = anyFormStatusResults.filter((r) => tokenMatchesAnyLookupKey(r.token!, lemmas));
-                if (lemmaMatches.length) return combineTokenStatusResults(lemmaMatches);
-                const exactMatches = anyFormStatusResults.filter((r) =>
-                    tokenMatchesLookupKey(r.token!, normalizedToken)
+                const lemmaMatches = anyFormStatusResults.filter((r) =>
+                    ts.tokenCollectionAny.tokenMatchesAnyKey(r.normalizedToken!, lemmas)
                 );
-                if (exactMatches.length) return combineTokenStatusResults(exactMatches);
-                return combineTokenStatusResults(anyFormStatusResults);
+                if (lemmaMatches.length) return TokenCollectionBase.resolveTokenStatusResults(lemmaMatches);
+                const exactMatches = anyFormStatusResults.filter((r) =>
+                    ts.tokenCollectionAny.tokenMatchesKey(r.normalizedToken!, normalizedToken)
+                );
+                if (exactMatches.length) return TokenCollectionBase.resolveTokenStatusResults(exactMatches);
+                return TokenCollectionBase.resolveTokenStatusResults(anyFormStatusResults);
             }
         }
         return { status: TokenStatus.UNCOLLECTED };
@@ -1821,69 +1891,67 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
     ): Promise<ResolvedTokenStatusResult | null> {
         const tokenStatusResults: TokenStatusResult[] = [];
 
-        if (shouldUseExactForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
+        if (ts.tokenCollectionExact.wordEnabled) {
+            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
             if (tokenStatusResult && tokenStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
                 tokenStatusResults.push(tokenStatusResult);
             }
         }
-        if (shouldUseLemmaForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionLemma.wordEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.collectedLemmaForm.get(lemma);
+                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
                 if (lemmaStatusResult && lemmaStatusResult.source !== DictionaryTokenSource.ANKI_SENTENCE) {
                     tokenStatusResults.push(lemmaStatusResult);
                 }
             }
         }
-        if (shouldUseAnyForm(ts.dt.dictionaryTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionAny.wordEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             tokenStatusResults.push(
-                ...getAnyFormStatusResults(
+                ...ts.tokenCollectionAny.getStatusResults(
                     trimmedToken,
                     lemmas,
-                    ts,
                     (source) => source !== DictionaryTokenSource.ANKI_SENTENCE
                 )
             );
         }
-        if (tokenStatusResults.length) return combineTokenStatusResults(tokenStatusResults, cmp);
+        if (tokenStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(tokenStatusResults, cmp);
 
-        if (shouldUseExactForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const tokenStatusResult = ts.collectedExactForm.get(normalizedToken);
+        if (ts.tokenCollectionExact.sentenceEnabled) {
+            const tokenStatusResult = ts.tokenCollectionExact.get(normalizedToken);
             if (tokenStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) {
                 tokenStatusResults.push(tokenStatusResult);
             }
         }
-        if (shouldUseLemmaForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionLemma.sentenceEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             for (const lemma of lemmas) {
-                const lemmaStatusResult = ts.collectedLemmaForm.get(lemma);
+                const lemmaStatusResult = ts.tokenCollectionLemma.get(lemma);
                 if (lemmaStatusResult?.source === DictionaryTokenSource.ANKI_SENTENCE) {
                     tokenStatusResults.push(lemmaStatusResult);
                 }
             }
         }
-        if (shouldUseAnyForm(ts.dt.dictionaryAnkiSentenceTokenMatchStrategy)) {
-            const lemmas = await lemmatizeForScript(trimmedToken, ts);
+        if (ts.tokenCollectionAny.sentenceEnabled) {
+            const lemmas = await ts.lemmatizeForScript(trimmedToken);
             if (this.shouldCancelBuild) return null;
             if (!lemmas) return null;
             tokenStatusResults.push(
-                ...getAnyFormStatusResults(
+                ...ts.tokenCollectionAny.getStatusResults(
                     trimmedToken,
                     lemmas,
-                    ts,
                     (source) => source === DictionaryTokenSource.ANKI_SENTENCE
                 )
             );
         }
-        if (tokenStatusResults.length) return combineTokenStatusResults(tokenStatusResults, cmp);
+        if (tokenStatusResults.length) return TokenCollectionBase.resolveTokenStatusResults(tokenStatusResults, cmp);
 
         return { status: TokenStatus.UNCOLLECTED };
     }

--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -693,6 +693,15 @@ export function dedupeTokenStatusInfos(statuses: TokenStatusInfo[]): TokenStatus
 }
 
 /**
+ * Normalize a string for dictionary lookup, currently only by case folding.
+ * If normalization expands from just case folding then the entire annotation and db logic will need
+ * to be revisited since Dexie supports case folding natively through anyOfIgnoreCase() but nothing custom.
+ */
+export function normalizeToken(value: string): string {
+    return value.toLowerCase();
+}
+
+/**
  * An async safe semaphore implementation that preserves FIFO order (within a priority group).
  * Priority levels are set with acquire(), higher numbers indicate a higher priority.
  * It uses an id for release to allow multiple releases (e.g try/finally with early releases).


### PR DESCRIPTION
Annotations will now ignore capitalization when matching tokens. This requires no change to the data stored, only using `anyOfIngoreCase()` instead of `anyOf()` for the db functions and normalizing the tokens for when using in `SubtitleAnnotations`. This required also reestablishing the db invariants around source priority withing `SubtitleAnnotations`.

Yomitan always returns the lower case version so normalization was already handle for the `ANY_FORM_COLLECTED` strategy. Now this allows the same flexibility for `EXACT_FORM_COLLECTED` and `LEMMA_FORM_COLLECTED`.

I think this makes sense to add without an option, the normalization only applies to English letters. There may be languages where this could be a legitimate difference in meaning but I don't think it's worth worrying about for now. We likely would need specific rules for those as we come across them if they exist.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
