### PR TITLE
Fix Hulu silently dropping non-first subtitle tracks

### DIFF
--- a/extension/src/entrypoints/hulu-page.ts
+++ b/extension/src/entrypoints/hulu-page.ts
@@ -1,151 +1,129 @@
-import { VideoDataSubtitleTrack } from '@project/common';
-import { extractExtension, trackFromDef } from '@/pages/util';
+import { VideoDataSubtitleTrackDef } from '@project/common';
+import { extractExtension, inferTracks, poll } from '@/pages/util';
 
 export default defineUnlistedScript(() => {
-    setTimeout(() => {
-        function isObject(val: any) {
-            return typeof val === 'object' && !Array.isArray(val) && val !== null;
+    const tracksByEntityId = new Map<string, VideoDataSubtitleTrackDef[]>();
+
+    function entityIdFromEabId(eabId: unknown): string | undefined {
+        if (typeof eabId !== 'string') {
+            return undefined;
         }
+        const m = eabId.match(/^EAB::([0-9a-fA-F-]+)/);
+        return m ? m[1] : undefined;
+    }
 
-        function extractSubtitleTracks(value: any) {
-            const subtitles = [];
-            if (isObject(value.transcripts_urls?.webvtt)) {
-                const urls = value.transcripts_urls.webvtt;
+    function entityIdFromPathname(pathname: string): string | undefined {
+        const m = pathname.match(/^\/watch\/([0-9a-fA-F-]+)/);
+        return m ? m[1] : undefined;
+    }
 
-                for (const language of Object.keys(urls)) {
-                    const url = urls[language];
-
-                    if (typeof url === 'string') {
-                        if (subtitles.find((s) => s.label === s.language) === undefined) {
-                            subtitles.push(
-                                trackFromDef({
+    const originalFetch = window.fetch;
+    window.fetch = function (...args) {
+        // @ts-ignore
+        const promise = originalFetch.apply(this, args);
+        const input = args[0];
+        const url =
+            typeof input === 'string'
+                ? input
+                : input instanceof Request
+                  ? input.url
+                  : input instanceof URL
+                    ? input.href
+                    : '';
+        if (url.includes('play.hulu.com/v6/playlist')) {
+            promise
+                .then((response) => response.clone().json())
+                .then((json) => {
+                    // Key by entityId from the response itself. Hulu sometimes fires
+                    // the next video's playlist before updating window.location, so
+                    // the URL is not a reliable identifier at fetch time.
+                    const entityId = entityIdFromEabId(json?.content_eab_id);
+                    if (!entityId) {
+                        return;
+                    }
+                    const urls = json?.transcripts_urls?.webvtt;
+                    const tracks: VideoDataSubtitleTrackDef[] = [];
+                    if (urls && typeof urls === 'object' && !Array.isArray(urls)) {
+                        for (const language of Object.keys(urls)) {
+                            const u = urls[language];
+                            if (typeof u === 'string') {
+                                tracks.push({
                                     label: language,
                                     language: language.toLowerCase(),
-                                    url: url,
-                                    extension: extractExtension(url, 'vtt'),
-                                })
-                            );
+                                    url: u,
+                                    extension: extractExtension(u, 'vtt'),
+                                });
+                            }
                         }
                     }
-                }
+                    tracksByEntityId.set(entityId, tracks);
+                })
+                .catch(() => {});
+        }
+        return promise;
+    };
+
+    function basenameFromDOM(): string | undefined {
+        for (const pm of document.querySelectorAll('[data-testid="player-metadata"]')) {
+            const text = (pm.textContent || '').trim();
+            if (text.startsWith('UP NEXT')) {
+                continue;
             }
 
-            return subtitles;
-        }
-
-        let playlistController: AbortController | undefined;
-
-        function fetchPlaylistAndExtractSubtitles(payload: any): Promise<VideoDataSubtitleTrack[]> {
-            playlistController?.abort();
-            return new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    playlistController?.abort();
-                    playlistController = new AbortController();
-                    fetch('https://play.hulu.com/v6/playlist', {
-                        method: 'POST',
-                        credentials: 'include',
-                        headers: { 'content-type': 'application/json' },
-                        body: payload,
-                        signal: playlistController.signal,
-                    })
-                        .then((response) => response.json())
-                        .then((json) => resolve(extractSubtitleTracks(json)))
-                        .catch(reject);
-                }, 0);
-            });
-        }
-
-        function extractBasename(payload: any) {
-            if (payload?.items instanceof Array && payload.items.length > 0) {
-                const item = payload.items[0];
-                if (item.series_name && item.season_short_display_name && item.number && item.name) {
-                    return `${item.series_name}.${item.season_short_display_name}.E${item.number} - ${item.name}`;
-                }
-
-                return item.name ?? '';
+            const series = pm.querySelector('span')?.textContent?.trim();
+            if (!series) {
+                continue;
             }
 
-            return '';
-        }
-
-        let upnextController: AbortController | undefined;
-
-        function fetchUpNextAndExtractBasename(eabId: string): Promise<string> {
-            upnextController?.abort();
-            return new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    upnextController?.abort();
-                    upnextController = new AbortController();
-                    fetch(
-                        `https://discover.hulu.com/content/v3/browse/upnext?current_eab=${encodeURIComponent(
-                            eabId
-                        )}&referral_host=www.hulu.com&schema=4`,
-                        { signal: upnextController.signal }
-                    )
-                        .then((response) => response.json())
-                        .then((json) => resolve(extractBasename(json)))
-                        .catch(reject);
-                }, 0);
-            });
-        }
-
-        let subtitlesPromise: Promise<VideoDataSubtitleTrack[]> | undefined;
-        let basenamePromise: Promise<string> | undefined;
-
-        const originalStringify = JSON.stringify;
-        JSON.stringify = function (value) {
-            // @ts-ignore
-            const stringified = originalStringify.apply(this, arguments);
-            if (
-                typeof value?.content_eab_id === 'string' &&
-                typeof value?.playback === 'object' &&
-                value?.playback !== null
-            ) {
-                subtitlesPromise = fetchPlaylistAndExtractSubtitles(stringified);
-                basenamePromise = fetchUpNextAndExtractBasename(value.content_eab_id);
+            const divs = Array.from(pm.querySelectorAll('div')).map((d) => (d.textContent || '').trim());
+            const seasonEpIdx = divs.findIndex((t) => /^S\d+\s+E\d+$/.test(t));
+            if (seasonEpIdx === -1) {
+                return series;
             }
 
-            return stringified;
-        };
+            const seasonEp = divs[seasonEpIdx].replace(/\s+/g, '.');
+            const title = divs[seasonEpIdx + 2];
+            if (!title || title === '•' || title === '-') {
+                return `${series}.${seasonEp}`;
+            }
+            return `${series}.${seasonEp} - ${title}`;
+        }
+        return undefined;
+    }
 
-        document.addEventListener(
-            'asbplayer-get-synced-data',
-            async () => {
-                let basename = '';
-                let subtitles: VideoDataSubtitleTrack[] = [];
-                let error = '';
+    inferTracks({
+        onRequest: async (addTrack, setBasename) => {
+            const entityId = entityIdFromPathname(window.location.pathname);
+            if (!entityId) {
+                return;
+            }
 
-                try {
-                    if (basenamePromise !== undefined) {
-                        basename = await basenamePromise;
-                        basenamePromise = undefined;
-                    }
+            // Wait for Hulu's own /v6/playlist response to be observed by the fetch wrapper.
+            await poll(() => tracksByEntityId.has(entityId));
+            const tracks = tracksByEntityId.get(entityId);
+            if (!tracks) {
+                return;
+            }
 
-                    if (subtitlesPromise !== undefined) {
-                        subtitles = await subtitlesPromise;
-                        subtitlesPromise = undefined;
-                    }
-                } catch (e) {
-                    if (e instanceof Error) {
-                        error = e.message;
-                    } else {
-                        error = String(e);
-                    }
-                }
+            // Wait briefly for the DOM-driven basename to appear.
+            let basename: string | undefined;
+            await poll(() => {
+                basename = basenameFromDOM();
+                return basename !== undefined;
+            }, 5000);
 
-                const response = {
-                    error: error,
-                    basename: basename,
-                    subtitles: subtitles,
-                };
+            // Bail if the user has soft-navigated to a different video since this request started.
+            if (entityIdFromPathname(window.location.pathname) !== entityId) {
+                return;
+            }
 
-                document.dispatchEvent(
-                    new CustomEvent('asbplayer-synced-data', {
-                        detail: response,
-                    })
-                );
-            },
-            false
-        );
-    }, 0);
+            if (basename) {
+                setBasename(basename);
+            }
+            for (const track of tracks) {
+                addTrack(track);
+            }
+        },
+        waitForBasename: false,
+    });
 });

