### PR TITLE
Add local video scrub timestamp previews

### DIFF
--- a/common/app/components/Controls.tsx
+++ b/common/app/components/Controls.tsx
@@ -47,6 +47,13 @@ import PlaybackRateInput from '../../components/PlaybackRateInput';
 import VideoElementFavicon from './VideoElementFavicon';
 import PlayModeSelector from '../../components/PlayModeSelector';
 import TimeDisplay from '../../components/TimeDisplay';
+import {
+    centeredProgressBarPreviewLeft,
+    clampProgressBarPreviewLeft,
+    formatProgressTimestamp,
+    progressBarProgress,
+    progressBarTrackWidth,
+} from './progress-bar';
 
 const useControlStyles = makeStyles<Theme>((theme) => ({
     container: {
@@ -203,6 +210,31 @@ const useProgressBarStyles = makeStyles<Theme>((theme) => ({
         height: 79,
         borderRadius: 5,
     },
+    timestampPreview: {
+        position: 'absolute',
+        top: -36,
+        height: 24,
+        padding: '1px 8px',
+        boxSizing: 'border-box',
+        border: '1px solid rgba(255, 255, 255, 0.16)',
+        borderRadius: 5,
+        backgroundColor: 'rgba(24, 24, 24, 0.94)',
+        color: '#fff',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 13,
+        fontWeight: 600,
+        fontVariantNumeric: 'tabular-nums',
+        letterSpacing: 0,
+        whiteSpace: 'nowrap',
+        pointerEvents: 'none',
+        zIndex: 2,
+        boxShadow: '0 2px 6px rgba(0, 0, 0, 0.4)',
+    },
+    timestampPreviewWithThumbnail: {
+        top: -120,
+    },
     fillContainer: {
         background: 'rgba(30,30,30,0.7)',
         width: '100%',
@@ -275,15 +307,27 @@ interface ProgressBarProps {
     onSeek: (progress: number) => void;
     onSeekPreview?: (progress: number) => string | undefined;
     value: number;
+    length: number;
     videoHeight: number | undefined;
     videoWidth: number | undefined;
     previewEnabled: boolean;
+    timestampPreviewEnabled: boolean;
 }
 
-function ProgressBar({ onSeek, onSeekPreview, value, videoHeight, videoWidth, previewEnabled }: ProgressBarProps) {
+function ProgressBar({
+    onSeek,
+    onSeekPreview,
+    value,
+    length,
+    videoHeight,
+    videoWidth,
+    previewEnabled,
+    timestampPreviewEnabled,
+}: ProgressBarProps) {
     const classes = useProgressBarStyles();
     const [mouseOver, setMouseOver] = useState(false);
-    const containerRef = useRef(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [hoverState, setHoverState] = useState({ progress: 0, trackWidth: 0 });
     // x position of mouse
     const [hoverX, setHoverX] = useState(0);
     const [thumbnailSrc, setThumbnailSrc] = useState<string | undefined>(undefined);
@@ -293,13 +337,25 @@ function ProgressBar({ onSeek, onSeekPreview, value, videoHeight, videoWidth, pr
         videoWidth = Math.round((videoWidth / videoHeight) * 79);
     }
 
+    const thumbnailPreviewEnabled = previewEnabled && onSeekPreview !== undefined;
+    const thumbnailWidth = videoWidth ?? 145;
+    const timestampPreviewWidth = length >= 3600000 ? 88 : 64;
+    const hoverTimestamp = timestampPreviewEnabled ? formatProgressTimestamp(hoverState.progress, length) : undefined;
+    const timestampPreviewClassName = thumbnailPreviewEnabled
+        ? classes.timestampPreview + ' ' + classes.timestampPreviewWithThumbnail
+        : classes.timestampPreview;
+    const timestampPreviewLeft = thumbnailPreviewEnabled
+        ? clampProgressBarPreviewLeft(
+              hoverX + (thumbnailWidth - timestampPreviewWidth) / 2,
+              hoverState.trackWidth,
+              timestampPreviewWidth
+          )
+        : centeredProgressBarPreviewLeft(hoverState.progress, hoverState.trackWidth, timestampPreviewWidth);
+
     const handleClick = useCallback(
         (e: React.MouseEvent<HTMLDivElement>) => {
             const rect = e.currentTarget.getBoundingClientRect();
-            // Account for margins by subtracting 10 from left/right sides
-            const width = rect.right - rect.left - 20;
-            const progress = Math.min(1, Math.max(0, (e.pageX - rect.left - 10) / width));
-            onSeek(progress);
+            onSeek(progressBarProgress(e.pageX, rect));
         },
         [onSeek]
     );
@@ -307,15 +363,14 @@ function ProgressBar({ onSeek, onSeekPreview, value, videoHeight, videoWidth, pr
     const handleMouseOver = useCallback(
         (e: React.MouseEvent<HTMLDivElement>) => {
             setMouseOver(true);
-            if (onSeekPreview == undefined) return;
             const rect = e.currentTarget.getBoundingClientRect();
-            // Account for margins by subtracting 10 from left/right sides
-            const width = rect.right - rect.left - 20;
-            const progress = Math.min(1, Math.max(0, (e.pageX - rect.left - 10) / width));
-            const positionInPixels = progress * width;
+            const trackWidth = progressBarTrackWidth(rect);
+            const progress = progressBarProgress(e.pageX, rect);
+            setHoverState({ progress, trackWidth });
             // subtract to center the mouse in the center of the preview box
-            setHoverX(positionInPixels - 145 / 2 + 10);
+            setHoverX(progress * trackWidth - 145 / 2 + 10);
 
+            if (onSeekPreview == undefined) return;
             const previewSrc = onSeekPreview(progress);
             if (previewSrc) {
                 setThumbnailSrc(previewSrc);
@@ -336,6 +391,18 @@ function ProgressBar({ onSeek, onSeekPreview, value, videoHeight, videoWidth, pr
 
     return (
         <div className={classes.root}>
+            {mouseOver && hoverTimestamp && (
+                <div
+                    aria-hidden="true"
+                    style={{
+                        left: timestampPreviewLeft,
+                        width: timestampPreviewWidth,
+                    }}
+                    className={timestampPreviewClassName}
+                >
+                    {hoverTimestamp}
+                </div>
+            )}
             {mouseOver && (
                 <div
                     style={{ left: hoverX, width: videoWidth ?? 145, display: previewEnabled ? 'block' : 'none' }}
@@ -575,6 +642,7 @@ interface ControlsProps {
     onBlurOverlayToggle?: () => void;
     videoWidth?: number | undefined;
     videoHeight?: number | undefined;
+    timestampPreviewEnabled?: boolean;
 }
 
 export default function Controls({
@@ -634,6 +702,7 @@ export default function Controls({
     videoWidth,
     videoHeight,
     previewEnabled,
+    timestampPreviewEnabled = false,
 }: ControlsProps) {
     const classes = useControlStyles();
     const { t } = useTranslation();
@@ -963,9 +1032,11 @@ export default function Controls({
                             onSeekPreview={onSeekPreview}
                             onSeek={handleSeek}
                             value={progress * 100}
+                            length={length}
                             videoHeight={videoHeight}
                             videoWidth={videoWidth}
                             previewEnabled={previewEnabled}
+                            timestampPreviewEnabled={timestampPreviewEnabled}
                         />
                         {!hideToolbar && (
                             <Grid container className={classes.gridContainer} direction="row" wrap="nowrap">

--- a/common/app/components/VideoPlayer.tsx
+++ b/common/app/components/VideoPlayer.tsx
@@ -1997,6 +1997,7 @@ export default function VideoPlayer({
                 onLoadFiles={popOut ? undefined : handleLoadFiles}
                 blurOverlayEnabled={blurOverlayVisible}
                 onBlurOverlayToggle={handleBlurOverlayToggle}
+                timestampPreviewEnabled={!isMobile}
             />
         </div>
     );

--- a/common/app/components/progress-bar.test.ts
+++ b/common/app/components/progress-bar.test.ts
@@ -1,0 +1,51 @@
+import {
+    centeredProgressBarPreviewLeft,
+    clampProgressBarPreviewLeft,
+    formatProgressTimestamp,
+    progressBarProgress,
+    progressBarTrackWidth,
+} from './progress-bar';
+
+const bounds = { left: 100, right: 300 };
+
+it('calculates the inner progress bar width excluding horizontal padding', () => {
+    expect(progressBarTrackWidth(bounds)).toBe(180);
+});
+
+it('calculates progress from a pointer x coordinate', () => {
+    expect(progressBarProgress(110, bounds)).toBe(0);
+    expect(progressBarProgress(200, bounds)).toBe(0.5);
+    expect(progressBarProgress(290, bounds)).toBe(1);
+});
+
+it('clamps progress to the valid range', () => {
+    expect(progressBarProgress(50, bounds)).toBe(0);
+    expect(progressBarProgress(400, bounds)).toBe(1);
+});
+
+it('returns zero progress when the track has no usable width', () => {
+    expect(progressBarProgress(200, { left: 100, right: 110 })).toBe(0);
+});
+
+it('centers and clamps preview left positions', () => {
+    expect(centeredProgressBarPreviewLeft(0, 180, 58)).toBe(0);
+    expect(centeredProgressBarPreviewLeft(0.5, 180, 58)).toBe(71);
+    expect(centeredProgressBarPreviewLeft(1, 180, 58)).toBe(142);
+});
+
+it('clamps explicit preview left positions', () => {
+    expect(clampProgressBarPreviewLeft(-10, 180, 58)).toBe(0);
+    expect(clampProgressBarPreviewLeft(71, 180, 58)).toBe(71);
+    expect(clampProgressBarPreviewLeft(200, 180, 58)).toBe(142);
+});
+
+it('formats hover timestamps using media length', () => {
+    expect(formatProgressTimestamp(0.5, 10 * 60 * 1000)).toBe('05:00');
+    expect(formatProgressTimestamp(0.5, 2 * 60 * 60 * 1000)).toBe('01:00:00');
+});
+
+it('does not format timestamps for invalid media lengths', () => {
+    expect(formatProgressTimestamp(0.5, 0)).toBeUndefined();
+    expect(formatProgressTimestamp(0.5, Number.NaN)).toBeUndefined();
+    expect(formatProgressTimestamp(0.5, Number.POSITIVE_INFINITY)).toBeUndefined();
+});

--- a/common/app/components/progress-bar.ts
+++ b/common/app/components/progress-bar.ts
@@ -1,0 +1,41 @@
+import { timeDurationDisplay } from '../../util';
+
+const horizontalPadding = 10;
+
+interface HorizontalBounds {
+    left: number;
+    right: number;
+}
+
+export function progressBarTrackWidth(bounds: HorizontalBounds): number {
+    return Math.max(0, bounds.right - bounds.left - 2 * horizontalPadding);
+}
+
+export function progressBarProgress(pointerX: number, bounds: HorizontalBounds): number {
+    const width = progressBarTrackWidth(bounds);
+
+    if (width <= 0) {
+        return 0;
+    }
+
+    return Math.min(1, Math.max(0, (pointerX - bounds.left - horizontalPadding) / width));
+}
+
+export function centeredProgressBarPreviewLeft(progress: number, trackWidth: number, previewWidth: number): number {
+    const unclampedLeft = progress * trackWidth + horizontalPadding - previewWidth / 2;
+    return clampProgressBarPreviewLeft(unclampedLeft, trackWidth, previewWidth);
+}
+
+export function clampProgressBarPreviewLeft(left: number, trackWidth: number, previewWidth: number): number {
+    const totalWidth = trackWidth + 2 * horizontalPadding;
+    return Math.min(Math.max(0, left), Math.max(0, totalWidth - previewWidth));
+}
+
+export function formatProgressTimestamp(progress: number, length: number): string | undefined {
+    if (!Number.isFinite(length) || length <= 0) {
+        return undefined;
+    }
+
+    const timestamp = Math.min(1, Math.max(0, progress)) * length;
+    return timeDurationDisplay(timestamp, length, false);
+}


### PR DESCRIPTION
Assisted-by: codex:gpt-5.5

﻿## Summary
- Add a configurable timestamp preview for the local video scrub bar, defaulted on.
- Respect the existing Subtitle above thumbnail layering setting for timestamp previews too.
- Add small progress bar helpers/tests plus settings schema and locale entries.

<img width="637" height="247" alt="image" src="https://github.com/user-attachments/assets/7ad0263a-9fc4-447d-b9e9-86069e5e951d" />
<img width="86" height="109" alt="image" src="https://github.com/user-attachments/assets/89cb5800-60f8-44fa-b3ad-c6892a057504" />
<img width="840" height="161" alt="image" src="https://github.com/user-attachments/assets/733b9a6f-738e-4e2d-ac93-dd221b16d2de" />

