### PR TITLE
feat: cache Jimaku subtitle works

### DIFF
--- a/common/global-state/index.ts
+++ b/common/global-state/index.ts
@@ -9,9 +9,15 @@ export enum AnnotationTutorialState {
     hasSeen = 2,
 }
 
+export interface JimakuCachedWork {
+    id: number;
+    name: string;
+}
+
 export interface OnlineSubtitleSourceConfig {
     jimakuApiKey: string;
     jimakuSearchCategory: 'anime' | 'drama';
+    jimakuRecentWorks?: JimakuCachedWork[];
 }
 
 export const initialGlobalState: GlobalState = {
@@ -21,6 +27,7 @@ export const initialGlobalState: GlobalState = {
     onlineSubtitleSourceConfig: {
         jimakuApiKey: '',
         jimakuSearchCategory: 'anime',
+        jimakuRecentWorks: [],
     },
 };
 

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "Recent",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -672,7 +672,7 @@
             "noDeckBreakdown": "No matching Anki cards were found for this media.",
             "info": {
                 "ankiStatistics": "How your Anki cards match up with the words in this media.",
-                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature." 
+                "projectedCards": "Preview your stats by treating past cards or new cards (in the order they will be introduced) as Mature."
             }
         },
         "waniKani": {
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "Recent",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "Recent",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "Recent",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "Recent",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "Recent",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Chiave API Jimaku",
         "jimakuApiKeyAutosaveHint": "Salvata automaticamente. Ottieni una chiave API <0>qui</0>.",
         "entries": "Risultati della ricerca",
+        "recentEntries": "Recent",
         "noEntries": "Nessun risultato",
         "availableFiles": "File",
         "noFiles": "Nessun file",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "JimakuのAPIキー",
         "jimakuApiKeyAutosaveHint": "自動的に保存されます。APIキーは<0>こちらから</0>入手できます。",
         "entries": "検索結果",
+        "recentEntries": "Recent",
         "noEntries": "検索結果はありません",
         "availableFiles": "ファイル",
         "noFiles": "ファイルはありません",

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "Recent",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "Recent",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "Recent",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -711,6 +711,7 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "Recent",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -711,11 +711,12 @@
         "jimakuApiKey": "Jimaku API key",
         "jimakuApiKeyAutosaveHint": "Saved automatically. Get an API key <0>here</0>.",
         "entries": "Search results",
+        "recentEntries": "最近",
         "noEntries": "No search results",
         "availableFiles": "Files",
         "noFiles": "No files",
-        "searchCategory": "Search category",
-        "categoryAnime": "Anime",
-        "categoryDrama": "Drama"
+        "searchCategory": "搜索类别",
+        "categoryAnime": "动画",
+        "categoryDrama": "剧集"
     }
 }

--- a/extension/src/services/extension-global-state-provider.test.ts
+++ b/extension/src/services/extension-global-state-provider.test.ts
@@ -26,6 +26,7 @@ it('can retrieve all keys', async () => {
         onlineSubtitleSourceConfig: {
             jimakuApiKey: '',
             jimakuSearchCategory: 'anime',
+            jimakuRecentWorks: [],
         },
     });
 });

--- a/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
+++ b/extension/src/ui/components/OnlineSubtitleSourceDialog.tsx
@@ -11,6 +11,7 @@ import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import CloseIcon from '@mui/icons-material/Close';
+import CircularProgress from '@mui/material/CircularProgress';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Stack from '@mui/material/Stack';
@@ -19,6 +20,7 @@ import Typography from '@mui/material/Typography';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { JimakuClient, JimakuEntry } from '@/services/subtitle-sources';
+import type { JimakuCachedWork } from '@project/common/global-state';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import Toolbar from '@mui/material/Toolbar';
@@ -38,9 +40,12 @@ interface Props {
     onJimakuApiKeyChange: (jimakuApiKey: string) => void;
     jimakuSearchCategory: 'anime' | 'drama';
     onJimakuSearchCategoryChange: (category: 'anime' | 'drama') => void;
+    jimakuRecentWorks: JimakuCachedWork[];
+    onJimakuRecentWorksChange: (recentWorks: JimakuCachedWork[]) => void;
 }
 
 const SUPPORTED_JIMAKU_EXTENSIONS = ['.srt', '.ass'];