--- a/extension/src/pages.json
+++ b/extension/src/pages.json
@@ -69,6 +69,9 @@
             "autoSync": {
                 "enabled": true,
                 "elementId": "content-video-player"
+            },
+            "ignoreVideoElements": {
+                "class": "VideoPreviewPlayer"
             }
         },
         {


### PR DESCRIPTION
### Summary

The Hulu page script's subtitle dedup filter was unconditionally dropping every track after the first whenever Hulu's webvtt object keys were already lowercase, which is the common case. Symptom: only English subtitles ever appeared, and Spanish (or any other language) was silently missing from the picker.

The old `extractSubtitleTracks` dedup check compared each existing subtitle's own `label` to its own `language`. But the loop builds entries with `label: language, language: language.toLowerCase()`, so for an already-lowercase key the two are equal, the filter matches the just-added track, and the next iteration's push is skipped. Verified by capturing a real `/v6/playlist` response in a live tab. The webvtt keys came back as `["en", "es"]`.

This PR refactors `hulu-page.ts` to use `inferTracks` (the shared helper used directly or through page utilities by other streaming scripts) plus a `window.fetch` wrapper that observes Hulu's own `/v6/playlist` response. Basename comes from a DOM scrape of `[data-testid="player-metadata"]`. This eliminates the previous architecture's duplicate POST to `/v6/playlist` (whose response carried session tokens like `sauron_id` and `sauron_token` and risked registering a second Hulu playback session against the user's account) and the `/upnext` GET.

Cached tracks are keyed by entityId extracted from the response's `content_eab_id` field, not by `window.location.pathname`. Hulu's in-player next-video button issues the new video's `/v6/playlist` request several hundred milliseconds before it updates the URL via `replaceState`. Keying by pathname at fetch time would file the new video's tracks under the previous URL. Keying by the `entityId` from the response is the reliable identifier for this flow.

The PR also adds an `ignoreVideoElements` config in `pages.json` for Hulu's `VideoPreviewPlayer` element (the up-next preview player). It has a valid blob `src` and would otherwise become a second binding, triggering asbplayer's multi-video element picker every time the subtitle picker is invoked.

### Tested

Testing was done on hulu.com in the US with various movies/series, and they work as desired.  Testing done included:

- Verified Hulu episode with English + Spanish subtitles shows both tracks.
- Verified in-player next-video navigation shows the new video's tracks and basename.
- Verified subtitle picker opens without the multi-video element prompt.
- Spot-checked episode and movie basename extraction.

### Known limitation

The new flow passively observes Hulu's own `/v6/playlist` fetch rather than actively re-POSTing as the previous implementation did. If the page script injects after Hulu has already fetched the playlist, such as when the extension is enabled late or asbplayer is toggled mid-session, there is nothing to observe and subtitles will be unavailable until the next `/v6/playlist` fires, typically on episode navigation or page reload. This is a deliberate tradeoff to avoid the duplicate POST and second-session-token risk in the previous active re-fetch approach.

### Ordering against the subtitle picker fix

This PR has no code dependency on the subtitle picker stability fix (PR #1026). The changes here work on their own. But the Hulu rewrite makes synced-data responses reliable on repeated requests, which exposes a latent picker-state bug on Hulu that the picker stability PR fixes.

**Ideally, PR #1026 should land before or alongside this one** to avoid a window where Hulu users get working subtitle detection but also start hitting the newly-exposed picker bug.

### Additional notes

`yarn run verify` ran successfully with no errors after all of the changes made in this pull request. Both the Chrome and Firefox extensions were tested.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).