### PR TITLE
Fix inferTracks leaking basename and tracks across soft-navigation

### DIFF
--- a/extension/src/pages/util.ts
+++ b/extension/src/pages/util.ts
@@ -7,9 +7,10 @@ export function extractExtension(url: string, fallback: string) {
 }
 
 export function poll(test: () => boolean, timeout: number = 10000): Promise<boolean> {
-    return new Promise<boolean>(async (resolve, reject) => {
+    return new Promise<boolean>(async (resolve) => {
         if (test()) {
             resolve(true);
+            return;
         }
 
         const t0 = Date.now();
@@ -51,7 +52,7 @@ export const trackId = (def: VideoDataSubtitleTrackDef) => {
 export function inferTracks({ onJson, onRequest, waitForBasename }: InferHooks, timeout?: number) {
     setTimeout(() => {
         const subtitlesByPath: SubtitlesByPath = {};
-        let basename = '';
+        const basenameByPath: { [key: string]: string } = {};
         let trackDataRequestHandled = false;
 
         if (onJson !== undefined) {
@@ -80,19 +81,20 @@ export function inferTracks({ onJson, onRequest, waitForBasename }: InferHooks, 
                         }
                     },
                     (theBasename) => {
-                        basename = theBasename;
+                        basenameByPath[window.location.pathname] = theBasename;
                         basenameFound = true;
                     }
                 );
 
                 if (trackDataRequestHandled && (tracksFound || basenameFound)) {
                     // Only notify additional tracks after the initial request for track info
+                    const currentPath = window.location.pathname;
                     document.dispatchEvent(
                         new CustomEvent('asbplayer-synced-data', {
                             detail: {
                                 error: '',
-                                basename: basename,
-                                subtitles: subtitlesByPath[window.location.pathname],
+                                basename: basenameByPath[currentPath] ?? '',
+                                subtitles: subtitlesByPath[currentPath],
                             },
                         })
                     );
@@ -103,9 +105,15 @@ export function inferTracks({ onJson, onRequest, waitForBasename }: InferHooks, 
         }
 
         function garbageCollect() {
+            const currentPath = window.location.pathname;
             for (const path of Object.keys(subtitlesByPath)) {
-                if (path !== window.location.pathname) {
+                if (path !== currentPath) {
                     delete subtitlesByPath[path];
+                }
+            }
+            for (const path of Object.keys(basenameByPath)) {
+                if (path !== currentPath) {
+                    delete basenameByPath[path];
                 }
             }
         }
@@ -113,29 +121,32 @@ export function inferTracks({ onJson, onRequest, waitForBasename }: InferHooks, 
         document.addEventListener(
             'asbplayer-get-synced-data',
             async () => {
+                // Pin the pathname at request-start time so async onRequest
+                // callbacks resolving after a soft-navigation still file their
+                // tracks and basename under the path they were fetched for.
+                const requestPath = window.location.pathname;
+
                 onRequest?.(
                     (track) => {
-                        const path = window.location.pathname;
-
-                        if (typeof subtitlesByPath[path] === 'undefined') {
-                            subtitlesByPath[path] = [];
+                        if (typeof subtitlesByPath[requestPath] === 'undefined') {
+                            subtitlesByPath[requestPath] = [];
                         }
 
                         const newId = trackId(track);
 
-                        if (subtitlesByPath[path].find((s) => s.id === newId) === undefined) {
-                            subtitlesByPath[path].push({ id: newId, ...track });
+                        if (subtitlesByPath[requestPath].find((s) => s.id === newId) === undefined) {
+                            subtitlesByPath[requestPath].push({ id: newId, ...track });
                         }
                     },
                     (theBasename) => {
-                        basename = theBasename;
-                        if (!trackDataRequestHandled) {
+                        basenameByPath[requestPath] = theBasename;
+                        if (!trackDataRequestHandled && requestPath === window.location.pathname) {
                             // Notify basename even if still waiting for subtitle track info
                             document.dispatchEvent(
                                 new CustomEvent('asbplayer-synced-data', {
                                     detail: {
                                         error: '',
-                                        basename: basename,
+                                        basename: theBasename,
                                         subtitles: undefined,
                                     },
                                 })
@@ -144,19 +155,22 @@ export function inferTracks({ onJson, onRequest, waitForBasename }: InferHooks, 
                     }
                 );
 
-                const ready = () =>
-                    (!waitForBasename || basename !== '') && window.location.pathname in subtitlesByPath;
+                const ready = () => {
+                    const path = window.location.pathname;
+                    return (!waitForBasename || (basenameByPath[path] ?? '') !== '') && path in subtitlesByPath;
+                };
 
                 if (!ready()) {
                     await poll(ready, timeout);
                 }
 
+                const currentPath = window.location.pathname;
                 document.dispatchEvent(
                     new CustomEvent('asbplayer-synced-data', {
                         detail: {
                             error: '',
-                            basename: basename,
-                            subtitles: subtitlesByPath[window.location.pathname] ?? [],
+                            basename: basenameByPath[currentPath] ?? '',
+                            subtitles: subtitlesByPath[currentPath] ?? [],
                         },
                     })
                 );


### PR DESCRIPTION
### Summary

`inferTracks` had two related defects that could surface as wrong data attached to the current video after the user soft-navigates within an SPA. This PR fixes both inside the shared helper.

**Basename was a singleton in the closure.** With `waitForBasename: false`, the final dispatch read whatever value happened to be set, so a previous video's title could end up on the current one if the new basename lookup had not completed (or had failed) by dispatch time. Fixed by adding a `basenameByPath` map mirroring the existing `subtitlesByPath`, written by `setBasename` and read by the current pathname at dispatch and in `ready()`. `garbageCollect` is extended to clean it too.

**`addTrack` and `setBasename` callbacks read pathname at resolve time.** Both were reading `window.location.pathname` only when the async `onRequest` callback resolved, which meant a soft-navigation between request-start and callback-resolution would file the old video's data under the new pathname. Fixed by capturing `requestPath` once when the `asbplayer-get-synced-data` handler fires, and having both callbacks write to that captured path. Reads (`ready()` and the final dispatch) still use the current pathname, so asbplayer always gets data for whichever video the user is actually watching.

The partial basename dispatch is also now guarded on `requestPath === window.location.pathname`, so an old request can no longer fire a basename-only event for a video that is no longer current.

**Affected scripts:** all `inferTracks` users, including direct callers such as Bandai Channel, Bilibili, Disney+, Hulu, NRK TV, SVT Play, and TVer, plus page scripts that go through `inferTracksFromInterceptedMpd` / `inferTracksFromInterceptedM3u8` / `inferTracksFromInterceptedMpdViaXMLHTTPRequest`. The MPD/M3U8 helpers call `setBasename(document.title)` internally, so they exercise the same code path. Single-video flow should be unchanged for all of them. Multi-video navigation through `onRequest` callbacks no longer leaks the previous video's title.

### Drive-by fix

While touching `util.ts`, also fixed an existing bug in `poll()`. The early `resolve(true)` on first-test success was missing a `return`, so the function still scheduled one wasted `setTimeout` and one extra `test()` call before exiting. Added the `return` to short-circuit the loop. The unused `reject` parameter on the Promise constructor was dropped at the same time.

### Tested

The below were tested successfully (sites not tested are noted).

- Hulu: switch between two episodes that have different titles. Mined cards or downloaded subs reflect the current episode's title, not the previous one's.
- Disney+, SVT Play: open subtitle picker. Tracks load. Subsequent mining cards use the current video's metadata. (Did not test Bandai Channel, NRK TV, TVer, and Bilibili, but ideally they would receive testing as well.)
- Other inferTracks users (HBO Max, UR Play): smoke test that subtitle picker still loads on a single-video page. (Did not test Disney+ Apps, iWantTFC, OSN Plus, Viki, and Yle Areena, but ideally they would receive testing as well.)

### Known limitation

The `onJson` path (Bandai Channel, Bilibili, TVer) still reads `window.location.pathname` at `JSON.parse` time. The parse hook has no reference to the originating fetch, so a response in flight across a soft-navigation can still attribute data to the wrong path on those three sites. Fixing it needs per-site changes that key on a stable payload identifier (the Hulu page script uses `content_eab_id` for exactly this reason), and is left for follow-up if it surfaces in practice.

### Additional notes

`yarn run verify` ran successfully with no errors after all of the changes made in this pull request. Both the Chrome and Firefox extensions were tested.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).