### PR TITLE
Stop subtitle picker resetting while user is interacting with it

### DIFF
--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -78,7 +78,7 @@ export default class VideoDataSyncController {
     private _syncedData?: VideoData;
     private _wasPaused?: boolean;
     private _playBlocker?: () => void;
-    private _openedPathname?: string;
+    private _openedLocation?: string;
     private _fullscreenElement?: Element;
     private _activeElement?: Element;
     private _autoSyncAttempted: boolean = false;
@@ -118,7 +118,7 @@ export default class VideoDataSyncController {
         this._dataReceivedListener = undefined;
         this._syncedData = undefined;
         this._cleanupPlayBlocker();
-        this._openedPathname = undefined;
+        this._openedLocation = undefined;
     }
 
     updateSettings({ streamingAutoSync, streamingLastLanguagesSynced }: AsbplayerSettings) {
@@ -146,8 +146,8 @@ export default class VideoDataSyncController {
         return !this._frame.hidden;
     }
 
-    get openedPathname(): string | undefined {
-        return this._openedPathname;
+    get openedLocation(): string | undefined {
+        return this._openedLocation;
     }
 
     async requestSubtitles() {
@@ -155,11 +155,11 @@ export default class VideoDataSyncController {
             return;
         }
 
-        // While the picker is open on the same path, skip refresh so cyclic
+        // While the picker is open on the same location, skip refresh so
         // player events do not clobber an in-progress user selection. On a
         // true soft-navigation, dismiss the stale picker and continue.
         if (this.pickerVisible) {
-            if (this.openedPathname !== undefined && window.location.pathname !== this.openedPathname) {
+            if (this.openedLocation !== undefined && window.location.href !== this.openedLocation) {
                 this._hideAndResume();
             } else {
                 return;
@@ -461,7 +461,7 @@ export default class VideoDataSyncController {
     }
 
     private _prepareShow() {
-        this._openedPathname = window.location.pathname;
+        this._openedLocation = window.location.href;
         this._wasPaused = this._wasPaused ?? this._context.video.paused;
         this._context.pause();
 
@@ -498,7 +498,7 @@ export default class VideoDataSyncController {
 
     private _hideAndResume() {
         this._cleanupPlayBlocker();
-        this._openedPathname = undefined;
+        this._openedLocation = undefined;
         this._context.keyBindings.bind(this._context);
         this._context.subtitleController.forceHideSubtitles = false;
         this._context.mobileVideoOverlayController.forceHide = false;

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -159,7 +159,7 @@ export default class VideoDataSyncController {
         // player events do not clobber an in-progress user selection. On a
         // true soft-navigation, dismiss the stale picker and continue.
         if (this.pickerVisible) {
-            if (this._openedPathname !== undefined && window.location.pathname !== this._openedPathname) {
+            if (this.openedPathname !== undefined && window.location.pathname !== this.openedPathname) {
                 this._hideAndResume();
             } else {
                 return;
@@ -327,22 +327,22 @@ export default class VideoDataSyncController {
                 this._autoSyncAttempted = true;
                 const subs = this._matchLastSyncedWithAvailableTracks();
 
-                if (subs.completeMatch && this._frame.hidden) {
+                if (subs.completeMatch && !this.pickerVisible) {
                     const autoSelectedTracks: VideoDataSubtitleTrack[] = subs.autoSelectedTracks;
                     await this._syncData(autoSelectedTracks);
-                } else if (!subs.completeMatch && this._frame.hidden) {
+                } else if (!subs.completeMatch && !this.pickerVisible) {
                     const shouldPrompt = await this._settings.getSingle('streamingAutoSyncPromptOnFailure');
 
                     if (shouldPrompt) {
                         await this.show({ reason: VideoDataUiOpenReason.failedToAutoLoadPreferredTrack });
                     }
-                } else if (this._frame.clientIfLoaded !== undefined && wasLoading) {
+                } else if (wasLoading) {
                     // Picker is open in loading state. Populate it now that tracks have arrived.
-                    this._frame.clientIfLoaded.updateState(await this._buildModel({}));
+                    this._frame.clientIfLoaded?.updateState(await this._buildModel({}));
                 }
             }
-        } else if (this._frame.clientIfLoaded !== undefined && (this._frame.hidden || wasLoading)) {
-            this._frame.clientIfLoaded.updateState(await this._buildModel({}));
+        } else if (!this.pickerVisible || wasLoading) {
+            this._frame.clientIfLoaded?.updateState(await this._buildModel({}));
         }
     }
 
@@ -470,7 +470,7 @@ export default class VideoDataSyncController {
         // picker is dismissed.
         if (!this._playBlocker) {
             this._playBlocker = () => {
-                this._context.video.pause();
+                this._context.pause();
             };
             this._context.video.addEventListener('play', this._playBlocker);
         }

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -77,6 +77,8 @@ export default class VideoDataSyncController {
     private _emptySubtitle: VideoDataSubtitleTrack;
     private _syncedData?: VideoData;
     private _wasPaused?: boolean;
+    private _playBlocker?: () => void;
+    private _openedPathname?: string;
     private _fullscreenElement?: Element;
     private _activeElement?: Element;
     private _autoSyncAttempted: boolean = false;
@@ -115,6 +117,8 @@ export default class VideoDataSyncController {
 
         this._dataReceivedListener = undefined;
         this._syncedData = undefined;
+        this._cleanupPlayBlocker();
+        this._openedPathname = undefined;
     }
 
     updateSettings({ streamingAutoSync, streamingLastLanguagesSynced }: AsbplayerSettings) {
@@ -138,9 +142,28 @@ export default class VideoDataSyncController {
         }
     }
 
+    get pickerVisible(): boolean {
+        return !this._frame.hidden;
+    }
+
+    get openedPathname(): string | undefined {
+        return this._openedPathname;
+    }
+
     async requestSubtitles() {
         if (!this._context.hasPageScript) {
             return;
+        }
+
+        // While the picker is open on the same path, skip refresh so cyclic
+        // player events do not clobber an in-progress user selection. On a
+        // true soft-navigation, dismiss the stale picker and continue.
+        if (this.pickerVisible) {
+            if (this._openedPathname !== undefined && window.location.pathname !== this._openedPathname) {
+                this._hideAndResume();
+            } else {
+                return;
+            }
         }
 
         const pageDelegate = await currentPageDelegate();
@@ -296,6 +319,7 @@ export default class VideoDataSyncController {
     }
 
     private async _setSyncedData(data: VideoData) {
+        const wasLoading = this._syncedData?.subtitles === undefined;
         this._syncedData = data;
 
         if (this._syncedData?.subtitles !== undefined && (await this._canAutoSync())) {
@@ -303,22 +327,21 @@ export default class VideoDataSyncController {
                 this._autoSyncAttempted = true;
                 const subs = this._matchLastSyncedWithAvailableTracks();
 
-                if (subs.completeMatch) {
+                if (subs.completeMatch && this._frame.hidden) {
                     const autoSelectedTracks: VideoDataSubtitleTrack[] = subs.autoSelectedTracks;
                     await this._syncData(autoSelectedTracks);
-
-                    if (!this._frame.hidden) {
-                        this._hideAndResume();
-                    }
-                } else {
+                } else if (!subs.completeMatch && this._frame.hidden) {
                     const shouldPrompt = await this._settings.getSingle('streamingAutoSyncPromptOnFailure');
 
                     if (shouldPrompt) {
                         await this.show({ reason: VideoDataUiOpenReason.failedToAutoLoadPreferredTrack });
                     }
+                } else if (this._frame.clientIfLoaded !== undefined && wasLoading) {
+                    // Picker is open in loading state. Populate it now that tracks have arrived.
+                    this._frame.clientIfLoaded.updateState(await this._buildModel({}));
                 }
             }
-        } else if (this._frame.clientIfLoaded !== undefined) {
+        } else if (this._frame.clientIfLoaded !== undefined && (this._frame.hidden || wasLoading)) {
             this._frame.clientIfLoaded.updateState(await this._buildModel({}));
         }
     }
@@ -391,6 +414,11 @@ export default class VideoDataSyncController {
                     return;
                 }
 
+                if ('cancel' === message.command) {
+                    this._hideAndResume();
+                    return;
+                }
+
                 let dataWasSynced = true;
 
                 if ('confirm' === message.command) {
@@ -433,8 +461,19 @@ export default class VideoDataSyncController {
     }
 
     private _prepareShow() {
+        this._openedPathname = window.location.pathname;
         this._wasPaused = this._wasPaused ?? this._context.video.paused;
         this._context.pause();
+
+        // Some players (e.g. Hulu) call video.play() on an internal timer that
+        // ignores the picker being open. Re-pause on any play event until the
+        // picker is dismissed.
+        if (!this._playBlocker) {
+            this._playBlocker = () => {
+                this._context.video.pause();
+            };
+            this._context.video.addEventListener('play', this._playBlocker);
+        }
 
         if (document.fullscreenElement) {
             this._fullscreenElement = document.fullscreenElement;
@@ -450,7 +489,16 @@ export default class VideoDataSyncController {
         this._context.mobileVideoOverlayController.forceHide = true;
     }
 
+    private _cleanupPlayBlocker() {
+        if (this._playBlocker) {
+            this._context.video.removeEventListener('play', this._playBlocker);
+            this._playBlocker = undefined;
+        }
+    }
+
     private _hideAndResume() {
+        this._cleanupPlayBlocker();
+        this._openedPathname = undefined;
         this._context.keyBindings.bind(this._context);
         this._context.subtitleController.forceHideSubtitles = false;
         this._context.mobileVideoOverlayController.forceHide = false;

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -679,6 +679,17 @@ export default class Binding {
         if (this.hasPageScript) {
             this.videoChangeListener = () => {
                 this._updateRegisteredVideoSrc(this.video.src || this._fallbackVideoSrc);
+
+                // Cyclic player events (e.g. Hulu's periodic loadedmetadata during blob
+                // URL rotation while paused) fire this listener without an actual video
+                // change. Skip refresh only when the picker is open on the same path.
+                if (
+                    this.videoDataSyncController.pickerVisible &&
+                    this.videoDataSyncController.openedPathname === window.location.pathname
+                ) {
+                    return;
+                }
+
                 this.videoDataSyncController.requestSubtitles();
                 this._resetSubtitles();
             };

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -136,6 +136,7 @@ export default class Binding {
 
     private _synced: boolean;
     private _syncedTimestamp?: number;
+    private _lastSyncedLocation?: string;
 
     recordingState: RecordingState = RecordingState.notRecording;
     recordingPostMineAction?: PostMineAction;
@@ -680,13 +681,17 @@ export default class Binding {
             this.videoChangeListener = () => {
                 this._updateRegisteredVideoSrc(this.video.src || this._fallbackVideoSrc);
 
-                // Cyclic player events (e.g. Hulu's periodic loadedmetadata during blob
-                // URL rotation while paused) fire this listener without an actual video
-                // change. Skip refresh only when the picker is open on the same path.
+                // Player events (e.g. Hulu blob URL rotation) can fire loadedmetadata
+                // without an actual video change. Skip refresh when the picker is open
+                // here or subtitles are already synced for it.
                 if (
                     this.videoDataSyncController.pickerVisible &&
-                    this.videoDataSyncController.openedPathname === window.location.pathname
+                    this.videoDataSyncController.openedLocation === window.location.href
                 ) {
+                    return;
+                }
+
+                if (this._synced && this._lastSyncedLocation === window.location.href) {
                     return;
                 }
 
@@ -1228,6 +1233,7 @@ export default class Binding {
 
         this._notifyVideoDisappeared(this._registeredVideoSrc);
         this._registeredVideoSrc = '';
+        this._lastSyncedLocation = undefined;
     }
 
     async _takeScreenshot() {
@@ -1643,6 +1649,7 @@ export default class Binding {
         this.ankiUiSavedState = undefined;
         this._synced = true;
         this._syncedTimestamp = Date.now();
+        this._lastSyncedLocation = window.location.href;
 
         if (this.video.paused) {
             this.mobileVideoOverlayController.show();
@@ -1674,6 +1681,7 @@ export default class Binding {
         this.ankiUiSavedState = undefined;
         this._synced = false;
         this._syncedTimestamp = undefined;
+        this._lastSyncedLocation = undefined;
         this.mobileVideoOverlayController.disposeOverlay();
     }
 


### PR DESCRIPTION
 ### Summary

The subtitle picker can be reset and the video auto-resumed while a user is actively interacting with the picker, on any site whose `<video>` element fires `loadedmetadata` outside an actual video change, or whose player explicitly calls `video.play()` on an internal timer.

Two mechanisms feed the same symptom:

**1. `loadedmetadata` firings re-fetch synced data, wipe the user's in-progress picker selection, and clear loaded subtitles.** The binding's `videoChangeListener` fires on `loadedmetadata` and calls `videoDataSyncController.requestSubtitles()` (which clears `_syncedData` and `_autoSyncAttempted`) plus `_resetSubtitles()` (which clears the loaded subtitles from the player). When the resulting fresh `asbplayer-synced-data` event arrives at `_setSyncedData`, the auto-sync evaluation regenerates the picker's contents from the new data and pushes the update into the UI, overwriting any selection the user had made but not yet confirmed.

**2. Internal `setTimeout` calls `video.play()` while the picker is open**, un-pausing the video even though `_prepareShow` had paused it via `this._context.pause()`. asbplayer's pause is set once and never re-enforced.

Hulu exhibits both behaviors. Disney+ does not (verified by probe that `loadedmetadata` never fires while paused). Amazon Prime also does not exhibit the symptom in testing. Verified Hulu's `play()` call by probing `video.play` and seeing `app.js` invoke it via `setTimeout` (fires roughly 10 seconds after pause). Direct instrumentation in a follow-up testing session showed that the `setTimeout` callback also rotates the MediaSource blob URL, which is what fires `loadedmetadata`. The rotation was observed only for the first two pauses of a fresh session; subsequent pauses (including pauses of 117+ seconds) did not trigger it. The exact gating condition is not fully characterized but appears tied to early-session DRM license or manifest state. The synced-state guard short-circuits the bug regardless of how narrow the natural trigger turns out to be in practice.

A related correctness issue: if the user has the picker open during a true SPA soft-navigation (e.g. Hulu autoplay or "Next Episode" while the picker is up), the open-picker guard would suppress the legitimate refresh for the new video and leave the picker stale on the previous episode's tracks. The fix gates the suppression on the href matching the one captured when the picker opened, so spurious `loadedmetadata` firings on the same video are still suppressed, but soft-navigations correctly dismiss and refresh. A second guard separately suppresses refresh when subtitles are already synced for the current href, so spurious firings during normal watching (picker closed) also do not clear loaded subtitles.

### Blast radius

The *symptom* is only observed on Hulu so far, but the *code paths* this PR modifies are shared by every page script asbplayer binds to:

- `binding.ts` `videoChangeListener` (fires on every bound video element's `loadedmetadata`), plus synced-state bookkeeping in `_updateSubtitles`, `_resetSubtitles`, and `unbind`
- `video-data-sync-controller.ts` `requestSubtitles`, `_setSyncedData`, `_prepareShow`, `_hideAndResume`, `unbind`, and the new explicit `cancel` handler

The new guards should be no-ops for sites that do not fire media-change events while the picker is open, and the play-blocker only has an effect if the page or player tries to resume playback while the picker is open. Because the code paths are shared, regression testing should sample across the streaming ecosystem rather than only the obviously-affected sites.

### Changes

**`extension/src/services/binding.ts`**

The `videoChangeListener` body now has two guards. The first skips refresh when the picker is already open at `window.location.href` (captured when the picker opened). The second skips refresh when subtitles are already synced for `window.location.href` (tracked via `_lastSyncedLocation`, set in `_updateSubtitles` and cleared in `_resetSubtitles` and `unbind`). While either guard holds, `_updateRegisteredVideoSrc` still runs (internal src tracking) but `requestSubtitles` and `_resetSubtitles` are skipped, so subs the user already had loaded stay loaded across spurious `loadedmetadata` firings. On a true soft-navigation (different href), both guards fall through and the listener refreshes for the new video.

**`extension/src/controllers/video-data-sync-controller.ts`**

New public `pickerVisible` and `openedLocation` getters expose picker state (visibility, and the href captured when the picker opened) to the binding without poking at private fields.

`requestSubtitles` returns early when the picker is open on the same href, so spurious `loadedmetadata` firings can no longer clear `_syncedData` or re-dispatch `asbplayer-get-synced-data` while the user is interacting. When called with the picker open on a different href (a soft-navigation), it dismisses the stale picker via `_hideAndResume` and proceeds with the fresh fetch.

`_setSyncedData` gates the auto-sync apply (`_syncData(autoSelectedTracks)`), the failure prompt (`show(...)`), and the trailing model `updateState` on `!this.pickerVisible`. One exception preserves the loading-to-loaded transition: if the picker was opened before subtitle data had arrived (`_syncedData.subtitles === undefined`), the first `_setSyncedData` event still pushes a model update into the visible picker so it can move from loading to populated. `wasLoading` is captured from `_syncedData?.subtitles` being undefined before the new data is assigned.

`_prepareShow` captures `window.location.href` and installs a `play` event listener on the video that immediately re-pauses via `this._context.pause()`. Both are cleaned up from `_hideAndResume`: the location is cleared, and the listener is removed via a new `_cleanupPlayBlocker` helper.

`unbind` now also calls `_cleanupPlayBlocker` and clears the captured location, so neither the play listener nor the picker-session marker leaks if the controller is torn down with the picker still open.

A new explicit `cancel` command handler now calls `_hideAndResume` instead of relying on cancel falling through the default `dataWasSynced = true` path implicitly.

### Tested

The below were tested successfully (sites not tested are noted).

Direct verification of the fix:

- Hulu: video playing, open picker, change track without confirming, wait 30+ seconds. Hulu's setTimeout fires play() during that window. Verify the video does not visibly resume (the play blocker re-pauses immediately). Dropdown stays where you put it. Cancel restores playback with the previously-applied track. Confirm applies the new one.
- Hulu soft-nav: open picker on Episode 1 (do not confirm). Trigger Next Episode (autoplay or click). The picker should dismiss and refresh for Episode 2's tracks instead of staying on Episode 1's.

Regression smoke across the ecosystem (sampling sites that bind to asbplayer):

- Direct inferTracks callers (Disney+, SVT Play): open subtitle picker. Tracks load. Cancel and Confirm behave as before. Auto-sync on initial page load (picker hidden) still applies the saved preference correctly. (Did not test Bandai Channel, NRK TV, TVer, Bilibili, but ideally they would receive testing as well.)
- Helper-routed inferTracks users (HBO Max, UR Play): smoke test that subtitle picker still loads on a representative video. (Did not test Disney+ Apps, iWantTFC, OSN Plus, Viki, Yle Areena, but ideally they would receive testing as well.)
- Page-scripted sites that don't use inferTracks (Amazon Prime, Netflix): subtitle picker still opens and existing subtitle workflows behave as before. (Did not test Emby/Jellyfin, Plex, Stremio, but ideally they would receive testing as well.)
- Binding-only sites without page scripts (Twitch, Archive.org): subtitle picker still reachable via file open / drag, no regression in behavior.

Cold-load edge case:

- Open a watch URL on any `inferTracks`-using site and immediately invoke the subtitle picker shortcut. Picker should transition from loading state to populated once tracks arrive (not stay stuck in loading).

### Known limitations

If the picker opens while subtitle data is still loading and the user edits the Video Name field before tracks arrive, the loading-to-loaded refresh may overwrite their edit (inferred from how `updateState` rebuilds the model, not verified empirically against the React UI). This is narrow (there is little useful metadata to edit before tracks appear anyway), and the alternative (leaving the picker stuck in loading state forever until reopened) is worse.

Separately, the href-based soft-navigation detection assumes the SPA updates `window.location.href` before or at the same time as the new video's `loadedmetadata` fires. On sites where the URL update lags the player event (Hulu's `/v6/playlist` was observed firing 343-620ms before the URL settled, for example), a fast next-episode transition could fire `loadedmetadata` ahead of the URL update, in which case the picker would not refresh. The fix is still a strict improvement over the prior behavior (which never refreshed on soft-nav), but a fully bulletproof solution would need a signal independent of `window.location.href` such as a page-script-supplied generation counter, which is out of scope here.

### Ordering against the Hulu subtitle rewrite

This PR has no code dependency on the Hulu subtitle rewrite (PR #1027). The changes here work on their own. But the bug it fixes was latent in asbplayer until the Hulu rewrite made synced-data responses reliable on repeated requests, which is what now exposes this picker-state behavior.

**Ideally, PR #1027 should land after or alongside this one** to avoid a window where Hulu users get the working subtitle detection fix but also start hitting the newly-exposed picker bug.

### Unrelated observation during testing

While running the test plan on Disney+, hit a "Data Sync failed: Failed to fetch" error when selecting Swedish subtitles in asbplayer after Disney+'s own native UI had already loaded the Swedish track. Other languages worked, only Swedish failed, and a page refresh fixed it. The error originates from `_syncDataArray` when one of the segmented subtitle fetches rejects. Most plausible cause is that Disney+'s segmented subtitle URLs are tokenized or single-use, so once Disney+'s own player has consumed them they cannot be re-fetched by the extension.

This code path is not modified by this PR and the behavior is pre-existing. Flagging as an observation, not something this PR addresses or claims to fix.

### Additional notes

`yarn run verify` ran successfully with no errors after all of the changes made in this pull request. Both the Chrome and Firefox extensions were tested.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
