### PR TITLE
retain newlines from mecab tokenize

### DIFF
--- a/common/dictionary-db/dictionary-db-anki.ts
+++ b/common/dictionary-db/dictionary-db-anki.ts
@@ -826,7 +826,9 @@ async function _buildTokensForTracks(
                             const tokenCardsMap = sourceTokensMap.get(source)!;
                             const field = card.fields.get(ankiField);
                             if (!field) continue;
-                            for (const tokenParts of await ts.yomitan.tokenize(field)) {
+                            const tokenizeRes = await ts.yomitan.tokenize(field);
+                            ts.yomitan.verifyTokenizeResult(field, tokenizeRes);
+                            for (const tokenParts of tokenizeRes) {
                                 const trimmedToken = tokenParts
                                     .map((p) => p.text)
                                     .join('')

--- a/common/dictionary-db/dictionary-db-wanikani.ts
+++ b/common/dictionary-db/dictionary-db-wanikani.ts
@@ -621,7 +621,9 @@ async function _buildWaniKaniTokensForTrack(
                 await ts.yomitan.tokenizeBulk(subjectsToTokenize.map((subject) => subject.characters));
                 for (const { subjectId, characters } of subjectsToTokenize) {
                     const tokens = new Set<string>();
-                    for (const tokenParts of await ts.yomitan.tokenize(characters)) {
+                    const tokenizeRes = await ts.yomitan.tokenize(characters);
+                    ts.yomitan.verifyTokenizeResult(characters, tokenizeRes);
+                    for (const tokenParts of tokenizeRes) {
                         const token = tokenParts
                             .map((part) => part.text)
                             .join('')

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -1629,6 +1629,8 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
             if (!ts.yt) throw new Error(`Yomitan not initialized for Track${ts.track + 1}`);
             const tokenizeRes = await ts.yt.tokenize(fullText);
             if (this.shouldCancelBuild) return;
+            ts.yt.verifyTokenizeResult(fullText, tokenizeRes);
+
             const tokens: Token[] = [];
             let currentOffset = 0;
             let reconstructedTextParts = [];

--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -418,6 +418,10 @@ export function isNumeric(str: string) {
 
 export const HAS_LETTER_REGEX = /\p{L}/u;
 
+export const NEWLINES_REGEX = /\r?\n/g;
+
+export const STERM_AND_NEWLINES_REGEX = /(?:\p{STerm}|\r?\n)+/u;
+
 export const ONLY_ASCII_LETTERS_REGEX = /^[a-z]+$/i;
 
 const KANA_ONLY_REGEX =

--- a/common/yomitan/yomitan.ts
+++ b/common/yomitan/yomitan.ts
@@ -359,6 +359,14 @@ export class Yomitan {
         }
     }
 
+    verifyTokenizeResult(originalText: string, tokenizeRes: TokenPart[][]): void {
+        const originalTextFromTokenize = tokenizeRes.map((t) => t.map((p) => p.text).join('')).join('');
+        if (originalTextFromTokenize === originalText) return;
+        throw new Error(
+            `Tokenize result does not match the original text:\n${originalText}\n--->\n${originalTextFromTokenize}`
+        );
+    }
+
     private extractLemmaFromMecab(token: string, tokenPart: TokenPartResult): void {
         if (!this.getSupportsMecabLemma()) return;
         const lemmas: string[] = [];

--- a/common/yomitan/yomitan.ts
+++ b/common/yomitan/yomitan.ts
@@ -1,6 +1,14 @@
 import { Fetcher, HttpFetcher, Progress } from '@project/common';
 import { DictionaryTrack } from '@project/common/settings';
-import { AsyncSemaphore, fromBatches, HAS_LETTER_REGEX, inBatches, isKanaOnly } from '@project/common/util';
+import {
+    AsyncSemaphore,
+    fromBatches,
+    HAS_LETTER_REGEX,
+    inBatches,
+    isKanaOnly,
+    NEWLINES_REGEX,
+    STERM_AND_NEWLINES_REGEX,
+} from '@project/common/util';
 import { coerce, lt, gte } from 'semver';
 
 const TOKENIZE_BATCH_SIZE = 100; // 1k can cause 1.5GB memory on Yomitan for subtitles, Anki cards may be larger too
@@ -150,7 +158,7 @@ export class Yomitan {
     ): Promise<TokenPart[][]> {
         return this.tokenizeBulk(
             text
-                .split(/(?:\p{STerm}|\r?\n)+/u)
+                .split(STERM_AND_NEWLINES_REGEX)
                 .map((p) => p.trim())
                 .filter((p) => HAS_LETTER_REGEX.test(p)),
             statusUpdates,
@@ -174,7 +182,10 @@ export class Yomitan {
         if (!Array.isArray(res)) throw new Error(`Unexpected Yomitan tokenize response: ${JSON.stringify(res)}`);
         const tokenizeResults = this.filterDictionaries(res, this.dt.dictionaryYomitanParser);
 
-        for (const tokenizeResult of tokenizeResults) this.cacheFromTokenize(tokenizeResult, tokens); // Requires this.filterDictionaries to ensure one tokenizeResult per index
+        const newlines: { text: string; index: number }[] = [];
+        for (const m of text.matchAll(NEWLINES_REGEX)) newlines.push({ text: m[0], index: m.index });
+
+        for (const tokenizeResult of tokenizeResults) this.cacheFromTokenize(tokenizeResult, tokens, newlines); // Requires this.filterDictionaries to ensure one tokenizeResult per index
         this.tokenizeCache.set(text, tokens);
         return tokens;
     }
@@ -193,6 +204,7 @@ export class Yomitan {
                     const tokensByText: TokenPart[][][] = [];
                     const textsToFetch: string[] = [];
                     const fetchedTextIndices: number[] = [];
+                    const newlinesByText: { text: string; index: number }[][] = [];
                     for (const [index, text] of texts.entries()) {
                         const tokensForText = this.tokenizeCache.get(text);
                         if (tokensForText) {
@@ -201,6 +213,9 @@ export class Yomitan {
                         }
                         textsToFetch.push(text);
                         fetchedTextIndices.push(index);
+                        const newlines: { text: string; index: number }[] = [];
+                        for (const m of text.matchAll(NEWLINES_REGEX)) newlines.push({ text: m[0], index: m.index });
+                        newlinesByText.push(newlines);
                     }
                     if (!textsToFetch.length) return tokensByText.flat();
 
@@ -225,7 +240,7 @@ export class Yomitan {
                     // Requires this.filterDictionaries to ensure one tokenizeResult per index
                     for (const tokenizeResult of tokenizeResults) {
                         const tokensForText: TokenPart[][] = [];
-                        this.cacheFromTokenize(tokenizeResult, tokensForText);
+                        this.cacheFromTokenize(tokenizeResult, tokensForText, newlinesByText[tokenizeResult.index]);
                         this.tokenizeCache.set(textsToFetch[tokenizeResult.index], tokensForText);
                         tokensByText[fetchedTextIndices[tokenizeResult.index]] = tokensForText;
                     }
@@ -309,15 +324,26 @@ export class Yomitan {
         return results;
     }
 
-    private cacheFromTokenize(tokenizeResult: TokenizeResult, tokensForText: TokenPartResult[][]): void {
+    private cacheFromTokenize(
+        tokenizeResult: TokenizeResult,
+        tokensForText: TokenPartResult[][],
+        newlines: { text: string; index: number }[]
+    ): void {
+        let currIndex = 0;
         for (const tokenParts of tokenizeResult.content) {
-            tokensForText.push(tokenParts);
             const tokenPart = tokenParts[0];
-            if (!tokenPart) return;
-            const token = tokenParts
-                .map((p) => p.text)
-                .join('')
-                .trim();
+            if (!tokenPart) continue;
+
+            const tokenText = tokenParts.map((p) => p.text).join('');
+            currIndex += tokenText.length;
+            while (newlines.length && newlines[0].index < currIndex) {
+                const { text } = newlines.shift()!;
+                if (tokenText.includes(text)) continue; // scanning-parser includes newlines
+                tokensForText.push([{ text, reading: '' }]);
+                currIndex += text.length;
+            }
+            tokensForText.push(tokenParts);
+            const token = tokenText.trim();
 
             if (!this.lemmatizeCache.has(token)) this.extractLemmaFromMecab(token, tokenPart);
 
@@ -326,6 +352,10 @@ export class Yomitan {
                 if (!this.lemmatizeCache.has(token)) this.extractLemmas(token, headwords);
                 if (!this.frequencyCache.has(token)) this.extractFrequencyFromTokenize(token, headwords);
             }
+        }
+        while (newlines.length) {
+            const { text } = newlines.shift()!;
+            tokensForText.push([{ text, reading: '' }]);
         }
     }
 


### PR DESCRIPTION
I can't believe I missed this during the original implementation but the `MeCab` parser drops newlines at the end of tokens unlike the `scanning-parser`. This means subtitles with multiple lines were being reduced to a single line.

The solution is to record the positions of the newlines before sending to be to tokenize so that we can re-add them at the correct positions after.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
