### PR TITLE
Fix: seek-timestamp command active tab restriction

### DIFF
--- a/extension/src/services/web-socket-client-binding.ts
+++ b/extension/src/services/web-socket-client-binding.ts
@@ -125,18 +125,24 @@ export const bindWebSocketClient = async (settings: SettingsProvider, tabRegistr
     client.onSeekTimestamp = async ({ body: { timestamp } }: SeekTimestampCommand) => {
         return new Promise<void>((resolve) => {
             // Publish the command to all active video elements
-            tabRegistry.publishCommandToVideoElements((videoElement) => {
-                return {
-                    sender: 'asbplayer-extension-to-video',
-                    message: {
-                        command: 'currentTime',
-                        value: timestamp,
-                    },
-                    src: videoElement.src,
-                };
-            });
+            browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+                tabRegistry.publishCommandToVideoElements((videoElement) => {
+                    if (tabs.find((t) => t.id === videoElement.tab.id) === undefined) {
+                        return undefined;
+                    }
 
-            resolve();
+                    return {
+                        sender: 'asbplayer-extension-to-video',
+                        message: {
+                            command: 'currentTime',
+                            value: timestamp,
+                        },
+                        src: videoElement.src,
+                    };
+                });
+
+                resolve();
+            });
         });
     };
 };

--- a/extension/src/services/web-socket-client-binding.ts
+++ b/extension/src/services/web-socket-client-binding.ts
@@ -124,7 +124,7 @@ export const bindWebSocketClient = async (settings: SettingsProvider, tabRegistr
     };
     client.onSeekTimestamp = async ({ body: { timestamp } }: SeekTimestampCommand) => {
         return new Promise<void>((resolve) => {
-            // Publish the command to all active video elements
+            // Publish the command to the active tab video element
             browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
                 tabRegistry.publishCommandToVideoElements((videoElement) => {
                     if (tabs.find((t) => t.id === videoElement.tab.id) === undefined) {


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
- [x] Ran `yarn verify` - All passed

Current Issue:

- The seek-timestamp command will seek on all video tabs instead the active/focused tab. 

The fix:

- Only send the seek command to the active tab, using the same browser tabs query
  pattern already used in `client.onMineSubtitle`.