+const MAX_RECENT_WORKS = 10;
 
 const isSupportedSubtitleFile = (name: string) =>
     SUPPORTED_JIMAKU_EXTENSIONS.some((ext) => name.toLowerCase().endsWith(ext));
@@ -91,6 +96,8 @@ export default function OnlineSubtitleSourceDialog({
     onJimakuApiKeyChange,
     jimakuSearchCategory,
     onJimakuSearchCategoryChange,
+    jimakuRecentWorks,
+    onJimakuRecentWorksChange,
 }: Props) {
     const { t } = useTranslation();
     const [searching, setSearching] = useState(false);
@@ -101,18 +108,38 @@ export default function OnlineSubtitleSourceDialog({
     const [lastQuery, setLastQuery] = useState<string>();
     const [lastSearchCategory, setLastSearchCategory] = useState<string>();
     const [jimakuEntries, setJimakuEntries] = useState<{ id: number; name: string }[]>([]);
-    const [jimakuSelectedEntry, setJimakuSelectedEntry] = useState<JimakuEntry>();
+    const [jimakuSelectedEntry, setJimakuSelectedEntry] = useState<{ id: number; name: string }>();
     const [jimakuFiles, setJimakuFiles] = useState<OnlineSubtitleImportCandidate[]>();
+    const [loadingJimakuFiles, setLoadingJimakuFiles] = useState(false);
     const resultsCache = useRef<Map<string, { anime: JimakuEntry[]; drama: JimakuEntry[] }>>(new Map());
+
+    // Ref to avoid stale closure in upsertRecentWork
+    const recentWorksRef = useRef(jimakuRecentWorks);
+    recentWorksRef.current = jimakuRecentWorks;
+
+    // Guards against out-of-order responses when user navigates quickly
+    const selectedEntryIdRef = useRef<number | undefined>(undefined);
+    const fileLoadRequestIdRef = useRef(0);
+
+    const upsertRecentWork = useCallback(
+        (work: JimakuCachedWork) => {
+            const next = [work, ...recentWorksRef.current.filter((w) => w.id !== work.id)].slice(0, MAX_RECENT_WORKS);
+            recentWorksRef.current = next;
+            onJimakuRecentWorksChange(next);
+        },
+        [onJimakuRecentWorksChange]
+    );
 
     const normalizedDetectedTitleHint = useMemo(
         () => normalizeDetectedTitleHint(detectedTitleHint),
         [detectedTitleHint]
     );
+    const isApiKeyMissing = jimakuApiKey.trim().length === 0;
     const isSearchDisabled =
         searching ||
+        loadingJimakuFiles ||
         query.trim().length === 0 ||
-        jimakuApiKey.trim().length === 0 ||
+        isApiKeyMissing ||
         (lastQuery === query && lastSearchCategory === jimakuSearchCategory) ||
         loadingFiles;
 
@@ -122,6 +149,11 @@ export default function OnlineSubtitleSourceDialog({
         setJimakuEntries([]);
         setJimakuSelectedEntry(undefined);
         setJimakuFiles(undefined);
+        setLoadingJimakuFiles(false);
+        setLastQuery(undefined);
+        setLastSearchCategory(undefined);
+        selectedEntryIdRef.current = undefined;
+        fileLoadRequestIdRef.current += 1;
     }, []);
 
     useEffect(() => {
@@ -139,6 +171,9 @@ export default function OnlineSubtitleSourceDialog({
         setError(undefined);
         setSearching(true);
         setFilterString('');
+        fileLoadRequestIdRef.current += 1;
+        selectedEntryIdRef.current = undefined;
+        setLoadingJimakuFiles(false);
 
         try {
             const cacheKey = query.trim();
@@ -151,6 +186,7 @@ export default function OnlineSubtitleSourceDialog({
                     setJimakuEntries(cachedResult.map((entry) => ({ id: entry.id, name: entry.name })));
                     setJimakuSelectedEntry(undefined);
                     setJimakuFiles(undefined);
+                    selectedEntryIdRef.current = undefined;
                     setSearching(false);
                     return;
                 }
@@ -174,6 +210,7 @@ export default function OnlineSubtitleSourceDialog({
             resultsCache.current.set(cacheKey, cacheEntry);
             setJimakuSelectedEntry(undefined);
             setJimakuFiles(undefined);
+            selectedEntryIdRef.current = undefined;
         } catch (e) {
             setError((e as Error).message);
         } finally {
@@ -182,38 +219,48 @@ export default function OnlineSubtitleSourceDialog({
     }, [jimakuApiKey, query, jimakuSearchCategory]);
 
     const prevCategoryRef = useRef(jimakuSearchCategory);
-    const lastQueryRef = useRef(lastQuery);
-    lastQueryRef.current = lastQuery;
-    const handleSearchJimakuRef = useRef(handleSearchJimaku);
-    handleSearchJimakuRef.current = handleSearchJimaku;
     useEffect(() => {
-        if (prevCategoryRef.current !== jimakuSearchCategory && lastQueryRef.current !== undefined) {
-            handleSearchJimakuRef.current?.();
+        if (prevCategoryRef.current !== jimakuSearchCategory && lastQuery !== undefined) {
+            handleSearchJimaku();
         }
         prevCategoryRef.current = jimakuSearchCategory;
-    }, [jimakuSearchCategory]);
+    }, [handleSearchJimaku, jimakuSearchCategory, lastQuery]);
 
     const handleLoadJimakuFiles = useCallback(
-        async (entry: JimakuEntry) => {
+        async (entry: { id: number; name: string }) => {
+            const requestId = fileLoadRequestIdRef.current + 1;
+            fileLoadRequestIdRef.current = requestId;
+
             setError(undefined);
-            setSearching(true);
             setFilterString('');
             setJimakuSelectedEntry(entry);
+            selectedEntryIdRef.current = entry.id;
+            setLoadingJimakuFiles(true);
+            setJimakuFiles(undefined);
 
             try {
                 const client = new JimakuClient({ apiKey: jimakuApiKey });
                 const files = (await client.getFiles(entry.id)).data
                     .filter((file) => isSupportedSubtitleFile(file.name))
                     .map((file) => ({ name: file.name, url: file.url }));
-                setJimakuFiles(files);
+
+                if (fileLoadRequestIdRef.current === requestId && selectedEntryIdRef.current === entry.id) {
+                    setJimakuFiles(files);
+                    upsertRecentWork({ id: entry.id, name: entry.name });
+                }
             } catch (e) {
-                setError((e as Error).message);
-                setJimakuFiles(undefined);
+                if (fileLoadRequestIdRef.current === requestId && selectedEntryIdRef.current === entry.id) {
+                    setError((e as Error).message);
+                    setJimakuSelectedEntry(undefined);
+                    selectedEntryIdRef.current = undefined;
+                }
             } finally {
-                setSearching(false);
+                if (fileLoadRequestIdRef.current === requestId) {
+                    setLoadingJimakuFiles(false);
+                }
             }
         },
-        [jimakuApiKey]
+        [jimakuApiKey, upsertRecentWork]
     );
 
     const handleImport = useCallback(
@@ -329,82 +376,120 @@ export default function OnlineSubtitleSourceDialog({
                         fullWidth
                     />
 
-                    {lastQuery !== undefined && (
+                    {lastQuery !== undefined && jimakuSelectedEntry === undefined && (
                         <Stack spacing={1} sx={{ flex: 1, minWidth: 0 }}>
-                            {jimakuFiles === undefined && (
-                                <>
-                                    <Typography variant="subtitle1" sx={{ flexGrow: 1 }}>
-                                        {t('onlineSubtitleSources.entries')} ({jimakuEntries.length})
-                                    </Typography>
-                                    <FilterTextField filterString={filterString} onChange={setFilterString} />
-                                    <List
-                                        dense
-                                        sx={{
-                                            maxHeight: 220,
-                                            overflow: 'auto',
-                                            border: '1px solid',
-                                            borderColor: 'divider',
-                                        }}
+                            <Typography variant="subtitle1" sx={{ flexGrow: 1 }}>
+                                {t('onlineSubtitleSources.entries')} ({jimakuEntries.length})
+                            </Typography>
+                            <FilterTextField filterString={filterString} onChange={setFilterString} />
+                            <List
+                                dense
+                                sx={{
+                                    maxHeight: 220,
+                                    overflow: 'auto',
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                }}
+                            >
+                                {filteredJimakuEntries.map((entry) => (
+                                    <ListItemButton
+                                        key={entry.id}
+                                        onClick={() => handleLoadJimakuFiles(entry)}
+                                        disabled={loadingFiles || loadingJimakuFiles || isApiKeyMissing}
                                     >
-                                        {filteredJimakuEntries.map((entry) => (
-                                            <ListItemButton
-                                                key={entry.id}
-                                                onClick={() => handleLoadJimakuFiles(entry)}
-                                                disabled={loadingFiles}
-                                            >
-                                                <ListItemText primary={entry.name} />
-                                            </ListItemButton>
-                                        ))}
-                                        {filteredJimakuEntries.length === 0 && (
-                                            <ListItem>
-                                                <ListItemText primary={t('onlineSubtitleSources.noEntries')} />
-                                            </ListItem>
-                                        )}
-                                    </List>
-                                </>
-                            )}
+                                        <ListItemText primary={entry.name} />
+                                    </ListItemButton>
+                                ))}
+                                {filteredJimakuEntries.length === 0 && (
+                                    <ListItem>
+                                        <ListItemText primary={t('onlineSubtitleSources.noEntries')} />
+                                    </ListItem>
+                                )}
+                            </List>
+                        </Stack>
+                    )}
 
-                            {jimakuFiles !== undefined && jimakuSelectedEntry !== undefined && (
-                                <>
-                                    <Box display="flex" sx={{ alignItems: 'center' }}>
-                                        <IconButton
-                                            size="small"
-                                            sx={{ p: 0.5 }}
-                                            onClick={() => {
-                                                setJimakuFiles(undefined);
-                                                setFilterString('');
-                                            }}
-                                        >
-                                            <ChevronLeftIcon />
-                                        </IconButton>
-                                        <Typography variant="subtitle1" noWrap>
-                                            {jimakuSelectedEntry.name}
-                                        </Typography>
-                                        <Typography variant="subtitle1">&nbsp;({jimakuFiles.length})</Typography>
-                                    </Box>
-                                    <FilterTextField filterString={filterString} onChange={setFilterString} />
-                                    <List
-                                        dense
-                                        sx={{
-                                            maxHeight: 220,
-                                            overflow: 'auto',
-                                            border: '1px solid',
-                                            borderColor: 'divider',
-                                        }}
+                    {jimakuSelectedEntry !== undefined && (
+                        <Stack spacing={1} sx={{ flex: 1, minWidth: 0 }}>
+                            <Box display="flex" sx={{ alignItems: 'center' }}>
+                                <IconButton
+                                    size="small"
+                                    sx={{ p: 0.5 }}
+                                    onClick={() => {
+                                        fileLoadRequestIdRef.current += 1;
+                                        setLoadingJimakuFiles(false);
+                                        setJimakuFiles(undefined);
+                                        setJimakuSelectedEntry(undefined);
+                                        selectedEntryIdRef.current = undefined;
+                                        setFilterString('');
+                                    }}
+                                >
+                                    <ChevronLeftIcon />
+                                </IconButton>
+                                <Typography variant="subtitle1" noWrap>
+                                    {jimakuSelectedEntry.name}
+                                </Typography>
+                                {jimakuFiles !== undefined && (
+                                    <Typography variant="subtitle1">&nbsp;({jimakuFiles.length})</Typography>
+                                )}
+                            </Box>
+                            <FilterTextField filterString={filterString} onChange={setFilterString} />
+                            <List
+                                dense
+                                sx={{
+                                    maxHeight: 220,
+                                    overflow: 'auto',
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                }}
+                            >
+                                {jimakuFiles === undefined && loadingJimakuFiles && (
+                                    <ListItem>
+                                        <CircularProgress size={20} />
+                                    </ListItem>
+                                )}
+                                {filteredJimakuFiles?.map((file) => (
+                                    <ListItemButton
+                                        key={file.url}
+                                        onClick={() => handleImport(file)}
+                                        disabled={loadingFiles}
                                     >
-                                        {filteredJimakuFiles?.map((file) => (
-                                            <ListItemButton key={file.url} onClick={() => handleImport(file)}>
-                                                <ListItemText primary={file.name} />
-                                            </ListItemButton>
-                                        ))}
-                                        {filteredJimakuFiles?.length === 0 && (
-                                            <ListItem>
-                                                <ListItemText primary={t('onlineSubtitleSources.noFiles')} />
-                                            </ListItem>
-                                        )}
-                                    </List>
-                                </>
-                            )}
+                                        <ListItemText primary={file.name} />
+                                    </ListItemButton>
+                                ))}
+                                {filteredJimakuFiles?.length === 0 && (
+                                    <ListItem>
+                                        <ListItemText primary={t('onlineSubtitleSources.noFiles')} />
+                                    </ListItem>
+                                )}
+                            </List>
+                        </Stack>
+                    )}
+
+                    {lastQuery === undefined && jimakuSelectedEntry === undefined && jimakuRecentWorks.length > 0 && (
+                        <Stack spacing={1} sx={{ flex: 1, minWidth: 0 }}>
+                            <Typography variant="subtitle1" sx={{ flexGrow: 1 }}>
+                                {t('onlineSubtitleSources.recentEntries')}
+                            </Typography>
+                            <List
+                                dense
+                                sx={{
+                                    maxHeight: 220,
+                                    overflow: 'auto',
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                }}
+                            >
+                                {jimakuRecentWorks.map((entry) => (
+                                    <ListItemButton
+                                        key={entry.id}
+                                        onClick={() => handleLoadJimakuFiles(entry)}
+                                        disabled={loadingFiles || loadingJimakuFiles || isApiKeyMissing}
+                                    >
+                                        <ListItemText primary={entry.name} />
+                                    </ListItemButton>
+                                ))}
+                            </List>
                         </Stack>
                     )}
                 </Stack>

--- a/extension/src/ui/components/VideoDataSyncUi.tsx
+++ b/extension/src/ui/components/VideoDataSyncUi.tsx
@@ -440,10 +440,19 @@ export default function VideoDataSyncUi({ bridge }: Props) {
                     onImport={handleImportOnlineFile}
                     detectedTitleHint={detectedTitleHint}
                     jimakuApiKey={onlineSubtitleSourceConfig.jimakuApiKey}
-                    onJimakuApiKeyChange={(jimakuApiKey) => handleOnlineSubtitleSourceConfigChanged({ jimakuApiKey })}
+                    onJimakuApiKeyChange={(jimakuApiKey) =>
+                        handleOnlineSubtitleSourceConfigChanged({
+                            jimakuApiKey,
+                            jimakuRecentWorks: [],
+                        })
+                    }
                     jimakuSearchCategory={onlineSubtitleSourceConfig.jimakuSearchCategory}
                     onJimakuSearchCategoryChange={(jimakuSearchCategory) =>
                         handleOnlineSubtitleSourceConfigChanged({ jimakuSearchCategory })
+                    }
+                    jimakuRecentWorks={onlineSubtitleSourceConfig.jimakuRecentWorks ?? []}
+                    onJimakuRecentWorksChange={(jimakuRecentWorks) =>
+                        handleOnlineSubtitleSourceConfigChanged({ jimakuRecentWorks })
                     }
                 />
                 <input


### PR DESCRIPTION
## Background
This PR addresses the pain point in #1009 regarding the Jimaku subtitle search workflow. Currently, when watching a series, users often have to manually search for each episode. Even with title auto-filling, it can be inaccurate or require several repetitive steps for every new episode.

This feature introduces a persistent cache for recently accessed Jimaku works. It is intended as a pure UX improvement that allows users to:
1. Instantly see previously used subtitle lists for a series without re-searching.
2. Speed up the workflow for binge-watching series where the automatic matching might not be perfect.

## Summary
- Persist recently opened Jimaku works with cached subtitle file lists
- Show cached files immediately while refreshing in the background
- Keep Jimaku loading state scoped to the currently selected work and complete locale keys

<img width="741" height="432" alt="image" src="https://github.com/user-attachments/assets/17bcb7d9-b3ff-422f-a225-4ccdc6d0fb09" />

## Tests
- `corepack yarn workspace root run verify`

I'm open to feedback on the implementation or the feature itself. If there are concerns about the approach, I'm happy to refine it or split the changes.