### PR TITLE
Add setting to hide page elements during clean screenshots

### DIFF
--- a/common/components/StreamingVideoSettingsTab.tsx
+++ b/common/components/StreamingVideoSettingsTab.tsx
@@ -55,6 +55,7 @@ const StreamingVideoSettingsTab: React.FC<Props> = ({
         streamingRecordMedia,
         streamingTakeScreenshot,
         streamingCleanScreenshot,
+        streamingScreenshotHiddenSelectors,
         streamingCropScreenshot,
         streamingSubsDragAndDrop,
         streamingAutoSync,
@@ -162,6 +163,18 @@ const StreamingVideoSettingsTab: React.FC<Props> = ({
                     label={t('extension.settings.cleanScreenshot')}
                     labelPlacement="start"
                 />
+                {streamingCleanScreenshot && (
+                    <SettingsTextField
+                        multiline
+                        minRows={2}
+                        color="primary"
+                        fullWidth
+                        label={t('extension.settings.screenshotHiddenSelectors')}
+                        helperText={t('extension.settings.screenshotHiddenSelectorsHelperText')}
+                        value={streamingScreenshotHiddenSelectors}
+                        onChange={(e) => onSettingChanged('streamingScreenshotHiddenSelectors', e.target.value)}
+                    />
+                )}
                 <SwitchLabelWithHoverEffect
                     control={
                         <Switch

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "Untertitel automatisch laden",
             "autoLoadDetectedSubsFailure": "Prompt on failure to auto-load subtitles",
             "cleanScreenshot": "Screenshot säubern",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "Maximale Stille zwischen gesprochenen Zeilen für komprimiertes Audio",
             "cropScreenshot": "Screenshot zuschneiden",
             "displaySubtitles": "Untertitel anzeigen",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "Auto-load detected subtitles",
             "autoLoadDetectedSubsFailure": "Prompt on failure to auto-load subtitles",
             "cleanScreenshot": "Clean screenshot when mining",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "Condensed playback minimum skip interval",
             "cropScreenshot": "Crop screenshot when mining",
             "displaySubtitles": "Display subtitles",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "Cargar subtítulos detectados automáticamente",
             "autoLoadDetectedSubsFailure": "Error al cargar los subtítulos automáticamente",
             "cleanScreenshot": "Limpiar captura de pantalla al minar",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "Intervalo mínimo de salto para reproducción condensada",
             "cropScreenshot": "Recortar captura de pantalla al minar",
             "displaySubtitles": "Mostrar subtítulos",

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "Lataa automaattisesti havaitut tekstitykset",
             "autoLoadDetectedSubsFailure": "Kysy tekstityksen automaattisen lataamisen epäonnistumisesta",
             "cleanScreenshot": "Puhdista kuvakaappaus louhinnassa",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "Tiivistetty toiston minimiaika väliin",
             "cropScreenshot": "Rajaa kuvakaappausta louhimassa",
             "displaySubtitles": "Näytä tekstitykset",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "Chargement automatique des sous-titres détectés",
             "autoLoadDetectedSubsFailure": "Prompt on failure to auto-load subtitles",
             "cleanScreenshot": "Nettoyer la capture d’écran lors de l’extraction",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "Intervalle de saut minimal en lecture condensée",
             "cropScreenshot": "Rogner la capture d’écran lors de l’extraction",
             "displaySubtitles": "Afficher les sous-titres",

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "Muat otomatis takarir yang terdeteksi",
             "autoLoadDetectedSubsFailure": "Tampilkan peringatan jika gagal memuat takarir secara otomatis",
             "cleanScreenshot": "Bersihkan tangkapan layar saat menambang",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "Interval lompatan minimum untuk pemutaran ringkas",
             "cropScreenshot": "Potong tangkapan layar saat menambang",
             "displaySubtitles": "Tampilkan takarir",

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "Carica automaticamente i sottotitoli rilevati",
             "autoLoadDetectedSubsFailure": "Chiedi in caso di errore nel caricamento automatico dei sottotitoli",
             "cleanScreenshot": "Screenshot pulito durante l'estrazione",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "Intervallo minimo di salto per la riproduzione condensata",
             "cropScreenshot": "Ritaglia lo screenshot durante l'estrazione",
             "displaySubtitles": "Mostra sottotitoli",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "字幕を探知したら自動的にロードする",
             "autoLoadDetectedSubsFailure": "字幕の自動ロードに失敗した時、字幕トラックウィンドウを表示",
             "cleanScreenshot": "マイニング時のスクリーンショットを綺麗にする",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "短縮プレイバックでスキップする時間の最小値",
             "cropScreenshot": "マイニング時のスクリーンショットをクロッピングする",
             "displaySubtitles": "字幕表示オン/オフ",

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "자동 감지된 자막 불러오기",
             "autoLoadDetectedSubsFailure": "자동 로드 자막에 실패한 프롬프트",
             "cleanScreenshot": "자막 추출시 화면 요소 없이 스크린샷 캡처",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "건너 뛰기 모드 실핼중 최소 건너뛰기 간격",
             "cropScreenshot": "자막 추출시 스크린샷에서 불필요한 영역 제거",
             "displaySubtitles": "자막 표시",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "Automatyczne ładowanie wykrytych napisów",
             "autoLoadDetectedSubsFailure": "Prompt on failure to auto-load subtitles",
             "cleanScreenshot": "Czyść zrzut ekranu",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "Minimalny interwał pominięcia odtwarzania skondensowanego",
             "cropScreenshot": "Przycinaj zrzut ekranu",
             "displaySubtitles": "Wyświetl napisy",

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "Carregar automaticamente legendas detectadas",
             "autoLoadDetectedSubsFailure": "Prompt sobre falha de carregamento automático de legendas",
             "cleanScreenshot": "Limpar captura de tela ao minerar",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "Intervalo mínimo de salto para reprodução condensada",
             "cropScreenshot": "Cortar captura de tela ao minerar",
             "displaySubtitles": "Exibir legendas",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "Автоматически загружать обнаруженные субтитры",
             "autoLoadDetectedSubsFailure": "Предлагать загружать субтитры автоматически при ошибке",
             "cleanScreenshot": "Создать чистый скриншот",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "Режим сжатого воспроизведения: минимальный интервал отсутствия речи для пропуска",
             "cropScreenshot": "Обрезать скриншот",
             "displaySubtitles": "Отображать субтитры",

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -213,6 +213,8 @@
             "autoLoadDetectedSubs": "自动加载检测到的字幕",
             "autoLoadDetectedSubsFailure": "自动加载字幕失败",
             "cleanScreenshot": "截图时隐藏界面元素",
+            "screenshotHiddenSelectors": "Hide elements during clean screenshots",
+            "screenshotHiddenSelectorsHelperText": "CSS selectors (one per line) of page elements to temporarily hide while taking a clean screenshot, e.g. a dictionary pop-up overlay such as Yomitan's.",
             "condensedPlaybackMinSkipInterval": "紧凑播放的最小跳过间隔",
             "cropScreenshot": "挖掘时裁剪截图",
             "displaySubtitles": "显示字幕",

--- a/common/settings/settings-import-export.ts
+++ b/common/settings/settings-import-export.ts
@@ -505,6 +505,9 @@ const settingsSchema = {
         streamingCleanScreenshot: {
             type: 'boolean',
         },
+        streamingScreenshotHiddenSelectors: {
+            type: 'string',
+        },
         streamingCropScreenshot: {
             type: 'boolean',
         },

--- a/common/settings/settings-provider.ts
+++ b/common/settings/settings-provider.ts
@@ -199,6 +199,7 @@ export const defaultSettings: AsbplayerSettings = {
     streamingRecordMedia: true,
     streamingTakeScreenshot: true,
     streamingCleanScreenshot: true,
+    streamingScreenshotHiddenSelectors: '',
     streamingCropScreenshot: true,
     streamingSubsDragAndDrop: true,
     streamingAutoSync: false,

--- a/common/settings/settings.ts
+++ b/common/settings/settings.ts
@@ -655,6 +655,9 @@ export interface StreamingVideoSettings {
     readonly streamingRecordMedia: boolean;
     readonly streamingTakeScreenshot: boolean;
     readonly streamingCleanScreenshot: boolean;
+    // Newline-separated CSS selectors of elements to temporarily hide during clean screenshots
+    // (e.g. a third-party dictionary pop-up overlay such as Yomitan's)
+    readonly streamingScreenshotHiddenSelectors: string;
     readonly streamingCropScreenshot: boolean;
     readonly streamingSubsDragAndDrop: boolean;
     readonly streamingAutoSync: boolean;

--- a/docs/docs/guides/one-click-mining.md
+++ b/docs/docs/guides/one-click-mining.md
@@ -31,3 +31,17 @@ Configure Yomitan:
 ## Mine with **Yomitan** as usual
 
 Mining sentences using Yomitan will create cards with word definition, image, and audio already provided. A truly one-click mining flow can be achieved if the proxy's `POST_MINE_ACTION` is `2` (update last card).
+
+## Keep the Yomitan pop-up out of screenshots
+
+Because you mine by clicking inside Yomitan's pop-up, the pop-up is usually still on screen when asbplayer captures its screenshot — so it ends up baked into the image. asbplayer's **Clean screenshot when mining** option only hides asbplayer's own UI, not overlays drawn by other extensions.
+
+To hide the pop-up, use the **Hide elements during clean screenshots** setting (under **Settings → Streaming video → Mining**) and add Yomitan's pop-up selector:
+
+```
+.yomitan-popup
+```
+
+This requires turning off Yomitan's **"Use a secure container around popups"** option (under the **Security** section of Yomitan's settings, after clicking **More…**), which otherwise keeps the pop-up out of reach of page-side scripts such as asbplayer.
+
+That option is a security feature, so rather than disabling it globally, use a [Yomitan profile](https://yomitan.wiki/) with a URL condition to effectively whitelist only the sites you mine from: create a profile whose condition matches those domains, turn the option off in that profile, and leave it on everywhere else.

--- a/docs/docs/reference/settings.md
+++ b/docs/docs/reference/settings.md
@@ -487,6 +487,22 @@ When mining a subtitle, take a screenshot for inclusion in the flashcrd.
 
 When mining a subtitle and screenshots are enabled, keep the screenshot "clean" by removing any HTML elements on top of the video element before taking the screenshot.
 
+### Hide elements during clean screenshots
+
+asbplayer's clean screenshot only hides asbplayer's own UI (subtitles, controls, etc.). Overlays drawn by _other_ extensions — for example a dictionary pop-up such as [Yomitan](https://yomitan.wiki/)'s — are not asbplayer's to hide, so they can end up in the screenshot.
+
+This setting lets you list the CSS selectors of such elements, one per line. asbplayer temporarily applies `display: none` to anything matching while it captures a clean screenshot, then restores it immediately afterward. It is only used when **Clean screenshot when mining** is enabled.
+
+To find a selector, right-click the overlay and choose _Inspect_, then write a selector that matches it (for example a class selector like `.yomitan-popup`).
+
+:::warning Yomitan's pop-up requires an extra step
+
+By default Yomitan renders its pop-up inside a closed shadow DOM (the **"Use a secure container around popups"** option, found under the **Security** section of Yomitan's settings after clicking **More…**), which page-side scripts such as asbplayer cannot reach — so a selector like `.yomitan-popup` will match nothing until you turn it off.
+
+That option is a security feature. Rather than disabling it globally, use a [Yomitan profile](https://yomitan.wiki/) with a URL condition to effectively whitelist only the sites you mine from: create a profile whose condition matches those domains, turn the option off in that profile, and leave it on everywhere else.
+
+:::
+
 ### Screenshot capture delay
 
 How long to wait after the target subtitle appears before taking the screenshot.

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -175,6 +175,8 @@ export default class Binding {
     private clickToMineDefaultAction: PostMineAction;
     private takeScreenshot: boolean;
     private cleanScreenshot: boolean;
+    private screenshotHiddenSelectors: string;
+    private screenshotHiddenSelectorsStyleElement?: HTMLStyleElement;
     private audioPaddingStart: number;
     private audioPaddingEnd: number;
     private maxImageWidth: number;
@@ -235,6 +237,7 @@ export default class Binding {
         this.recordMedia = true;
         this.takeScreenshot = true;
         this.cleanScreenshot = true;
+        this.screenshotHiddenSelectors = '';
         this.clickToMineDefaultAction = PostMineAction.showAnkiDialog;
         this.audioPaddingStart = 0;
         this.audioPaddingEnd = 500;
@@ -937,6 +940,7 @@ export default class Binding {
                         const screenshotTakenMessage = request.message as ScreenshotTakenMessage;
                         this.subtitleController.forceHideSubtitles = false;
                         this.mobileVideoOverlayController.forceHide = false;
+                        this._showScreenshotSelectors();
                         this.controlsController.show();
 
                         if (!this.recordingMedia && screenshotTakenMessage.ankiUiState) {
@@ -1092,6 +1096,7 @@ export default class Binding {
         this.recordMedia = currentSettings.streamingRecordMedia;
         this.takeScreenshot = currentSettings.streamingTakeScreenshot;
         this.cleanScreenshot = currentSettings.streamingTakeScreenshot && currentSettings.streamingCleanScreenshot;
+        this.screenshotHiddenSelectors = currentSettings.streamingScreenshotHiddenSelectors;
         this.condensedPlaybackMinimumSkipIntervalMs = currentSettings.streamingCondensedPlaybackMinimumSkipIntervalMs;
         this.fastForwardModePlaybackRate = currentSettings.fastForwardModePlaybackRate;
         this.imageDelay = currentSettings.streamingScreenshotDelay;
@@ -1425,8 +1430,34 @@ export default class Binding {
             this.notificationController.hide();
             this.subtitleController.forceHideSubtitles = true;
             this.mobileVideoOverlayController.forceHide = true;
+            this._hideScreenshotSelectors();
             await this.controlsController.hide();
         }
+    }
+
+    private _hideScreenshotSelectors() {
+        this._showScreenshotSelectors();
+
+        const selectors = this.screenshotHiddenSelectors
+            .split('\n')
+            .map((selector) => selector.trim())
+            .filter((selector) => selector.length > 0);
+
+        if (selectors.length === 0) {
+            return;
+        }
+
+        // Use `display: none` rather than `visibility: hidden` so this wins the cascade even against
+        // overlays that set an inline `visibility: visible !important` (e.g. Yomitan's popup iframe).
+        const styleElement = document.createElement('style');
+        styleElement.textContent = `${selectors.join(',\n')} { display: none !important; }`;
+        document.head.appendChild(styleElement);
+        this.screenshotHiddenSelectorsStyleElement = styleElement;
+    }
+
+    private _showScreenshotSelectors() {
+        this.screenshotHiddenSelectorsStyleElement?.remove();
+        this.screenshotHiddenSelectorsStyleElement = undefined;
     }
 
     async rerecord(start: number, end: number, uiState: AnkiUiSavedState) {


### PR DESCRIPTION
## Summary

asbplayer's **Clean screenshot when mining** option only hides asbplayer's own UI (subtitles, controls, etc.). Overlays drawn by *other* extensions — most notably a dictionary pop-up such as [Yomitan](https://yomitan.wiki/)'s — are not asbplayer's to hide, so they get baked into the mined screenshot.

This is especially common in the **one-click mining** flow, where you mine by clicking inside Yomitan's pop-up while it's still on screen, so the pop-up is almost always present when the screenshot is captured.

This PR adds a **Hide elements during clean screenshots** setting (Settings → Streaming video → Mining, shown only when "Clean screenshot when mining" is enabled). It accepts CSS selectors, one per line. While capturing a clean screenshot, asbplayer applies `display: none` to anything matching, then restores it immediately afterward.

`display: none` is used (rather than `visibility: hidden`) so the rule wins the cascade even against overlays that set an inline `visibility: visible !important` — e.g. Yomitan's pop-up iframe.

## Notes on Yomitan

By default Yomitan renders its pop-up inside a closed shadow DOM (its "Use a secure container around popups" security option), which page-side scripts like asbplayer can't reach. To use this with Yomitan, that option must be turned off — ideally scoped to trusted mining sites via a URL-conditioned Yomitan profile. This is documented in the guide and settings reference.

## Changes

- New `streamingScreenshotHiddenSelectors` setting (interface, default `''`, import/export schema).
- Settings UI field in the Streaming video → Mining section.
- `binding.ts` injects/removes a `<style>` rule around clean screenshot capture.
- English localization string (propagated to all locale files via the merge script).
- Docs: settings reference entry + a "Keep the Yomitan pop-up out of screenshots" section in the one-click mining guide.

## Testing

- `yarn workspace @project/extension run build:dev` succeeds (type-checks).
- ESLint and Prettier clean on changed source.
- `settings-import-export` tests pass.

Assisted-by: Claude:claude-opus-4-8
