### PR TITLE
Add JW Player page support

### DIFF
--- a/common/pages/index.ts
+++ b/common/pages/index.ts
@@ -31,4 +31,5 @@ export const pageMetadata: { [K in keyof PageSettings]: PageMetadata } = {
     urplay: { title: 'UR Play', disableCspRuleId: 23 },
     archive: { title: 'Internet Archive', disableCspRuleId: 24 },
     huluJp: { title: 'Hulu Japan', disableCspRuleId: 25 },
+    jwPlayer: { title: 'JW Player', disableCspRuleId: 26 },
 };

--- a/common/settings/settings-provider.test.ts
+++ b/common/settings/settings-provider.test.ts
@@ -141,6 +141,12 @@ it('provides default values for unpopulated, nested settings', async () => {
         ...defaultSettings.ankiFieldSettings,
         url: { order: 12 },
     });
+
+    storage.setData({ streamingPages: { netflix: { additionalHosts: ['example.com'] } } });
+    expect(await provider.getSingle('streamingPages')).toEqual({
+        ...defaultSettings.streamingPages,
+        netflix: { additionalHosts: ['example.com'] },
+    });
 });
 
 it('removes corresponding field settings when custom anki fields are removed', async () => {

--- a/common/settings/settings-provider.ts
+++ b/common/settings/settings-provider.ts
@@ -14,6 +14,7 @@ import {
     TokenMatchStrategy,
     TokenStyling,
     DictionaryTrack,
+    PageSettings,
     TokenReadingAnnotation,
     TokenFrequencyAnnotation,
     getFullyKnownTokenStatus,
@@ -234,6 +235,7 @@ export const defaultSettings: AsbplayerSettings = {
         svtplay: {},
         urplay: {},
         archive: {},
+        jwPlayer: {},
     },
     webSocketClientEnabled: false,
     webSocketServerUrl: 'ws://127.0.0.1:8766/ws',
@@ -530,6 +532,8 @@ export const ensureConsistencyOnRead = (settings: Partial<AsbplayerSettings>) =>
     let newKeyBindSet: any = {};
     let ankiFieldSettingsModified = false;
     let newAnkiFieldSettings: any = {};
+    let streamingPagesModified = false;
+    let newStreamingPages: any = {};
 
     if (settings.keyBindSet !== undefined) {
         const keyBindSet = settings.keyBindSet;
@@ -561,11 +565,31 @@ export const ensureConsistencyOnRead = (settings: Partial<AsbplayerSettings>) =>
         }
     }
 
-    if (!ankiFieldSettingsModified && !keyBindSetModified) {
+    if (settings.streamingPages !== undefined) {
+        const streamingPages = settings.streamingPages;
+
+        for (const key of Object.keys(defaultSettings.streamingPages)) {
+            const pageKey = key as keyof PageSettings;
+
+            if (streamingPages[pageKey] === undefined) {
+                newStreamingPages[pageKey] = defaultSettings.streamingPages[pageKey];
+                streamingPagesModified = true;
+            } else {
+                newStreamingPages[pageKey] = streamingPages[pageKey];
+            }
+        }
+    }
+
+    if (!ankiFieldSettingsModified && !keyBindSetModified && !streamingPagesModified) {
         return settings;
     }
 
-    return { ...settings, ...{ ankiFieldSettings: newAnkiFieldSettings }, ...{ keyBindSet: newKeyBindSet } };
+    return {
+        ...settings,
+        ...(ankiFieldSettingsModified ? { ankiFieldSettings: newAnkiFieldSettings } : {}),
+        ...(keyBindSetModified ? { keyBindSet: newKeyBindSet } : {}),
+        ...(streamingPagesModified ? { streamingPages: newStreamingPages } : {}),
+    };
 };
 
 type SettingsKey = keyof AsbplayerSettings;

--- a/common/settings/settings.ts
+++ b/common/settings/settings.ts
@@ -647,6 +647,7 @@ export interface PageSettings {
     svtplay: Page;
     urplay: Page;
     archive: Page;
+    jwPlayer: Page;
 }
 
 export interface StreamingVideoSettings {

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -588,7 +588,9 @@ export default class VideoDataSyncController {
         }
 
         if (typeof url === 'string') {
-            const response = await fetch(url)
+            const isJwPlayer = (await currentPageDelegate())?.config?.key === 'jwPlayer';
+            const fetchOptions: RequestInit | undefined = isJwPlayer ? { credentials: 'include' } : undefined;
+            const response = await fetch(url, fetchOptions)
                 .catch((error) => this._reportError(error.message))
                 .finally(() => {
                     if (localFile) {
@@ -617,7 +619,9 @@ export default class VideoDataSyncController {
         const firstUri = url[0];
         const partExtension = extractExtension(firstUri, extension);
         const fileName = `${name}.${partExtension}`;
-        const promises = url.map((u) => fetch(u));
+        const isJwPlayer = (await currentPageDelegate())?.config?.key === 'jwPlayer';
+        const fetchOptions: RequestInit | undefined = isJwPlayer ? { credentials: 'include' } : undefined;
+        const promises = url.map((u) => fetch(u, fetchOptions));
         const tracks = [];
         let totalPromises = promises.length;
         let finishedPromises = 0;

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -527,6 +527,204 @@ export default defineBackground(() => {
     }
 
     if (isFirefoxBuild) {
+        const jwPlayerHostRegex = /^(vidwish\.live|watching\.onl|vidcloud\..+|megaplay\.buzz)$/;
+        const subtitlePathRegex = /(?:\/subtitles\/|\.(?:vtt|srt|ass|ssa)(?:$|[?#]))/i;
+        const subtitleRequestPatterns = [
+            '*://*/*/subtitles/*',
+            '*://*/*.vtt*',
+            '*://*/*.srt*',
+            '*://*/*.ass*',
+            '*://*/*.ssa*',
+        ];
+        // JW Player iframe URL registries. Time-bound so stale entries cannot leak
+        // the Referer/Origin rewrite to unrelated requests. Reaped on tab close
+        // and on tab navigation away from a JW Player host. The asbplayer
+        // overlay iframe fetches arrive with tabId === -1, so the
+        // `anyJwPlayer` fallback uses the most recent fresh entry.
+        const JW_PLAYER_REGISTRATION_TTL_MS = 60_000;
+        const jwPlayerFrameReferersByFrame = new Map<string, { url: string; ts: number }>();
+        const jwPlayerFrameReferersByTab = new Map<number, { url: string; ts: number }>();
+        const jwPlayerTabUrls = new Map<number, { url: string; ts: number }>();
+        const jwPlayerTabUrlInflight = new Map<number, Promise<string | undefined>>();
+
+        const jwPlayerFrameKey = (tabId: number, frameId: number) => `${tabId}:${frameId}`;
+
+        const isJwPlayerRefererFresh = (entry: { url: string; ts: number } | undefined, now: number) =>
+            entry !== undefined && now - entry.ts < JW_PLAYER_REGISTRATION_TTL_MS;
+
+        const jwPlayerRefererFromUrl = (url: string | undefined) => {
+            if (typeof url !== 'string') {
+                return undefined;
+            }
+
+            try {
+                const parsed = new URL(url);
+                if (
+                    (parsed.protocol === 'https:' || parsed.protocol === 'http:') &&
+                    jwPlayerHostRegex.test(parsed.host)
+                ) {
+                    return parsed.toString();
+                }
+            } catch {
+                return undefined;
+            }
+
+            return undefined;
+        };
+
+        const resolveJwPlayerTabUrl = async (tabId: number): Promise<string | undefined> => {
+            const cached = jwPlayerTabUrls.get(tabId);
+            if (cached !== undefined && isJwPlayerRefererFresh(cached, Date.now())) {
+                return cached.url;
+            }
+            jwPlayerTabUrls.delete(tabId);
+            const inflight = jwPlayerTabUrlInflight.get(tabId);
+            if (inflight !== undefined) {
+                return inflight;
+            }
+            const promise = (async () => {
+                try {
+                    const tab = await browser.tabs.get(tabId);
+                    const referer = jwPlayerRefererFromUrl(tab.url);
+                    if (referer !== undefined) {
+                        const entry = { url: referer, ts: Date.now() };
+                        jwPlayerTabUrls.set(tabId, entry);
+                        return referer;
+                    }
+                    return undefined;
+                } catch {
+                    return undefined;
+                } finally {
+                    jwPlayerTabUrlInflight.delete(tabId);
+                }
+            })();
+            jwPlayerTabUrlInflight.set(tabId, promise);
+            return promise;
+        };
+
+        const registerJwPlayerReferer = (
+            tabId: number | undefined,
+            frameId: number | undefined,
+            referer: string | undefined
+        ) => {
+            if (referer === undefined) {
+                return;
+            }
+            const entry = { url: referer, ts: Date.now() };
+            if (tabId !== undefined) {
+                jwPlayerFrameReferersByTab.set(tabId, entry);
+                jwPlayerTabUrls.set(tabId, entry);
+            }
+            if (tabId !== undefined && frameId !== undefined) {
+                jwPlayerFrameReferersByFrame.set(jwPlayerFrameKey(tabId, frameId), entry);
+            }
+        };
+
+        const evictJwPlayerFrameEntriesForTab = (tabId: number) => {
+            jwPlayerFrameReferersByTab.delete(tabId);
+            jwPlayerTabUrls.delete(tabId);
+            jwPlayerTabUrlInflight.delete(tabId);
+            for (const key of jwPlayerFrameReferersByFrame.keys()) {
+                if (key.startsWith(`${tabId}:`)) {
+                    jwPlayerFrameReferersByFrame.delete(key);
+                }
+            }
+        };
+
+        browser.runtime.onMessage.addListener((message, sender) => {
+            if (message?.command !== 'asbplayer-register-jwplayer-frame') {
+                return;
+            }
+
+            const tabId = sender.tab?.id;
+            const frameId = sender.frameId;
+            const referer = jwPlayerRefererFromUrl(message.url);
+            if (tabId === undefined || referer === undefined) {
+                return;
+            }
+
+            registerJwPlayerReferer(tabId, frameId, referer);
+        });
+
+        browser.tabs.onRemoved.addListener((tabId) => {
+            evictJwPlayerFrameEntriesForTab(tabId);
+        });
+
+        browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+            if (changeInfo.url !== undefined) {
+                if (jwPlayerRefererFromUrl(changeInfo.url) === undefined) {
+                    evictJwPlayerFrameEntriesForTab(tabId);
+                } else {
+                    registerJwPlayerReferer(tabId, undefined, changeInfo.url);
+                }
+            } else if (changeInfo.status === 'loading' && !jwPlayerTabUrls.has(tabId)) {
+                const referer = jwPlayerRefererFromUrl(tab.url);
+                if (referer !== undefined) {
+                    registerJwPlayerReferer(tabId, undefined, referer);
+                }
+            }
+        });
+
+        browser.webRequest.onBeforeSendHeaders.addListener(
+            (details) => {
+                if (!subtitlePathRegex.test(details.url)) {
+                    return;
+                }
+
+                const now = Date.now();
+                const sourceUrl = (details as any).documentUrl ?? (details as any).originUrl;
+                const sourceReferer = jwPlayerRefererFromUrl(sourceUrl);
+                const frameEntry = jwPlayerFrameReferersByFrame.get(jwPlayerFrameKey(details.tabId, details.frameId));
+                const tabEntry = jwPlayerFrameReferersByTab.get(details.tabId);
+
+                const frameReferer = isJwPlayerRefererFresh(frameEntry, now) ? frameEntry!.url : undefined;
+                const tabReferer = isJwPlayerRefererFresh(tabEntry, now) ? tabEntry!.url : undefined;
+
+                let anyJwPlayer: string | undefined;
+                if (details.tabId === -1) {
+                    for (const candidate of jwPlayerFrameReferersByTab.values()) {
+                        if (isJwPlayerRefererFresh(candidate, now)) {
+                            anyJwPlayer = candidate.url;
+                            break;
+                        }
+                    }
+                }
+
+                const referer = sourceReferer ?? frameReferer ?? tabReferer ?? anyJwPlayer;
+
+                if (referer === undefined) {
+                    void resolveJwPlayerTabUrl(details.tabId).then((fallback) => {
+                        if (fallback === undefined) {
+                            return;
+                        }
+                        jwPlayerFrameReferersByTab.set(details.tabId, { url: fallback, ts: Date.now() });
+                    });
+                    return;
+                }
+
+                const requestHeaders = (details.requestHeaders ?? []).filter((header) => {
+                    const name = header.name.toLowerCase();
+                    return name !== 'referer' && name !== 'origin';
+                });
+
+                requestHeaders.push({ name: 'Referer', value: referer });
+
+                let origin: string | undefined;
+                try {
+                    origin = new URL(referer).origin;
+                } catch {
+                    origin = undefined;
+                }
+                if (origin !== undefined) {
+                    requestHeaders.push({ name: 'Origin', value: origin });
+                }
+
+                return { requestHeaders };
+            },
+            { urls: subtitleRequestPatterns },
+            ['blocking', 'requestHeaders']
+        );
+
         // Firefox requires the use of iframe.srcdoc in order to load UI into an about:blank iframe
         // (which is required for UI to be scannable by other extensions like Yomitan).
         // However, such an iframe inherits the content security directives of the parent document,

--- a/extension/src/entrypoints/jwplayer-page.test.ts
+++ b/extension/src/entrypoints/jwplayer-page.test.ts
@@ -1,0 +1,314 @@
+import { extractExtension, trackFromDef, trackId } from '../pages/util';
+import { VideoDataSubtitleTrack } from '@project/common';
+
+describe('JW Player subtitle track detection', () => {
+    describe('extractExtension', () => {
+        it('extracts vtt extension', () => {
+            expect(extractExtension('https://example.com/subtitles/jpn.vtt', 'vtt')).toBe('vtt');
+        });
+
+        it('extracts srt extension', () => {
+            expect(extractExtension('https://example.com/subtitles/eng.srt', 'srt')).toBe('srt');
+        });
+
+        it('extracts ass extension with query params', () => {
+            expect(extractExtension('https://example.com/subtitles/ja.ass?token=abc', 'ass')).toBe('ass');
+        });
+
+        it('extracts extension from url with hash', () => {
+            expect(extractExtension('https://example.com/subtitles/en.vtt#t=10', 'vtt')).toBe('vtt');
+        });
+
+        it('returns fallback for urls without extension', () => {
+            expect(extractExtension('https://example.com/subtitles/noextension', 'vtt')).toBe('vtt');
+        });
+    });
+
+    describe('trackId', () => {
+        it('generates unique id from language, label, and url', () => {
+            const def = {
+                label: 'Japanese',
+                language: 'ja',
+                url: 'https://example.com/jpn.vtt',
+                extension: 'vtt',
+            };
+            const id = trackId(def);
+            expect(id).toBe('ja:Japanese:https://example.com/jpn.vtt');
+        });
+
+        it('generates different ids for different languages', () => {
+            const def1 = { label: 'English', language: 'en', url: 'https://example.com/eng.vtt', extension: 'vtt' };
+            const def2 = { label: 'Japanese', language: 'ja', url: 'https://example.com/jpn.vtt', extension: 'vtt' };
+            expect(trackId(def1)).not.toBe(trackId(def2));
+        });
+    });
+
+    describe('trackFromDef', () => {
+        it('creates track with id and def properties', () => {
+            const def = {
+                label: 'Japanese',
+                language: 'ja',
+                url: 'https://example.com/jpn.vtt',
+                extension: 'vtt',
+            };
+            const track = trackFromDef(def);
+            expect(track.id).toBe('ja:Japanese:https://example.com/jpn.vtt');
+            expect(track.label).toBe('Japanese');
+            expect(track.language).toBe('ja');
+            expect(track.url).toBe('https://example.com/jpn.vtt');
+            expect(track.extension).toBe('vtt');
+        });
+    });
+
+    describe('inferLanguage logic', () => {
+        function inferLanguage(track: { label?: string; srclang?: string; file?: string }): string | undefined {
+            const text = `${track.label || ''} ${track.srclang || ''} ${track.file || ''}`;
+
+            if (/japanese/i.test(text)) return 'ja';
+            if (/\bjpn\b/i.test(text)) return 'ja';
+            if (/日本語/.test(text)) return 'ja';
+
+            if (/english/i.test(text)) return 'en';
+            if (/chinese/i.test(text)) return 'zh';
+            if (/korean/i.test(text)) return 'ko';
+
+            if (track.srclang) {
+                return track.srclang.toLowerCase();
+            }
+
+            return undefined;
+        }
+
+        it('detects japanese from label', () => {
+            expect(inferLanguage({ label: 'Japanese' })).toBe('ja');
+            expect(inferLanguage({ label: 'Japanese', srclang: 'en' })).toBe('ja');
+        });
+
+        it('detects japanese from file path', () => {
+            expect(inferLanguage({ file: '/subtitles/jpn-2.vtt' })).toBe('ja');
+            expect(inferLanguage({ file: '/subtitles/japanese.vtt' })).toBe('ja');
+        });
+
+        it('detects japanese from srclang', () => {
+            expect(inferLanguage({ srclang: 'ja' })).toBe('ja');
+        });
+
+        it('detects english', () => {
+            expect(inferLanguage({ label: 'English' })).toBe('en');
+            expect(inferLanguage({ srclang: 'en' })).toBe('en');
+        });
+
+        it('detects chinese', () => {
+            expect(inferLanguage({ label: 'Chinese' })).toBe('zh');
+        });
+
+        it('detects korean', () => {
+            expect(inferLanguage({ label: 'Korean' })).toBe('ko');
+        });
+
+        it('falls back to srclang lowercase when no match', () => {
+            expect(inferLanguage({ srclang: 'FR' })).toBe('fr');
+        });
+    });
+
+    describe('scoreTrack logic', () => {
+        function scoreTrack(track: { label?: string; srclang?: string; file?: string }): number {
+            const text = `${track.label || ''} ${track.srclang || ''} ${track.file || ''}`;
+
+            if (/japanese/i.test(text)) return 100;
+            if (/日本語/.test(text)) return 100;
+            if (/\bjpn\b/i.test(text)) return 90;
+            if (/\bja\b/i.test(text) && !/\bjava\b/i.test(text)) return 80;
+
+            if (/english/i.test(text)) return 50;
+            if (/chinese/i.test(text)) return 50;
+            if (/korean/i.test(text)) return 50;
+
+            return 0;
+        }
+
+        it('scores japanese label highest', () => {
+            expect(scoreTrack({ label: 'Japanese' })).toBe(100);
+            expect(scoreTrack({ label: 'japanese' })).toBe(100);
+        });
+
+        it('scores japanese file path high', () => {
+            expect(scoreTrack({ file: '/subtitles/jpn-2.vtt' })).toBe(90);
+            expect(scoreTrack({ file: '/subtitles/japanese.vtt' })).toBe(100);
+        });
+
+        it('scores ja code lower than jpn', () => {
+            expect(scoreTrack({ file: '/subtitles/ja.vtt' })).toBe(80);
+        });
+
+        it('scores english lower than japanese', () => {
+            expect(scoreTrack({ label: 'Japanese' })).toBe(100);
+            expect(scoreTrack({ label: 'English' })).toBe(50);
+        });
+
+        it('scores unknown tracks as 0', () => {
+            expect(scoreTrack({ label: 'Spanish' })).toBe(0);
+        });
+    });
+
+    describe('track filtering logic', () => {
+        function isValidSubtitleTrack(track: { kind?: string; file?: string }): boolean {
+            return (
+                ['captions', 'subtitles'].includes(track.kind || '') &&
+                typeof track.file === 'string' &&
+                /\.(vtt|srt|ass|ssa)(\?|#|$)/i.test(track.file)
+            );
+        }
+
+        it('accepts tracks with kind captions', () => {
+            expect(isValidSubtitleTrack({ kind: 'captions', file: 'https://example.com/jpn.vtt' })).toBe(true);
+        });
+
+        it('accepts tracks with kind subtitles', () => {
+            expect(isValidSubtitleTrack({ kind: 'subtitles', file: 'https://example.com/jpn.vtt' })).toBe(true);
+        });
+
+        it('rejects tracks with other kinds', () => {
+            expect(isValidSubtitleTrack({ kind: 'metadata', file: 'https://example.com/jpn.vtt' })).toBe(false);
+            expect(isValidSubtitleTrack({ kind: 'thumbnails', file: 'https://example.com/jpn.vtt' })).toBe(false);
+        });
+
+        it('rejects tracks without file', () => {
+            expect(isValidSubtitleTrack({ kind: 'captions' })).toBe(false);
+            expect(isValidSubtitleTrack({ kind: 'captions', file: '' })).toBe(false);
+        });
+
+        it('rejects tracks with invalid file extensions', () => {
+            expect(isValidSubtitleTrack({ kind: 'captions', file: 'https://example.com/jpn.mp4' })).toBe(false);
+            expect(isValidSubtitleTrack({ kind: 'captions', file: 'https://example.com/jpn.json' })).toBe(false);
+        });
+
+        it('accepts vtt, srt, ass, ssa extensions', () => {
+            expect(isValidSubtitleTrack({ kind: 'captions', file: 'https://example.com/jpn.vtt' })).toBe(true);
+            expect(isValidSubtitleTrack({ kind: 'captions', file: 'https://example.com/eng.srt' })).toBe(true);
+            expect(isValidSubtitleTrack({ kind: 'captions', file: 'https://example.com/ja.ass' })).toBe(true);
+            expect(isValidSubtitleTrack({ kind: 'captions', file: 'https://example.com/ja.ssa' })).toBe(true);
+        });
+
+        it('accepts files with query params', () => {
+            expect(isValidSubtitleTrack({ kind: 'captions', file: 'https://example.com/jpn.vtt?token=abc' })).toBe(
+                true
+            );
+        });
+
+        it('accepts files with hash', () => {
+            expect(isValidSubtitleTrack({ kind: 'captions', file: 'https://example.com/jpn.vtt#t=10' })).toBe(true);
+        });
+    });
+
+    describe('JW Player sample data simulation', () => {
+        function detectJwPlayerSubtitleTracks(playlist: { tracks?: any[] }[]): VideoDataSubtitleTrack[] {
+            const rawTracks = playlist?.[0]?.tracks || [];
+
+            const subtitleTracks = rawTracks
+                .filter(
+                    (track: any) =>
+                        ['captions', 'subtitles'].includes(track.kind) &&
+                        typeof track.file === 'string' &&
+                        /\.(vtt|srt|ass|ssa)(\?|#|$)/i.test(track.file)
+                )
+                .map((track: any) => {
+                    const text = `${track.label || ''} ${track.srclang || ''} ${track.file || ''}`;
+                    let language: string | undefined;
+                    if (/japanese/i.test(text)) language = 'ja';
+                    else if (/\bjpn\b/i.test(text)) language = 'ja';
+                    else if (/日本語/.test(text)) language = 'ja';
+                    else if (track.srclang) language = track.srclang.toLowerCase();
+
+                    const label = track.label || language || 'Unknown';
+
+                    return trackFromDef({
+                        label,
+                        language,
+                        url: track.file,
+                        extension: extractExtension(track.file, 'vtt'),
+                    });
+                });
+
+            subtitleTracks.sort((a: VideoDataSubtitleTrack, b: VideoDataSubtitleTrack) => {
+                const scoreA = (t: { label?: string; language?: string; url?: string | string[] }) => {
+                    const txt = `${t.label || ''} ${t.language || ''} ${t.url || ''}`;
+                    if (/japanese/i.test(txt)) return 100;
+                    if (/\bjpn\b/i.test(txt)) return 90;
+                    if (/english/i.test(txt)) return 50;
+                    return 0;
+                };
+                return scoreA(b) - scoreA(a);
+            });
+
+            return subtitleTracks;
+        }
+
+        it('detects japanese track from sample data', () => {
+            const mockPlaylist = [
+                {
+                    tracks: [
+                        {
+                            kind: 'captions',
+                            default: false,
+                            file: 'https://fxpy7.watching.onl/anime/.../subtitles/jpn-2.vtt',
+                            label: 'Japanese',
+                            sideloaded: true,
+                        },
+                        {
+                            kind: 'captions',
+                            default: false,
+                            file: 'https://fxpy7.watching.onl/anime/.../subtitles/eng-1.vtt',
+                            label: 'English',
+                            sideloaded: true,
+                        },
+                        {
+                            kind: 'captions',
+                            default: false,
+                            file: 'https://fxpy7.watching.onl/anime/.../subtitles/spa-3.vtt',
+                            label: 'Spanish',
+                            sideloaded: true,
+                        },
+                    ],
+                },
+            ];
+
+            const tracks = detectJwPlayerSubtitleTracks(mockPlaylist);
+            expect(tracks.length).toBe(3);
+            expect(tracks[0].label).toBe('Japanese');
+            expect(tracks[0].language).toBe('ja');
+            expect(tracks[0].url).toContain('jpn-2.vtt');
+        });
+
+        it('sorts japanese track first', () => {
+            const mockPlaylist = [
+                {
+                    tracks: [
+                        { kind: 'captions', file: 'https://example.com/eng.vtt', label: 'English' },
+                        { kind: 'captions', file: 'https://example.com/jpn.vtt', label: 'Japanese' },
+                        { kind: 'captions', file: 'https://example.com/spa.vtt', label: 'Spanish' },
+                    ],
+                },
+            ];
+
+            const tracks = detectJwPlayerSubtitleTracks(mockPlaylist);
+            expect(tracks[0].label).toBe('Japanese');
+            expect(tracks[1].label).toBe('English');
+            expect(tracks[2].label).toBe('Spanish');
+        });
+
+        it('returns empty array when no valid tracks', () => {
+            const mockPlaylist = [
+                {
+                    tracks: [
+                        { kind: 'thumbnails', file: 'https://example.com/thumbnails.vtt' },
+                        { kind: 'captions', file: 'https://example.com/eng.mp4' },
+                    ],
+                },
+            ];
+
+            const tracks = detectJwPlayerSubtitleTracks(mockPlaylist);
+            expect(tracks.length).toBe(0);
+        });
+    });
+});

--- a/extension/src/entrypoints/jwplayer-page.ts
+++ b/extension/src/entrypoints/jwplayer-page.ts
@@ -1,0 +1,278 @@
+import { VideoData, VideoDataSubtitleTrack } from '@project/common';
+import { extractExtension, poll, trackFromDef } from '@/pages/util';
+
+declare const jwplayer: any | undefined;
+
+type JwTrack = { kind?: string; file?: string; label?: string; srclang?: string; default?: boolean };
+type JwSubtitleTrack = JwTrack & { file: string };
+
+export default defineUnlistedScript(() => {
+    setTimeout(() => {
+        let disposed = false;
+        const DEBUG = false;
+
+        function log(...args: any[]) {
+            if (DEBUG) {
+                console.log('[jwplayer-page]', ...args);
+            }
+        }
+
+        function inferLanguage(track: { label?: string; srclang?: string; file?: string }): string | undefined {
+            const text = `${track.label || ''} ${track.srclang || ''} ${track.file || ''}`;
+
+            if (/japanese/i.test(text)) return 'ja';
+            if (/\bjpn\b/i.test(text)) return 'ja';
+            if (/日本語/.test(text)) return 'ja';
+
+            if (/english/i.test(text)) return 'en';
+            if (/chinese/i.test(text)) return 'zh';
+            if (/korean/i.test(text)) return 'ko';
+            if (/spanish/i.test(text)) return 'es';
+            if (/french/i.test(text)) return 'fr';
+            if (/german/i.test(text)) return 'de';
+            if (/portuguese/i.test(text)) return 'pt';
+            if (/italian/i.test(text)) return 'it';
+            if (/russian/i.test(text)) return 'ru';
+            if (/arabic/i.test(text)) return 'ar';
+            if (/hindi/i.test(text)) return 'hi';
+            if (/thai/i.test(text)) return 'th';
+            if (/indonesian/i.test(text)) return 'id';
+            if (/vietnamese/i.test(text)) return 'vi';
+            if (/malay/i.test(text)) return 'ms';
+
+            if (track.srclang) {
+                return track.srclang.toLowerCase();
+            }
+
+            return undefined;
+        }
+
+        function scoreTrack(track: {
+            label?: string;
+            language?: string;
+            srclang?: string;
+            file?: string;
+            url?: string | string[];
+        }): number {
+            const text = `${track.label || ''} ${track.language || ''} ${track.srclang || ''} ${track.file || ''} ${track.url || ''}`;
+
+            if (/japanese/i.test(text)) return 100;
+            if (/日本語/.test(text)) return 100;
+            if (/\bjpn\b/i.test(text)) return 90;
+            if (/\bja\b/i.test(text) && !/\bjava\b/i.test(text)) return 80;
+
+            if (/english/i.test(text)) return 50;
+            if (/chinese/i.test(text)) return 50;
+            if (/korean/i.test(text)) return 50;
+
+            return 0;
+        }
+
+        function getJwPlayer() {
+            if (typeof jwplayer === 'undefined') {
+                return undefined;
+            }
+
+            return jwplayer;
+        }
+
+        function getPlayer() {
+            try {
+                return getJwPlayer()?.();
+            } catch (e) {
+                log('JW Player API not ready:', e);
+                return undefined;
+            }
+        }
+
+        function playlistTracks(player: any): JwTrack[] | undefined {
+            const playlist = player.getPlaylist?.();
+            if (!Array.isArray(playlist)) {
+                return undefined;
+            }
+
+            const tracks: JwTrack[] = [];
+            for (const item of playlist) {
+                if (Array.isArray(item?.tracks)) {
+                    tracks.push(...item.tracks);
+                }
+            }
+
+            return tracks;
+        }
+
+        function isSubtitleTrack(track: JwTrack): track is JwSubtitleTrack {
+            return (
+                ['captions', 'subtitles'].includes(track.kind || '') &&
+                typeof track.file === 'string' &&
+                /\.(vtt|srt|ass|ssa)(\?|#|$)/i.test(track.file)
+            );
+        }
+
+        function detectTracks(): VideoData {
+            const player = getPlayer();
+            if (!player) {
+                return { error: 'JW Player not found', basename: '' };
+            }
+
+            if (typeof player.getPlaylist !== 'function') {
+                return { error: 'JW Player not initialized', basename: '' };
+            }
+
+            const rawTracks = playlistTracks(player);
+
+            if (!Array.isArray(rawTracks) || !rawTracks.length) {
+                return { error: 'No tracks found in JW Player playlist', basename: '' };
+            }
+
+            const subtitleTracks = rawTracks.filter(isSubtitleTrack).map((track: JwSubtitleTrack) => {
+                const language = inferLanguage(track);
+                const label = track.label || language || 'Unknown';
+
+                return trackFromDef({
+                    label,
+                    language,
+                    url: track.file,
+                    extension: extractExtension(track.file, 'vtt'),
+                });
+            });
+
+            if (!subtitleTracks.length) {
+                return { error: 'No valid subtitle tracks found', basename: '' };
+            }
+
+            subtitleTracks.sort(
+                (a: VideoDataSubtitleTrack, b: VideoDataSubtitleTrack) => scoreTrack(b) - scoreTrack(a)
+            );
+
+            log(
+                'Detected subtitle tracks:',
+                subtitleTracks.map((t: VideoDataSubtitleTrack) => ({
+                    label: t.label,
+                    language: t.language,
+                    url: t.url,
+                }))
+            );
+
+            return {
+                error: '',
+                basename: '',
+                subtitles: subtitleTracks,
+            };
+        }
+
+        function injectTrackToVideo(
+            track: { file: string; label?: string; default?: boolean },
+            video: HTMLVideoElement
+        ) {
+            if (!video) {
+                log('No video element found');
+                return;
+            }
+
+            const existingTrack = Array.from(video.querySelectorAll('track[data-asb-injected="jwplayer"]')).find(
+                (trackEl) => trackEl.getAttribute('src') === track.file
+            );
+            if (existingTrack) {
+                log('Track already injected, skipping');
+                return;
+            }
+
+            const trackEl = document.createElement('track');
+            trackEl.kind = 'subtitles';
+            trackEl.label = track.label || 'Unknown';
+            trackEl.src = track.file;
+            trackEl.dataset.asbInjected = 'jwplayer';
+
+            if (track.default) {
+                trackEl.default = true;
+            }
+
+            const lang = inferLanguage({ label: track.label, file: track.file });
+            if (lang) {
+                trackEl.srclang = lang;
+            }
+
+            video.appendChild(trackEl);
+            log('Injected track element:', trackEl.label);
+
+            setTimeout(() => {
+                for (const textTrack of video.textTracks) {
+                    if (textTrack.label === (track.label || 'Unknown') || textTrack.language === lang) {
+                        textTrack.mode = 'showing';
+                        log('Enabled text track:', textTrack.label);
+                    }
+                }
+            }, 100);
+        }
+
+        function injectBestTrack() {
+            const player = getPlayer();
+            if (typeof player?.getPlaylist !== 'function') return;
+
+            const rawTracks = playlistTracks(player);
+            if (!Array.isArray(rawTracks)) return;
+
+            const bestTrack = rawTracks
+                .filter(isSubtitleTrack)
+                .sort((a: JwTrack, b: JwTrack) => scoreTrack(b) - scoreTrack(a))[0];
+
+            if (!bestTrack) {
+                log('No subtitle track found');
+                return;
+            }
+
+            const video = document.querySelector('video');
+            if (video) {
+                injectTrackToVideo(bestTrack, video);
+            }
+        }
+
+        document.addEventListener(
+            'asbplayer-get-synced-data',
+            async () => {
+                if (disposed) return;
+
+                log('Received asbplayer-get-synced-data');
+
+                const data = detectTracks();
+
+                document.dispatchEvent(
+                    new CustomEvent('asbplayer-synced-data', {
+                        detail: data,
+                    })
+                );
+            },
+            false
+        );
+
+        document.addEventListener(
+            'asbplayer-query-jwplayer',
+            async () => {
+                const apiAvailable = await poll(() => getJwPlayer() !== undefined, 5000);
+                document.dispatchEvent(
+                    new CustomEvent('asbplayer-jwplayer-enabled', {
+                        detail: apiAvailable,
+                    })
+                );
+            },
+            false
+        );
+
+        (async () => {
+            const ready = await poll(() => getPlayer()?.getPlaylist !== undefined, 15000);
+
+            if (ready && !disposed) {
+                log('JW Player detected, checking for tracks');
+                const data = detectTracks();
+
+                if (data.subtitles?.length) {
+                    log('Auto-injecting best subtitle track');
+                    injectBestTrack();
+                }
+            } else {
+                log('JW Player not detected within timeout');
+            }
+        })();
+    }, 0);
+});

--- a/extension/src/entrypoints/jwplayer-page.ts
+++ b/extension/src/entrypoints/jwplayer-page.ts
@@ -274,5 +274,27 @@ export default defineUnlistedScript(() => {
                 log('JW Player not detected within timeout');
             }
         })();
+
+        // Re-register the JW Player iframe URL with the background script on a
+        // short interval so the Referer/Origin rewrite remains in effect for
+        // long-running sessions. The background script expires stale entries.
+        const heartbeat = setInterval(() => {
+            if (disposed) {
+                return;
+            }
+            try {
+                browser.runtime.sendMessage({
+                    command: 'asbplayer-register-jwplayer-frame',
+                    url: window.location.href,
+                });
+            } catch {
+                // ignore
+            }
+        }, 30_000);
+        const clearHeartbeat = () => {
+            clearInterval(heartbeat);
+        };
+        window.addEventListener('pagehide', clearHeartbeat, { once: true });
+        window.addEventListener('beforeunload', clearHeartbeat, { once: true });
     }, 0);
 });

--- a/extension/src/entrypoints/page.content.ts
+++ b/extension/src/entrypoints/page.content.ts
@@ -15,6 +15,15 @@ export default defineContentScript({
     runAt: 'document_start',
 
     main(ctx: ContentScriptContext) {
-        currentPageDelegate().then((pageDelegate) => pageDelegate?.loadScripts());
+        currentPageDelegate().then((pageDelegate) => {
+            pageDelegate?.loadScripts();
+
+            if (pageDelegate?.config.key === 'jwPlayer') {
+                browser.runtime.sendMessage({
+                    command: 'asbplayer-register-jwplayer-frame',
+                    url: window.location.href,
+                });
+            }
+        });
     },
 });

--- a/extension/src/pages.json
+++ b/extension/src/pages.json
@@ -228,6 +228,15 @@
             "key": "archive",
             "host": "archive\\.org",
             "searchShadowRootsForVideoElements": true
+        },
+        {
+            "key": "jwPlayer",
+            "host": "(vidwish\\.live|watching\\.onl|vidcloud\\..+|megaplay\\.buzz)",
+            "pageScript": "jwplayer-page.js",
+            "syncAllowedAtPath": ".*",
+            "autoSync": {
+                "enabled": true
+            }
         }
     ]
 }

--- a/extension/src/pages/util.ts
+++ b/extension/src/pages/util.ts
@@ -2,8 +2,9 @@ import { VideoDataSubtitleTrack, VideoDataSubtitleTrackDef } from '@project/comm
 
 export function extractExtension(url: string, fallback: string) {
     const path = url.split(/[?#]/)[0];
-    const dotIndex = path.lastIndexOf('.');
-    return dotIndex === -1 ? fallback : path.substring(dotIndex + 1);
+    const filename = path.substring(path.lastIndexOf('/') + 1);
+    const dotIndex = filename.lastIndexOf('.');
+    return dotIndex === -1 ? fallback : filename.substring(dotIndex + 1);
 }
 
 export function poll(test: () => boolean, timeout: number = 10000): Promise<boolean> {

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -59,6 +59,15 @@ export default defineConfig({
             }
             paths.push('content-scripts/video.css');
         },
+        'entrypoints:found': (wxt: Wxt, entrypoints: { name: string; inputPath: string; type: string }[]) => {
+            const testFiles = entrypoints.filter((e) => e.inputPath.endsWith('.test.ts'));
+            for (const test of testFiles) {
+                wxt.logger.info(`Excluding test file from entrypoints: ${test.inputPath}`);
+            }
+            const filtered = entrypoints.filter((e) => !e.inputPath.endsWith('.test.ts'));
+            entrypoints.length = 0;
+            entrypoints.push(...filtered);
+        },
     },
     manifest: ({ browser, mode }) => {
         const version = '1.18.0';
@@ -108,6 +117,7 @@ export default defineConfig({
                         'svt-play-page.js',
                         'ur-play-page.js',
                         'hulu-jp-page.js',
+                        'jwplayer-page.js',
                         'anki-ui.js',
                         'mp3-encoder-worker.js',
                         'pgs-parser-worker.js',


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

## Summary
- Add a JW Player page script for supported JW Player hosts
- Register JW Player page settings metadata and defaults
- Add tests for JW Player track detection and settings migration

## Verification
- yarn workspace @project/extension run check
- yarn workspace @project/extension compile
- yarn workspace @project/extension build