### PR TITLE
Feat/get-bound-media command

### DIFF
--- a/common/app/components/App.tsx
+++ b/common/app/components/App.tsx
@@ -1148,6 +1148,7 @@ function App({
         if (inVideoPlayer) {
             extension.videoPlayer = true;
             extension.loadedSubtitles = false;
+            extension.setSubtitleTracks([], []);
             extension.syncedVideoElement = undefined;
             extension.startHeartbeat();
             return undefined;
@@ -1234,6 +1235,10 @@ function App({
         const unsubscribe = extension.subscribe(onMessage);
         extension.videoPlayer = false;
         extension.loadedSubtitles = subtitles.length > 0;
+        extension.setSubtitleTracks(
+            subtitles,
+            sources.subtitleFiles.map((f) => f.name)
+        );
         extension.syncedVideoElement = tab;
         extension.startHeartbeat();
         return unsubscribe;
@@ -1243,6 +1248,7 @@ function App({
         supportsDictionaryStatistics,
         inVideoPlayer,
         sources.videoFileUrl,
+        sources.subtitleFiles,
         statisticsOverlayOpen,
         tab,
         handleFiles,

--- a/common/app/services/chrome-extension.ts
+++ b/common/app/services/chrome-extension.ts
@@ -25,6 +25,7 @@ import {
     AddProfileMessage,
     RemoveProfileMessage,
     RequestSubtitlesFromAppMessage,
+    SubtitleTrack,
     LoadSubtitlesMessage,
     RequestCopyHistoryMessage,
     RequestCopyHistoryResponse,
@@ -54,6 +55,7 @@ import {
     AckTabsMessage,
     BrowserFeatures,
 } from '@project/common';
+import { buildSubtitleTracks } from '@project/common/util';
 import { DictionaryStatisticsSnapshot } from '@project/common/dictionary-statistics';
 import {
     DictionaryLocalTokenInput,
@@ -109,6 +111,7 @@ export default class ChromeExtension {
     videoPlayer: boolean | undefined;
     syncedVideoElement: VideoTabModel | undefined;
     loadedSubtitles: boolean = false;
+    subtitleTracks: SubtitleTrack[] = [];
 
     private readonly windowEventListener: (event: MessageEvent) => void;
     private readonly _responseResolves: { [key: string]: (value: any) => void } = {};
@@ -169,6 +172,7 @@ export default class ChromeExtension {
                         sidePanel: this.sidePanel,
                         sidePanelAppRequestedLocation: this.sidePanelAppRequestedLocation,
                         loadedSubtitles: this.loadedSubtitles,
+                        subtitleTracks: this.subtitleTracks,
                         syncedVideoElement: this.syncedVideoElement,
                         videoPlayer: this.videoPlayer ?? false,
                     };
@@ -309,6 +313,10 @@ export default class ChromeExtension {
         return id;
     }
 
+    setSubtitleTracks(subtitles: { track: number }[], subtitleFileNames: string[]) {
+        this.subtitleTracks = buildSubtitleTracks(subtitles, subtitleFileNames);
+    }
+
     startHeartbeat() {
         if (!this.installed) {
             return;
@@ -349,6 +357,7 @@ export default class ChromeExtension {
             sidePanel: this.sidePanel,
             sidePanelAppRequestedLocation: this.sidePanelAppRequestedLocation,
             loadedSubtitles,
+            subtitleTracks: this.subtitleTracks,
             syncedVideoElement,
         };
         window.postMessage({

--- a/common/src/message.ts
+++ b/common/src/message.ts
@@ -14,6 +14,7 @@ import type { DictionaryStatisticsSnapshot } from '../dictionary-statistics';
 import {
     RectModel,
     SubtitleModel,
+    SubtitleTrack,
     AudioTrackModel,
     AnkiUiSavedState,
     ConfirmedVideoDataSubtitleTrack,
@@ -53,6 +54,7 @@ export interface AsbplayerInstance {
     timestamp: number;
     videoPlayer: boolean;
     loadedSubtitles: boolean;
+    subtitleTracks?: SubtitleTrack[];
     syncedVideoElement?: VideoTabModel;
 }
 
@@ -64,6 +66,7 @@ export interface AsbplayerHeartbeatMessage extends Message {
     readonly sidePanel?: boolean;
     readonly sidePanelAppRequestedLocation?: SidePanelLocation;
     readonly loadedSubtitles?: boolean;
+    readonly subtitleTracks?: SubtitleTrack[];
     readonly syncedVideoElement?: VideoTabModel;
 }
 
@@ -75,6 +78,7 @@ export interface AckTabsMessage extends Message {
     readonly sidePanel?: boolean;
     readonly sidePanelAppRequestedLocation?: SidePanelLocation;
     readonly loadedSubtitles?: boolean;
+    readonly subtitleTracks?: SubtitleTrack[];
     readonly syncedVideoElement?: VideoTabModel;
 }
 
@@ -91,6 +95,7 @@ export interface VideoHeartbeatMessage extends Message {
     readonly synced: boolean;
     readonly syncedTimestamp?: number;
     readonly loadedSubtitles: boolean;
+    readonly subtitleTracks?: SubtitleTrack[];
 }
 
 export interface VideoDisappearedMessage extends Message {

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -245,6 +245,11 @@ export interface VideoDataUiModel {
     hideRememberTrackPreferenceToggle: boolean;
 }
 
+export interface SubtitleTrack {
+    trackNumber: number;
+    fileName: string;
+}
+
 export interface VideoTabModel {
     id: number; // Actually the tab ID
     title?: string;
@@ -252,6 +257,7 @@ export interface VideoTabModel {
     subscribed: boolean; // Whether the video element is subscribed to extension messages
     synced: boolean; // Whether the video element has received subtitles
     loadedSubtitles: boolean; // Whether a non-empty subtitle track is loaded
+    subtitleTracks?: SubtitleTrack[]; // The loaded non-empty subtitle tracks (track number + file name)
     syncedTimestamp?: number;
     faviconUrl?: string;
 }

--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -1,5 +1,5 @@
 import sanitize from 'sanitize-filename';
-import { Rgb, SubtitleModel, Tokenization, TokenReading } from '../src/model';
+import { Rgb, SubtitleModel, SubtitleTrack, Tokenization, TokenReading } from '../src/model';
 import { TextSubtitleSettings, TokenStatus } from '../settings/settings';
 import { Progress } from '..';
 import { TokenStatusInfo } from '../dictionary-db';
@@ -508,6 +508,11 @@ export function percentToHex2(percent: number): string {
 
 export function sourceString(subtitleFileName: string, timestamp: number) {
     return timestamp === 0 ? subtitleFileName : `${subtitleFileName} (${humanReadableTime(timestamp, true, true)})`;
+}
+
+export function buildSubtitleTracks(subtitles: { track: number }[], subtitleFileNames: string[]): SubtitleTrack[] {
+    const trackNumbers = [...new Set(subtitles.map((s) => s.track))].sort((a, b) => a - b);
+    return trackNumbers.map((trackNumber) => ({ trackNumber, fileName: subtitleFileNames[trackNumber] ?? '' }));
 }
 
 export function seekWithNudge(media: HTMLMediaElement, timestampSeconds: number) {

--- a/common/web-socket-client/web-socket-client.ts
+++ b/common/web-socket-client/web-socket-client.ts
@@ -40,6 +40,30 @@ export interface SeekTimestampCommand {
     };
 }
 
+export interface GetBoundMediaCommand {
+    command: 'get-bound-media';
+    messageId: string;
+    body: {};
+}
+
+export interface BoundMedia {
+    tabId: number;
+    src: string;
+    title?: string;
+    faviconUrl?: string;
+    subscribed: boolean;
+    synced: boolean;
+    loadedSubtitles: boolean;
+    syncedTimestamp?: number;
+    active: boolean;
+    focused: boolean;
+    discarded: boolean;
+}
+
+interface GetBoundMediaResponseBody {
+    media: BoundMedia[];
+}
+
 export class WebSocketClient {
     private _socket?: WebSocket;
     private _pingInterval?: NodeJS.Timeout;
@@ -50,6 +74,7 @@ export class WebSocketClient {
     onMineSubtitle?: (command: MineSubtitleCommand) => Promise<boolean>;
     onLoadSubtitles?: (command: LoadSubtitlesCommand) => Promise<void>;
     onSeekTimestamp?: (command: SeekTimestampCommand) => Promise<void>;
+    onGetBoundMedia?: () => Promise<BoundMedia[]>;
 
     get socket() {
         return this._socket;
@@ -130,6 +155,15 @@ export class WebSocketClient {
                             body: {},
                         };
                         this._socket?.send(JSON.stringify(response));
+                    } else if (payload.command === 'get-bound-media') {
+                        const messageId = payload.messageId;
+                        const media = (await this.onGetBoundMedia?.()) ?? [];
+                        const response: Response<GetBoundMediaResponseBody> = {
+                            command: 'response',
+                            messageId,
+                            body: { media },
+                        };
+                        this._socket?.send(JSON.stringify(response));
                     }
                 }
             };
@@ -199,5 +233,6 @@ export class WebSocketClient {
         this.onMineSubtitle = undefined;
         this.onSeekTimestamp = undefined;
         this.onLoadSubtitles = undefined;
+        this.onGetBoundMedia = undefined;
     }
 }

--- a/common/web-socket-client/web-socket-client.ts
+++ b/common/web-socket-client/web-socket-client.ts
@@ -1,3 +1,7 @@
+import type { SubtitleTrack } from '../src/model';
+
+export type { SubtitleTrack };
+
 export interface MineSubtitleCommand {
     command: 'mine-subtitle';
     messageId: string;
@@ -47,17 +51,12 @@ export interface GetBoundMediaCommand {
 }
 
 export interface BoundMedia {
-    tabId: number;
-    src: string;
+    id: string; // Derived from a hash of `streaming:<tabId>:<src>` or `local:<asbplayerId>`.
+    type: 'streaming' | 'local';
     title?: string;
     faviconUrl?: string;
-    subscribed: boolean;
-    synced: boolean;
-    loadedSubtitles: boolean;
-    syncedTimestamp?: number;
+    loadedSubtitles: SubtitleTrack[];
     active: boolean;
-    focused: boolean;
-    discarded: boolean;
 }
 
 interface GetBoundMediaResponseBody {
@@ -156,14 +155,16 @@ export class WebSocketClient {
                         };
                         this._socket?.send(JSON.stringify(response));
                     } else if (payload.command === 'get-bound-media') {
-                        const messageId = payload.messageId;
-                        const media = (await this.onGetBoundMedia?.()) ?? [];
-                        const response: Response<GetBoundMediaResponseBody> = {
-                            command: 'response',
-                            messageId,
-                            body: { media },
-                        };
-                        this._socket?.send(JSON.stringify(response));
+                        if (this.onGetBoundMedia !== undefined) {
+                            const messageId = payload.messageId;
+                            const media = await this.onGetBoundMedia();
+                            const response: Response<GetBoundMediaResponseBody> = {
+                                command: 'response',
+                                messageId,
+                                body: { media },
+                            };
+                            this._socket?.send(JSON.stringify(response));
+                        }
                     }
                 }
             };

--- a/docs/docs/reference/external-api.md
+++ b/docs/docs/reference/external-api.md
@@ -103,12 +103,64 @@ asbplayer, as a WebSocket client, responds to the following commands from a WebS
 }
 ```
 
+### `get-bound-media`
+
+Returns every `<video>` element asbplayer is currently tracking, keyed by tab and `src`.
+
+#### Request
+
+```javascript
+{
+    "command": "get-bound-media",
+    // Message ID to correlate with asbplayer's response
+    "messageId": "9f1c2b3a-4d5e-6f70-8190-a1b2c3d4e5f6",
+    "body": {}
+}
+```
+
+#### Response
+
+```javascript
+{
+    "command": "response",
+    // Same message ID received in request
+    "messageId": "9f1c2b3a-4d5e-6f70-8190-a1b2c3d4e5f6",
+    "body": {
+        "media": [{
+            // ID of the tab the video element lives in
+            "tabId": 123,
+            // The video element's src; serves as the media's identifier
+            "src": "https://example.com/video.mp4",
+            // Title of the tab
+            "title": "Example video",
+            // Favicon of the tab
+            "faviconUrl": "https://example.com/favicon.ico",
+            // Whether the video element is subscribed to extension messages
+            "subscribed": true,
+            // Whether subtitles have been synced to the video element
+            "synced": true,
+            // Whether a non-empty subtitle track is loaded
+            "loadedSubtitles": true,
+            // When syncing occurred (epoch milliseconds), if synced
+            "syncedTimestamp": 1717000000000,
+            // Whether the tab is the active tab of its window
+            "active": true,
+            // Whether the tab is the active tab of the currently focused window
+            "focused": true,
+            // Whether the tab has been discarded (unloaded from memory) - acting on it may fail
+            "discarded": false
+        }]
+    }
+}
+```
+
 ## HTTP-based API
 
 The WebSocket server also implements an HTTP-based API which can trigger the commands above.
 
 - `POST asbplayer/load-subtitles` ([script](https://github.com/asbplayer/asbplayer/blob/main/scripts/web-socket-server/cli/load-subtitles))
 - `POST asbplayer/seek` ([script](https://github.com/asbplayer/asbplayer/blob/main/scripts/web-socket-server/cli/seek))
+- `GET asbplayer/bound-media` ([script](https://github.com/asbplayer/asbplayer/blob/main/scripts/web-socket-server/cli/bound-media))
 
 ## AnkiConnect proxy
 

--- a/docs/docs/reference/external-api.md
+++ b/docs/docs/reference/external-api.md
@@ -105,7 +105,7 @@ asbplayer, as a WebSocket client, responds to the following commands from a WebS
 
 ### `get-bound-media`
 
-Returns every `<video>` element asbplayer is currently tracking, keyed by tab and `src`.
+Returns the media asbplayer is currently tracking, including both `streaming` and `local` media.
 
 #### Request
 
@@ -127,28 +127,23 @@ Returns every `<video>` element asbplayer is currently tracking, keyed by tab an
     "messageId": "9f1c2b3a-4d5e-6f70-8190-a1b2c3d4e5f6",
     "body": {
         "media": [{
-            // ID of the tab the video element lives in
-            "tabId": 123,
-            // The video element's src; serves as the media's identifier
-            "src": "https://example.com/video.mp4",
-            // Title of the tab
-            "title": "Example video",
-            // Favicon of the tab
+            // Identifier for the media
+            "id": "a1b2c3d4e5f6",
+            // Type of media: "streaming" or "local"
+            "type": "streaming",
+            // Display title for the media, if available
+            "title": "Title of the Video",
+            // Favicon of the tab containing the media, if available
             "faviconUrl": "https://example.com/favicon.ico",
-            // Whether the video element is subscribed to extension messages
-            "subscribed": true,
-            // Whether subtitles have been synced to the video element
-            "synced": true,
-            // Whether a non-empty subtitle track is loaded
-            "loadedSubtitles": true,
-            // When syncing occurred (epoch milliseconds), if synced
-            "syncedTimestamp": 1717000000000,
-            // Whether the tab is the active tab of its window
-            "active": true,
-            // Whether the tab is the active tab of the currently focused window
-            "focused": true,
-            // Whether the tab has been discarded (unloaded from memory) - acting on it may fail
-            "discarded": false
+            // Subtitle tracks currently loaded for this media. Empty if none are loaded.
+            "loadedSubtitles": [{
+                // Track number
+                "trackNumber": 0,
+                // File name of the subtitle track
+                "fileName": "subtitles.srt"
+            }],
+            // Whether the media's tab is the active tab of its window
+            "active": true
         }]
     }
 }

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -68,6 +68,7 @@ import {
 import { SubtitleSlice } from '@project/common/subtitle-collection';
 import { SubtitleReader } from '@project/common/subtitle-reader';
 import {
+    buildSubtitleTracks,
     extractText,
     seekWithNudge,
     sourceString,
@@ -693,6 +694,10 @@ export default class Binding {
                     synced: this._synced,
                     syncedTimestamp: this._syncedTimestamp,
                     loadedSubtitles: this.subtitleController.subtitles.length > 0,
+                    subtitleTracks: buildSubtitleTracks(
+                        this.subtitleController.subtitles,
+                        this.subtitleController.subtitleFileNames ?? []
+                    ),
                 },
                 src,
             };

--- a/extension/src/services/tab-registry.ts
+++ b/extension/src/services/tab-registry.ts
@@ -71,7 +71,7 @@ export default class TabRegistry {
                 this._removeAsbplayersInTab(tabId);
             }
         });
-        
+
         // A replaced tab (e.g. Chrome reactivating a discarded tab under a new id) fires
         // onReplaced, not onRemoved, for the old id...without this the old id's bound
         // media would remain in the registry forever.

--- a/extension/src/services/tab-registry.ts
+++ b/extension/src/services/tab-registry.ts
@@ -9,6 +9,7 @@ import {
     SidePanelLocation,
     VideoHeartbeatMessage,
     VideoTabModel,
+    SubtitleTrack,
 } from '@project/common';
 import { SettingsProvider } from '@project/common/settings';
 
@@ -28,6 +29,7 @@ export interface Asbplayer {
     receivedTabs?: VideoTabModel[];
     videoPlayer: boolean;
     loadedSubtitles?: boolean;
+    subtitleTracks?: SubtitleTrack[];
     syncedVideoElement?: VideoTabModel;
 }
 
@@ -39,6 +41,7 @@ export interface VideoElement {
     synced: boolean;
     syncedTimestamp?: number;
     loadedSubtitles?: boolean;
+    subtitleTracks?: SubtitleTrack[];
 }
 
 export default class TabRegistry {
@@ -200,6 +203,7 @@ export default class TabRegistry {
             sidePanelAppRequestedLocation,
             receivedTabs,
             loadedSubtitles,
+            subtitleTracks,
             syncedVideoElement,
         }: AsbplayerHeartbeatMessage
     ) {
@@ -210,6 +214,7 @@ export default class TabRegistry {
             sidePanel ?? false,
             sidePanelAppRequestedLocation,
             loadedSubtitles ?? false,
+            subtitleTracks,
             receivedTabs,
             syncedVideoElement
         );
@@ -243,6 +248,7 @@ export default class TabRegistry {
             sidePanel,
             sidePanelAppRequestedLocation,
             loadedSubtitles,
+            subtitleTracks,
             receivedTabs,
             syncedVideoElement,
         }: AckTabsMessage
@@ -254,6 +260,7 @@ export default class TabRegistry {
             sidePanel ?? false,
             sidePanelAppRequestedLocation,
             loadedSubtitles ?? false,
+            subtitleTracks,
             receivedTabs,
             syncedVideoElement
         );
@@ -266,6 +273,7 @@ export default class TabRegistry {
         sidePanel: boolean,
         sidePanelAppRequestedLocation: SidePanelLocation | undefined,
         loadedSubtitles: boolean,
+        subtitleTracks: SubtitleTrack[] | undefined,
         receivedTabs: VideoTabModel[] | undefined,
         syncedVideoElement: VideoTabModel | undefined
     ) {
@@ -287,6 +295,7 @@ export default class TabRegistry {
                 sidePanel,
                 sidePanelAppRequestedLocation,
                 loadedSubtitles,
+                subtitleTracks,
                 videoPlayer,
                 syncedVideoElement,
             };
@@ -320,6 +329,7 @@ export default class TabRegistry {
                     subscribed: videoElement.subscribed,
                     synced: videoElement.synced,
                     loadedSubtitles: videoElement.loadedSubtitles ?? false,
+                    subtitleTracks: videoElement.subtitleTracks,
                     syncedTimestamp: videoElement.syncedTimestamp,
                 };
                 activeVideoElements.push(element);
@@ -341,6 +351,7 @@ export default class TabRegistry {
                 timestamp: asbplayer.timestamp,
                 videoPlayer: asbplayer.videoPlayer,
                 loadedSubtitles: asbplayer.loadedSubtitles ?? false,
+                subtitleTracks: asbplayer.subtitleTracks,
                 syncedVideoElement: asbplayer.syncedVideoElement,
             });
         }
@@ -351,7 +362,7 @@ export default class TabRegistry {
     async onVideoElementHeartbeat(
         tab: Browser.tabs.Tab,
         src: string,
-        { subscribed, synced, syncedTimestamp, loadedSubtitles }: VideoHeartbeatMessage
+        { subscribed, synced, syncedTimestamp, loadedSubtitles, subtitleTracks }: VideoHeartbeatMessage
     ) {
         if (tab.id === undefined) {
             return;
@@ -373,6 +384,7 @@ export default class TabRegistry {
                 synced,
                 syncedTimestamp,
                 loadedSubtitles,
+                subtitleTracks,
             };
             return true;
         });

--- a/extension/src/services/tab-registry.ts
+++ b/extension/src/services/tab-registry.ts
@@ -71,6 +71,14 @@ export default class TabRegistry {
                 this._removeAsbplayersInTab(tabId);
             }
         });
+        
+        // A replaced tab (e.g. Chrome reactivating a discarded tab under a new id) fires
+        // onReplaced, not onRemoved, for the old id...without this the old id's bound
+        // media would remain in the registry forever.
+        browser.tabs.onReplaced.addListener((_addedTabId, removedTabId) => {
+            this._removeVideoElementsInTab(removedTabId);
+            this._removeAsbplayersInTab(removedTabId);
+        });
     }
 
     private async _fetchVideoElementState(): Promise<{ [key: string]: VideoElement }> {

--- a/extension/src/services/web-socket-client-binding.ts
+++ b/extension/src/services/web-socket-client-binding.ts
@@ -19,6 +19,30 @@ import {
 
 let client: WebSocketClient | undefined;
 
+// Derives a human-readable title from a subtitle file name by dropping its extension.
+const withoutExtension = (fileName: string) => {
+    const dot = fileName.lastIndexOf('.');
+    return dot > 0 ? fileName.substring(0, dot) : fileName;
+};
+
+// cyrb53 string hash...should be collision resistant and fast to compute
+const cyrb53 = (str: string) => {
+    let h1 = 0xdeadbeef;
+    let h2 = 0x41c6ce57;
+
+    for (let i = 0; i < str.length; i++) {
+        const ch = str.charCodeAt(i);
+        h1 = Math.imul(h1 ^ ch, 2654435761);
+        h2 = Math.imul(h2 ^ ch, 1597334677);
+    }
+
+    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+    return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(36);
+};
+
+const boundMediaId = (key: string) => cyrb53(key);
+
 export const bindWebSocketClient = async (settings: SettingsProvider, tabRegistry: TabRegistry) => {
     client?.unbind();
     const url = await settings.getSingle('webSocketServerUrl');
@@ -148,34 +172,47 @@ export const bindWebSocketClient = async (settings: SettingsProvider, tabRegistr
     };
     client.onGetBoundMedia = async (): Promise<BoundMedia[]> => {
         const videoElements = await tabRegistry.activeVideoElements();
+        const asbplayerInstances = await tabRegistry.asbplayerInstances();
         const allTabs = await browser.tabs.query({});
-        const tabStateById = new Map<number, { active: boolean; discarded: boolean }>();
+        const activeByTabId = new Map<number, boolean>();
 
         for (const tab of allTabs) {
             if (tab.id !== undefined) {
-                tabStateById.set(tab.id, { active: tab.active ?? false, discarded: tab.discarded ?? false });
+                activeByTabId.set(tab.id, tab.active ?? false);
             }
         }
 
-        const focusedTabs = await browser.tabs.query({ active: true, lastFocusedWindow: true });
-        const focusedTabId = focusedTabs[0]?.id;
+        const streamingMedia: BoundMedia[] = videoElements.map((videoElement) => ({
+            id: boundMediaId(`streaming:${videoElement.id}:${videoElement.src}`),
+            type: 'streaming',
+            title: videoElement.title,
+            faviconUrl: videoElement.faviconUrl,
+            loadedSubtitles: videoElement.subtitleTracks ?? [],
+            active: activeByTabId.get(videoElement.id) ?? false,
+        }));
 
-        return videoElements.map((videoElement) => {
-            const tabState = tabStateById.get(videoElement.id);
-            return {
-                tabId: videoElement.id,
-                src: videoElement.src,
-                title: videoElement.title,
-                faviconUrl: videoElement.faviconUrl,
-                subscribed: videoElement.subscribed,
-                synced: videoElement.synced,
-                loadedSubtitles: videoElement.loadedSubtitles,
-                syncedTimestamp: videoElement.syncedTimestamp,
-                active: tabState?.active ?? false,
-                focused: videoElement.id === focusedTabId,
-                discarded: tabState?.discarded ?? false,
-            };
-        });
+        // Include asbplayer webapp instances that have media loaded, excluding side-panel instances
+        const localMedia: BoundMedia[] = asbplayerInstances
+            .filter(
+                (asbplayer) =>
+                    asbplayer.tabId !== undefined &&
+                    !asbplayer.sidePanel &&
+                    asbplayer.syncedVideoElement === undefined &&
+                    asbplayer.loadedSubtitles
+            )
+            .map((asbplayer) => {
+                const loadedSubtitles = asbplayer.subtitleTracks ?? [];
+                const [firstTrack] = loadedSubtitles;
+                return {
+                    id: boundMediaId(`local:${asbplayer.id}`),
+                    type: 'local',
+                    title: firstTrack === undefined ? undefined : withoutExtension(firstTrack.fileName),
+                    loadedSubtitles,
+                    active: activeByTabId.get(asbplayer.tabId!) ?? false,
+                };
+            });
+
+        return [...streamingMedia, ...localMedia];
     };
 };
 

--- a/extension/src/services/web-socket-client-binding.ts
+++ b/extension/src/services/web-socket-client-binding.ts
@@ -1,5 +1,6 @@
 import { SettingsProvider, ankiSettingsKeys } from '@project/common/settings';
 import {
+    BoundMedia,
     LoadSubtitlesCommand,
     MineSubtitleCommand,
     SeekTimestampCommand,
@@ -143,6 +144,37 @@ export const bindWebSocketClient = async (settings: SettingsProvider, tabRegistr
 
                 resolve();
             });
+        });
+    };
+    client.onGetBoundMedia = async (): Promise<BoundMedia[]> => {
+        const videoElements = await tabRegistry.activeVideoElements();
+        const allTabs = await browser.tabs.query({});
+        const tabStateById = new Map<number, { active: boolean; discarded: boolean }>();
+
+        for (const tab of allTabs) {
+            if (tab.id !== undefined) {
+                tabStateById.set(tab.id, { active: tab.active ?? false, discarded: tab.discarded ?? false });
+            }
+        }
+
+        const focusedTabs = await browser.tabs.query({ active: true, lastFocusedWindow: true });
+        const focusedTabId = focusedTabs[0]?.id;
+
+        return videoElements.map((videoElement) => {
+            const tabState = tabStateById.get(videoElement.id);
+            return {
+                tabId: videoElement.id,
+                src: videoElement.src,
+                title: videoElement.title,
+                faviconUrl: videoElement.faviconUrl,
+                subscribed: videoElement.subscribed,
+                synced: videoElement.synced,
+                loadedSubtitles: videoElement.loadedSubtitles,
+                syncedTimestamp: videoElement.syncedTimestamp,
+                active: tabState?.active ?? false,
+                focused: videoElement.id === focusedTabId,
+                discarded: tabState?.discarded ?? false,
+            };
         });
     };
 };

--- a/scripts/web-socket-server/cli/bound-media
+++ b/scripts/web-socket-server/cli/bound-media
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl -H "content-type: application/json" \
+    -X GET "http://127.0.0.1:8766/asbplayer/bound-media"

--- a/scripts/web-socket-server/main.go
+++ b/scripts/web-socket-server/main.go
@@ -318,6 +318,19 @@ func (forwarder forwarder) handleAsbplayerSeekRequest(c echo.Context) error {
 	return nil
 }
 
+func (forwarder forwarder) handleAsbplayerBoundMediaRequest(c echo.Context) error {
+	command := clientCommand{Command: "get-bound-media", MessageId: uuid.NewString(), Body: map[string]interface{}{}}
+	responseChannel := make(chan clientResponse)
+
+	go forwarder.publishMessageAndAwaitResponse(command, responseChannel)
+	response, ok := <-responseChannel
+	if !ok {
+		return echo.NewHTTPError(http.StatusInternalServerError, nil)
+	}
+
+	return c.JSONBlob(http.StatusOK, response.Body)
+}
+
 func (forwarder forwarder) disconnectWebsocketClients(c echo.Context) error {
 	forwarder.Mutex.Lock()
 	defer forwarder.Mutex.Unlock()
@@ -372,6 +385,7 @@ func main() {
 	e.POST("/", forwarder.handlePostRequest)
 	e.POST("/asbplayer/load-subtitles", forwarder.handleAsbplayerLoadSubtitlesRequest)
 	e.POST("/asbplayer/seek", forwarder.handleAsbplayerSeekRequest)
+	e.GET("/asbplayer/bound-media", forwarder.handleAsbplayerBoundMediaRequest)
 	e.OPTIONS("/", forwarder.handleOptionsRequest)
 	e.Logger.Fatal(e.Start(":" + port))
 }


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

This PR adds a new command `get-bound-media` as per part of the discussion here: https://github.com/asbplayer/asbplayer/issues/840

The command returns a list of currently bound media by asbplayer. Each has the following shape:

```ts
export interface BoundMedia {
    tabId: number; 
    src: string; 
    title?: string;
    faviconUrl?: string;
    subscribed: boolean;
    synced: boolean;
    loadedSubtitles: boolean;
    syncedTimestamp?: number;
    
    // Added ontop of the base VideoElement type
    //Is the tab active
    active: boolean; 
    //Is this the focused tab (you can have multiple windows with active tabs, but only one focused window)
    focused: boolean; 
    //Chrome/mozilla will unload tabs that are inactive, in theory this should be set in those cases
    discarded: boolean; 
}
```

### A note about the `browser.tabs.onReplaced` listener 

I noticed while testing that duplicate entries could appear for what seemed to be the same tab, even though there was only one instance of that tab/video open. This appears to happen in Chrome when a discarded/unloaded tab is restored: `browser.tabs.onRemoved` is not called, but `browser.tabs.onReplaced` is. This PR includes a fix for that case.