### PR TITLE
Allow statistics drawer when no extension is installed

### DIFF
--- a/common/app/components/App.tsx
+++ b/common/app/components/App.tsx
@@ -1684,6 +1684,7 @@ function App({
                                 onAnki={handleAnki}
                             />
                             <StatisticsDrawer
+                                mediaId={extension.id}
                                 open={statisticsOpen}
                                 settings={settings}
                                 dictionaryProvider={dictionaryProvider}


### PR DESCRIPTION
Statistics were not working for the drawer if no extension was installed since the `mediaId` wasn't being passed to it. When an extension is installed it always uses the `SidePanel` which hides this issue.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).