### PR TITLE
Virtualize subtitles to improve performance and memory usage

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,7 +6,7 @@ labels: ''
 assignees: ''
 ---
 
-Before submitting a feature request, please look through the asbplayer readme (https://github.com/asbplayer/asbplayer) and settings (https://app.asbplayer.dev/?view=settings)
+Before submitting a feature request, please look through the asbplayer readme (https://github.com/asbplayer/asbplayer), docs (https://docs.asbplayer.dev/docs/reference/settings), and settings (https://app.asbplayer.dev/?view=settings)
 to be sure that your feature request isn't already implemented.
 
 **Is your feature request related to a problem? Please describe.**

--- a/common/app/components/Player.tsx
+++ b/common/app/components/Player.tsx
@@ -8,11 +8,11 @@ import {
     AutoPausePreference,
     CardModel,
     CardTextFieldValues,
+    IndexedSubtitleModel,
     PlayMode,
     PostMineAction,
     PostMinePlayback,
     RequestSubtitlesResponse,
-    RichSubtitleModel,
     SubtitleModel,
     TokenizedSubtitleModel,
     VideoTabModel,
@@ -20,7 +20,6 @@ import {
 import {
     ApplyStrategy,
     AsbplayerSettings,
-    DictionaryTrack,
     isTrackAutoCopyable,
     isTrackSeekable,
     SettingsProvider,
@@ -29,7 +28,7 @@ import {
 } from '@project/common/settings';
 import { DictionaryProvider } from '@project/common/dictionary-db';
 import { SubtitleCollection } from '@project/common/subtitle-collection';
-import { renderRichTextOntoSubtitles, HoveredToken, SubtitleAnnotations } from '@project/common/subtitle-annotations';
+import { HoveredToken, SubtitleAnnotations } from '@project/common/subtitle-annotations';
 import { SubtitleReader } from '@project/common/subtitle-reader';
 import { KeyBinder } from '@project/common/key-binder';
 import { surroundingSubtitles, timeDurationDisplay } from '@project/common/util';
@@ -98,17 +97,8 @@ function trackLength(
     return Math.max(videoLength, subtitlesLength);
 }
 
-function subtitlesForPlayer<T extends RichSubtitleModel>(
-    subtitles: T[],
-    dictionaryTracks: DictionaryTrack[] | undefined
-): T[] {
-    const playerSubtitles = subtitles.map((subtitle) => ({
-        ...subtitle,
-        richText: undefined,
-        richTextOnHover: undefined,
-    }));
-    renderRichTextOntoSubtitles(playerSubtitles, 'subtitlePlayer', dictionaryTracks);
-    return playerSubtitles;
+function subtitlesForPlayer<T extends IndexedSubtitleModel>(subtitles: T[]): T[] {
+    return subtitles.map((subtitle) => ({ ...subtitle }));
 }
 
 function pause(clock: Clock, mediaAdapter: MediaAdapter, forwardToMedia: boolean) {
@@ -444,8 +434,6 @@ const Player = React.memo(function Player({
                 displayTime: timeDurationDisplay(s.originalStart + offset, length),
                 track: s.track,
                 index: i,
-                richText: s.richText,
-                richTextOnHover: s.richTextOnHover,
                 tokenization: s.tokenization,
             }));
 
@@ -522,8 +510,6 @@ const Player = React.memo(function Player({
                         tokenization: s.tokenization,
                     }));
 
-                    renderRichTextOntoSubtitles(subtitles, 'subtitlePlayer', settingsRef.current.dictionaryTracks);
-
                     setSubtitlesSentThroughChannel(false);
                     onSubtitles(subtitles);
                     setPlayModes((playModes) =>
@@ -559,8 +545,8 @@ const Player = React.memo(function Player({
             settingsProvider,
             subtitleCollectionOptions,
             mediaId,
-            (updatedSubtitles, dictionaryTracks) => {
-                const playerSubtitles = subtitlesForPlayer(updatedSubtitles, dictionaryTracks);
+            (updatedSubtitles) => {
+                const playerSubtitles = subtitlesForPlayer(updatedSubtitles);
                 if (channel) channel.subtitlesUpdated(updatedSubtitles);
                 onSubtitles((prevSubtitles) => {
                     if (!prevSubtitles?.length) return prevSubtitles;
@@ -569,8 +555,6 @@ const Player = React.memo(function Player({
                         allSubtitles[s.index] = {
                             ...allSubtitles[s.index],
                             text: s.text,
-                            richText: s.richText,
-                            richTextOnHover: s.richTextOnHover,
                             tokenization: s.tokenization,
                         };
                     }
@@ -601,7 +585,7 @@ const Player = React.memo(function Player({
 
     useEffect(() => {
         return channel?.onSubtitlesUpdated((updatedSubtitles) => {
-            const playerSubtitles = subtitlesForPlayer(updatedSubtitles, settingsRef.current.dictionaryTracks);
+            const playerSubtitles = subtitlesForPlayer(updatedSubtitles);
             onSubtitles((prevSubtitles) => {
                 if (!prevSubtitles?.length) return prevSubtitles;
                 const allSubtitles = prevSubtitles.slice();
@@ -615,8 +599,6 @@ const Player = React.memo(function Player({
                         allSubtitles[s.index] = {
                             ...allSubtitles[s.index],
                             text: s.text,
-                            richText: s.richText,
-                            richTextOnHover: s.richTextOnHover,
                             tokenization: s.tokenization,
                         };
                     }
@@ -639,7 +621,7 @@ const Player = React.memo(function Player({
                 | undefined;
             if (!response) return;
             const { subtitles: updatedSubtitles } = response;
-            const playerSubtitles = subtitlesForPlayer(updatedSubtitles, settingsRef.current.dictionaryTracks);
+            const playerSubtitles = subtitlesForPlayer(updatedSubtitles);
             onSubtitles((prevSubtitles) => {
                 if (!prevSubtitles?.length) return prevSubtitles;
                 const allSubtitles = prevSubtitles.slice();
@@ -653,8 +635,6 @@ const Player = React.memo(function Player({
                         allSubtitles[s.index] = {
                             ...allSubtitles[s.index],
                             text: s.text,
-                            richText: s.richText,
-                            richTextOnHover: s.richTextOnHover,
                             tokenization: s.tokenization,
                         };
                     }

--- a/common/app/components/SubtitlePlayer.tsx
+++ b/common/app/components/SubtitlePlayer.tsx
@@ -74,6 +74,8 @@ import { MineSubtitleCommand, WebSocketClient } from '../../web-socket-client';
 import { clampSubtitlePlayerWidth } from './video-subtitle-split';
 import './subtitles.css';
 
+const findDelayMs = 300;
+
 let lastKnownWidth: number | undefined;
 export const minSubtitlePlayerWidth = 200;
 const calculateInitialWidth = () => lastKnownWidth ?? Math.max(350, 0.25 * window.innerWidth);
@@ -262,7 +264,7 @@ const parseRegexQuery = (query: string): RegExp | undefined => {
 
 const subtitleSearchableText = (subtitle: DisplaySubtitleModel): string => {
     const tokens = subtitle.tokenization?.tokens;
-    if (!tokens || !tokens.length) return subtitle.text;
+    if (!tokens?.length) return subtitle.text;
     let readings = '';
     for (const token of tokens) {
         for (const reading of token.readings) {
@@ -1016,7 +1018,7 @@ export default function SubtitlePlayer({
 
             if (cancelled) return;
             setFindExpansion({ query: trimmed, terms: normalizedLookupTerms(...queryForms, ...lemmaTerms) });
-        }, 300);
+        }, findDelayMs);
 
         return () => {
             cancelled = true;

--- a/common/app/components/SubtitlePlayer.tsx
+++ b/common/app/components/SubtitlePlayer.tsx
@@ -1,6 +1,16 @@
-import React, { ForwardedRef, useCallback, useEffect, useState, useRef, createRef, RefObject, ReactNode } from 'react';
+import React, { ForwardedRef, useCallback, useEffect, useMemo, useState, useRef, ReactNode } from 'react';
 import { makeStyles } from '@mui/styles';
 import { type Theme } from '@mui/material';
+import {
+    ContextProp,
+    ItemProps,
+    ScrollerProps,
+    TableBodyProps,
+    TableComponents,
+    TableProps,
+    TableVirtuoso,
+    TableVirtuosoHandle,
+} from 'react-virtuoso';
 import { keysAreEqual } from '../services/util';
 import { useResize } from '../hooks/use-resize';
 import { ScreenLocation, useDragging } from '../hooks/use-dragging';
@@ -8,13 +18,17 @@ import { useTranslation } from 'react-i18next';
 import {
     PostMineAction,
     SubtitleModel,
-    SubtitleHtml,
     AutoPauseContext,
     CopySubtitleWithAdditionalFieldsMessage,
     CardTextFieldValues,
     RichSubtitleModel,
 } from '@project/common';
-import { AsbplayerSettings, TokenAnnotationConfig, tokenAnnotationStyleValues } from '@project/common/settings';
+import {
+    AsbplayerSettings,
+    DictionaryTrack,
+    TokenAnnotationConfig,
+    tokenAnnotationStyleValues,
+} from '@project/common/settings';
 import {
     surroundingSubtitles,
     mockSurroundingSubtitles,
@@ -31,8 +45,7 @@ import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableRow, { TableRowProps } from '@mui/material/TableRow';
+import TableRow from '@mui/material/TableRow';
 import Tooltip from '../../components/Tooltip';
 import Typography from '@mui/material/Typography';
 import Clock from '../services/clock';
@@ -60,17 +73,7 @@ const lineIntersects = (a1: number, b1: number, a2: number, b2: number) => {
     return b2 >= a1;
 };
 
-const intersects = (
-    startLocation: ScreenLocation,
-    endLocation: ScreenLocation,
-    tableRow: React.RefObject<HTMLElement | null>
-) => {
-    const element = tableRow.current;
-
-    if (!element) {
-        return false;
-    }
-
+const intersects = (startLocation: ScreenLocation, endLocation: ScreenLocation, element: HTMLElement) => {
     const selectionRect = {
         x: Math.min(startLocation.clientX, endLocation.clientX),
         y: Math.min(startLocation.clientY, endLocation.clientY),
@@ -104,19 +107,12 @@ const useSubtitlePlayerStyles = makeStyles<Theme, StylesProps, string>((theme) =
     container: {
         height: ({ appBarHidden, appBarHeight }) => (appBarHidden ? '100vh' : `calc(100vh - ${appBarHeight}px)`),
         position: 'relative',
-        overflowX: 'hidden',
+        overflow: 'hidden',
         backgroundColor: theme.palette.background.default,
         width: ({ resizable }) => (resizable ? 'auto' : '100%'),
         '&:focus': {
             outline: 'none',
         },
-    },
-    table: {
-        backgroundColor: theme.palette.background.default,
-        marginBottom: 75, // so the last row doesn't collide with controls
-    },
-    unselectableTable: {
-        userSelect: 'none',
     },
     noSubtitles: {
         height: '100%',
@@ -203,73 +199,86 @@ enum SelectionState {
     outsideSelection = 2,
 }
 
-interface SubtitleRowProps extends TableRowProps {
-    index: number;
+interface SubtitleRowContext {
     compressed: boolean;
-    selectionState?: SelectionState;
-    disabled: boolean;
-    subtitle: DisplaySubtitleModel;
     showCopyButton: boolean;
-    subtitleRef: RefObject<HTMLTableRowElement | null>;
+    disabledSubtitleTracks: { [track: number]: boolean };
+    dictionaryTracks: DictionaryTrack[];
+    selectedSubtitleIndexes?: boolean[];
+    highlightedJumpToSubtitleIndex?: number;
+    currentSubtitleIndexes: { [index: number]: boolean };
     onClickSubtitle: (index: number) => void;
     onCopySubtitle: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, index: number) => void;
     onMouseOver: (e: React.MouseEvent) => void;
     onMouseOut: (e: React.MouseEvent) => void;
-    subtitleHtml: SubtitleHtml;
-    tokenAnnotationConfig?: TokenAnnotationConfig;
+    lastScrollTimestampRef: React.MutableRefObject<number>;
 }
 
-const SubtitleRow = React.memo(function SubtitleRow({
-    index,
-    selectionState,
-    subtitleRef,
-    onClickSubtitle,
-    onCopySubtitle,
-    onMouseOver,
-    onMouseOut,
-    compressed,
-    disabled,
-    subtitle,
-    showCopyButton,
-    subtitleHtml,
-    tokenAnnotationConfig,
-}: SubtitleRowProps) {
+const selectionStateForIndex = (
+    index: number,
+    selectedSubtitleIndexes: boolean[] | undefined,
+    highlightedJumpToSubtitleIndex: number | undefined
+): SelectionState | undefined => {
+    let selectionState: SelectionState | undefined;
+    if (selectedSubtitleIndexes !== undefined) {
+        selectionState = selectedSubtitleIndexes[index]
+            ? SelectionState.insideSelection
+            : SelectionState.outsideSelection;
+    }
+    if (highlightedJumpToSubtitleIndex !== undefined) {
+        selectionState =
+            highlightedJumpToSubtitleIndex === index ? SelectionState.insideSelection : SelectionState.outsideSelection;
+    }
+    return selectionState;
+};
+
+const SubtitleScroller = React.forwardRef<HTMLDivElement, ScrollerProps & ContextProp<SubtitleRowContext>>(
+    function SubtitleScroller({ style, context, ...rest }, ref) {
+        return (
+            <div
+                {...rest}
+                ref={ref}
+                style={{ ...style, overflowX: 'auto' }}
+                onWheel={() => {
+                    context.lastScrollTimestampRef.current = Date.now();
+                }}
+            />
+        );
+    }
+);
+
+const SubtitleTable = ({ context, children, ...rest }: TableProps & ContextProp<SubtitleRowContext>) => (
+    <Table {...rest}>
+        {children}
+        {/* Trailing spacer so the last row clears the controls. */}
+        <tbody aria-hidden="true">
+            <tr>
+                <td style={{ height: 75, border: 0, padding: 0 }} />
+            </tr>
+        </tbody>
+    </Table>
+);
+
+const SubtitleTableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps & ContextProp<SubtitleRowContext>>(
+    function SubtitleTableBody({ context, ...rest }, ref) {
+        return <TableBody {...rest} ref={ref} />;
+    }
+);
+
+const SubtitleTableRow = ({
+    item,
+    context,
+    ...props
+}: ItemProps<DisplaySubtitleModel> & ContextProp<SubtitleRowContext>) => {
     const classes = useSubtitleRowStyles();
-    const textRef = useRef<HTMLSpanElement>(null);
-    const [textSelected, setTextSelected] = useState<boolean>(false);
-    const className = compressed ? classes.compressedSubtitle : classes.subtitle;
-    const disabledClassName = disabled ? classes.disabledSubtitle : '';
-    const { t } = useTranslation();
-
-    if (subtitle.start < 0 || subtitle.end < 0) {
-        return null;
-    }
-
-    function handleMouseUp() {
-        const selection = document.getSelection();
-        const selected =
-            selection?.type === 'Range' && textRef.current?.isSameNode(selection.anchorNode?.parentNode ?? null);
-        setTextSelected(selected ?? false);
-    }
-
-    const content = subtitle.textImage ? (
-        <SubtitleTextImage availableWidth={window.screen.availWidth / 2} subtitle={subtitle} scale={1} />
-    ) : (
-        <span
-            ref={textRef}
-            className={`${disabledClassName} asb-subtitles`.trim()}
-            dangerouslySetInnerHTML={{
-                __html: getAnnotationsHtml(subtitle.text, subtitle.richText, subtitle.richTextOnHover),
-            }}
-            data-track={subtitle.track}
-            style={tokenAnnotationStyleValues(tokenAnnotationConfig) as React.CSSProperties}
-            onMouseOver={onMouseOver}
-            onMouseOut={onMouseOut}
-        />
+    const index = props['data-item-index'];
+    const selectionState = selectionStateForIndex(
+        index,
+        context.selectedSubtitleIndexes,
+        context.highlightedJumpToSubtitleIndex
     );
 
     let rowClassName: string;
-
     if (selectionState === undefined) {
         rowClassName = classes.subtitleRow;
     } else if (selectionState === SelectionState.insideSelection) {
@@ -280,12 +289,74 @@ const SubtitleRow = React.memo(function SubtitleRow({
 
     return (
         <TableRow
-            onClick={() => !textSelected && onClickSubtitle(index)}
-            onMouseUp={handleMouseUp}
-            ref={subtitleRef}
+            {...props}
             className={rowClassName}
-        >
-            {selectionState === undefined && (
+            selected={!!context.currentSubtitleIndexes[index]}
+            onClick={(event) => {
+                const selection = document.getSelection();
+                const row = event.currentTarget;
+                const selectingText =
+                    selection !== null &&
+                    selection.type === 'Range' &&
+                    !selection.isCollapsed &&
+                    selection.anchorNode !== null &&
+                    row.contains(selection.anchorNode);
+                if (selectingText) return;
+                context.onClickSubtitle(index);
+            }}
+        />
+    );
+};
+
+interface SubtitleRowCellsProps {
+    index: number;
+    subtitle: DisplaySubtitleModel;
+    selectionState: SelectionState | undefined;
+    disabled: boolean;
+    compressed: boolean;
+    showCopyButton: boolean;
+    tokenAnnotationConfig?: TokenAnnotationConfig;
+    onCopySubtitle: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, index: number) => void;
+    onMouseOver: (e: React.MouseEvent) => void;
+    onMouseOut: (e: React.MouseEvent) => void;
+}
+
+// Memoized so that frequently-changing context state does not re-render the row content.
+const SubtitleRowCells = React.memo(function SubtitleRowCells({
+    index,
+    subtitle,
+    selectionState,
+    disabled,
+    compressed,
+    showCopyButton,
+    tokenAnnotationConfig,
+    onCopySubtitle,
+    onMouseOver,
+    onMouseOut,
+}: SubtitleRowCellsProps) {
+    const classes = useSubtitleRowStyles();
+    const { t } = useTranslation();
+    if (subtitle.start < 0 || subtitle.end < 0) return null;
+    const className = `${compressed ? classes.compressedSubtitle : classes.subtitle} asb-subtitles`.trim();
+    const disabledClassName = disabled ? classes.disabledSubtitle : '';
+    const content = subtitle.textImage ? (
+        <SubtitleTextImage availableWidth={window.screen.availWidth / 2} subtitle={subtitle} scale={1} />
+    ) : (
+        <span
+            className={disabledClassName}
+            dangerouslySetInnerHTML={{
+                __html: getAnnotationsHtml(subtitle.text, subtitle.richText, subtitle.richTextOnHover),
+            }}
+            data-track={subtitle.track}
+            style={tokenAnnotationStyleValues(tokenAnnotationConfig) as React.CSSProperties}
+            onMouseOver={onMouseOver}
+            onMouseOut={onMouseOut}
+        />
+    );
+
+    return (
+        <>
+            {selectionState === undefined ? (
                 <Tooltip
                     disabled={!showCopyButton}
                     enterDelay={1500}
@@ -295,8 +366,9 @@ const SubtitleRow = React.memo(function SubtitleRow({
                 >
                     <TableCell className={className}>{content}</TableCell>
                 </Tooltip>
+            ) : (
+                <TableCell className={className}>{content}</TableCell>
             )}
-            {selectionState !== undefined && <TableCell className={className}>{content}</TableCell>}
             {showCopyButton && (
                 <TableCell className={classes.copyButton}>
                     <IconButton disabled={selectionState !== undefined} onClick={(e) => onCopySubtitle(e, index)}>
@@ -311,9 +383,37 @@ const SubtitleRow = React.memo(function SubtitleRow({
                     <span style={{ display: 'none' }}>.</span>
                 </div>
             </TableCell>
-        </TableRow>
+        </>
     );
 });
+
+const renderSubtitleRow = (index: number, subtitle: DisplaySubtitleModel, context: SubtitleRowContext) => (
+    <SubtitleRowCells
+        index={index}
+        subtitle={subtitle}
+        selectionState={selectionStateForIndex(
+            index,
+            context.selectedSubtitleIndexes,
+            context.highlightedJumpToSubtitleIndex
+        )}
+        disabled={!!context.disabledSubtitleTracks[subtitle.track]}
+        compressed={context.compressed}
+        showCopyButton={context.showCopyButton}
+        tokenAnnotationConfig={context.dictionaryTracks[subtitle.track]?.dictionaryTokenAnnotationConfig.subtitlePlayer}
+        onCopySubtitle={context.onCopySubtitle}
+        onMouseOver={context.onMouseOver}
+        onMouseOut={context.onMouseOut}
+    />
+);
+
+const computeSubtitleItemKey = (_index: number, subtitle: DisplaySubtitleModel) => subtitle.index;
+
+const subtitleTableComponents: TableComponents<DisplaySubtitleModel, SubtitleRowContext> = {
+    Scroller: SubtitleScroller,
+    Table: SubtitleTable,
+    TableBody: SubtitleTableBody,
+    TableRow: SubtitleTableRow,
+};
 
 interface ResizeHandleProps extends React.HTMLAttributes<HTMLDivElement> {
     isResizing: boolean;
@@ -329,6 +429,7 @@ const ResizeHandle = React.forwardRef(function ResizeHandle(
             style={{
                 ...style,
                 position: 'absolute',
+                top: 0,
                 width: isResizing ? 30 : isMobile ? 20 : 5,
                 left: isResizing ? -15 : -2.5,
                 height: '100%',
@@ -424,21 +525,11 @@ export default function SubtitlePlayer({
     const subtitleListRef = useRef<DisplaySubtitleModel[]>(undefined);
     subtitleListRef.current = subtitles;
 
-    // Maintain a stable array of refs across subtitle list changes so that
-    // individual row refs don't get a new identity on every subtitles update.
-    // This prevents jumping to subtitle when their color is updated.
-    const subtitleRefsRef = useRef<RefObject<HTMLTableRowElement | null>[]>([]);
-    const subtitleRefs = subtitleRefsRef.current;
-    if (subtitles) {
-        while (subtitleRefs.length < subtitles.length) {
-            subtitleRefs.push(createRef<HTMLTableRowElement>());
-        }
-        while (subtitleRefs.length > subtitles.length) {
-            subtitleRefs.pop();
-        }
-    } else {
-        subtitleRefsRef.current.length = 0;
-    }
+    const virtuosoRef = useRef<TableVirtuosoHandle>(null);
+    const scrollerElementRef = useRef<HTMLElement | null>(null);
+    const handleScrollerRef = useCallback((element: HTMLElement | Window | null) => {
+        scrollerElementRef.current = element instanceof HTMLElement ? element : null;
+    }, []);
 
     const subtitleCollectionRef = useRef<SubtitleAnnotations | SubtitleCollection<DisplaySubtitleModel>>(
         subtitleCollection
@@ -446,6 +537,7 @@ export default function SubtitlePlayer({
     subtitleCollectionRef.current = subtitleCollection;
 
     const highlightedSubtitleIndexesRef = useRef<{ [index: number]: boolean }>({});
+    const [currentSubtitleIndexes, setCurrentSubtitleIndexes] = useState<{ [index: number]: boolean }>({});
     const [selectedSubtitleIndexes, setSelectedSubtitleIndexes] = useState<boolean[]>();
     const [highlightedJumpToSubtitleIndex, setHighlightedJumpToSubtitleIndex] = useState<number>();
     const lengthRef = useRef<number>(0);
@@ -454,7 +546,6 @@ export default function SubtitlePlayer({
     hiddenRef.current = hidden;
     const lastScrollTimestampRef = useRef<number>(0);
     const requestAnimationRef = useRef<number>(undefined);
-    const containerRef = useRef<HTMLDivElement>(null);
     const drawerOpenRef = useRef<boolean>(undefined);
     drawerOpenRef.current = drawerOpen;
     const appBarHeight = useAppBarHeight();
@@ -464,25 +555,10 @@ export default function SubtitlePlayer({
     const onSubtitlesHighlightedRef = useRef<(subtitles: SubtitleModel[]) => void>(undefined);
     onSubtitlesHighlightedRef.current = onSubtitlesHighlighted;
 
-    // Performance optimization: Set highlight style via refs rather than React state to avoid re-renders
-    const updateHighlightedSubtitleRows = () => {
-        const highlightedIndexes = highlightedSubtitleIndexesRef.current;
-        for (let index = 0; index < subtitleRefsRef.current.length; ++index) {
-            const classList = subtitleRefsRef.current[index].current?.classList;
-
-            if (index in highlightedIndexes) {
-                classList?.add('Mui-selected');
-            } else {
-                classList?.remove('Mui-selected');
-            }
-        }
-    };
-
     // This effect should be scheduled only once as re-scheduling seems to cause performance issues.
     // Therefore all of the state it operates on is contained in refs.
     useEffect(() => {
         const update = () => {
-            const subtitleRefs = subtitleRefsRef.current;
             const clock = clockRef.current;
             const currentSubtitleIndexes: { [index: number]: boolean } = {};
             const timestamp = clock.time(lengthRef.current);
@@ -501,17 +577,16 @@ export default function SubtitlePlayer({
 
             if (!keysAreEqual(currentSubtitleIndexes, highlightedSubtitleIndexesRef.current)) {
                 highlightedSubtitleIndexesRef.current = currentSubtitleIndexes;
-                updateHighlightedSubtitleRows();
+                setCurrentSubtitleIndexes(currentSubtitleIndexes);
                 onSubtitlesHighlightedRef.current?.(showing);
 
                 if (smallestIndex !== undefined) {
-                    const scrollToSubtitleRef = subtitleRefs[smallestIndex];
                     const allowScroll = !hiddenRef.current && Date.now() - lastScrollTimestampRef.current > 5000;
 
-                    if (scrollToSubtitleRef?.current && allowScroll) {
-                        scrollToSubtitleRef.current.scrollIntoView({
-                            block: 'center',
-                            inline: 'nearest',
+                    if (allowScroll) {
+                        virtuosoRef.current?.scrollToIndex({
+                            index: smallestIndex,
+                            align: 'center',
                             behavior: 'smooth',
                         });
                     }
@@ -539,26 +614,14 @@ export default function SubtitlePlayer({
     }, []);
 
     const scrollToCurrentSubtitle = useCallback(() => {
-        const highlightedSubtitleIndexes = highlightedSubtitleIndexesRef.current;
-
-        if (!highlightedSubtitleIndexes) {
-            return;
-        }
-
-        const indexes = Object.keys(highlightedSubtitleIndexes);
-
-        if (indexes.length === 0) {
-            return;
-        }
-
-        const scrollToSubtitleRef = subtitleRefs[Number(indexes[0])];
-
-        scrollToSubtitleRef?.current?.scrollIntoView({
-            block: 'center',
-            inline: 'nearest',
+        const indexes = Object.keys(highlightedSubtitleIndexesRef.current);
+        if (indexes.length === 0) return;
+        virtuosoRef.current?.scrollToIndex({
+            index: Number(indexes[0]),
+            align: 'center',
             behavior: 'smooth',
         });
-    }, [subtitleRefs]);
+    }, []);
 
     useEffect(() => {
         if (hidden) {
@@ -574,7 +637,7 @@ export default function SubtitlePlayer({
         document.addEventListener('visibilitychange', scrollIfVisible);
 
         return () => document.removeEventListener('visibilitychange', scrollIfVisible);
-    }, [hidden, subtitleRefs, scrollToCurrentSubtitle]);
+    }, [hidden, scrollToCurrentSubtitle]);
 
     useEffect(() => {
         if (!hidden) {
@@ -583,20 +646,10 @@ export default function SubtitlePlayer({
     }, [hidden, scrollToCurrentSubtitle]);
 
     useEffect(() => {
-        if (hiddenRef.current) {
-            return;
-        }
-
-        const subtitleRefs = subtitleRefsRef.current;
-
-        if (!subtitleRefs || subtitleRefs.length === 0) {
-            return;
-        }
-
-        const firstSubtitleRef = subtitleRefs[0];
-        firstSubtitleRef?.current?.scrollIntoView({
-            block: 'center',
-            inline: 'nearest',
+        if (hiddenRef.current || !subtitleListRef.current?.length) return;
+        virtuosoRef.current?.scrollToIndex({
+            index: 0,
+            align: 'center',
             behavior: 'smooth',
         });
     }, [lastJumpToTopTimestamp]);
@@ -682,17 +735,6 @@ export default function SubtitlePlayer({
     }, [keyBinder, clock, length, disableKeyEvents, settings.seekDuration, onSeek]);
 
     useEffect(() => {
-        function handleScroll() {
-            lastScrollTimestampRef.current = Date.now();
-        }
-
-        const table = containerRef.current;
-        table?.addEventListener('wheel', handleScroll, { passive: true });
-
-        return () => table?.removeEventListener('wheel', handleScroll);
-    }, [containerRef, lastScrollTimestampRef]);
-
-    useEffect(() => {
         if (!jumpToSubtitle || !subtitles) {
             return;
         }
@@ -712,15 +754,15 @@ export default function SubtitlePlayer({
         onJumpToSubtitleHandled?.();
 
         if (!hiddenRef.current && jumpToIndex !== -1) {
-            subtitleRefs[jumpToIndex]?.current?.scrollIntoView({
-                block: 'center',
-                inline: 'nearest',
+            virtuosoRef.current?.scrollToIndex({
+                index: jumpToIndex,
+                align: 'center',
                 behavior: 'smooth',
             });
             setHighlightedJumpToSubtitleIndex(jumpToIndex);
             setTimeout(() => setHighlightedJumpToSubtitleIndex(undefined), 1000);
         }
-    }, [jumpToSubtitle, subtitles, subtitleRefs, onSeek, onJumpToSubtitleHandled, clock]);
+    }, [jumpToSubtitle, subtitles, onSeek, onJumpToSubtitleHandled, clock]);
 
     const currentMockSubtitle = useCallback(() => {
         const timestamp = clock.time(length);
@@ -989,23 +1031,6 @@ export default function SubtitlePlayer({
         );
     }, []);
 
-    const resizeHandleRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        if (!resizable) {
-            return;
-        }
-
-        const interval = setInterval(() => {
-            const resizeHandleDiv = resizeHandleRef.current;
-
-            if (resizeHandleDiv) {
-                resizeHandleDiv.style.top = `${containerRef.current?.scrollTop ?? 0}px`;
-            }
-        }, 1000);
-        return () => clearInterval(interval);
-    }, [resizable]);
-
     const { width, setWidth, enableResize, isResizing } = useResize({
         initialWidth: calculateInitialWidth,
         minWidth: minSubtitlePlayerWidth,
@@ -1043,7 +1068,6 @@ export default function SubtitlePlayer({
             !dragging ||
             !draggingStartLocation ||
             !draggingCurrentLocation ||
-            !subtitleRefs ||
             isResizing ||
             !showCopyButton ||
             disableKeyEvents
@@ -1052,20 +1076,21 @@ export default function SubtitlePlayer({
             return;
         }
 
-        setSelectedSubtitleIndexes(
-            subtitleRefs.map((ref) => {
-                return intersects(draggingStartLocation, draggingCurrentLocation, ref);
-            })
-        );
-    }, [
-        dragging,
-        draggingStartLocation,
-        draggingCurrentLocation,
-        subtitleRefs,
-        isResizing,
-        showCopyButton,
-        disableKeyEvents,
-    ]);
+        const subtitleCount = subtitleListRef.current?.length ?? 0;
+        const selected = new Array<boolean>(subtitleCount).fill(false);
+        const scroller = scrollerElementRef.current;
+        if (scroller) {
+            for (const row of scroller.querySelectorAll<HTMLElement>('tr[data-item-index]')) {
+                const rowIndex = Number(row.getAttribute('data-item-index'));
+                if (Number.isNaN(rowIndex)) continue;
+                if (rowIndex >= subtitleCount) continue;
+                if (!intersects(draggingStartLocation, draggingCurrentLocation, row)) continue;
+                selected[rowIndex] = true;
+            }
+        }
+
+        setSelectedSubtitleIndexes(selected);
+    }, [dragging, draggingStartLocation, draggingCurrentLocation, isResizing, showCopyButton, disableKeyEvents]);
 
     useEffect(() => {
         if (
@@ -1103,8 +1128,6 @@ export default function SubtitlePlayer({
                 }
             }
         }
-
-        updateHighlightedSubtitleRows();
     }, [
         dragging,
         disabledSubtitleTracks,
@@ -1115,87 +1138,80 @@ export default function SubtitlePlayer({
         onCopy,
     ]);
 
-    let subtitleTable: ReactNode | null = null;
+    const rowContext = useMemo<SubtitleRowContext>(
+        () => ({
+            compressed,
+            showCopyButton,
+            disabledSubtitleTracks,
+            dictionaryTracks: settings.dictionaryTracks,
+            selectedSubtitleIndexes,
+            highlightedJumpToSubtitleIndex,
+            currentSubtitleIndexes,
+            onClickSubtitle: handleClick,
+            onCopySubtitle: handleCopy,
+            onMouseOver,
+            onMouseOut,
+            lastScrollTimestampRef,
+        }),
+        [
+            compressed,
+            showCopyButton,
+            disabledSubtitleTracks,
+            settings.dictionaryTracks,
+            selectedSubtitleIndexes,
+            highlightedJumpToSubtitleIndex,
+            currentSubtitleIndexes,
+            handleClick,
+            handleCopy,
+            onMouseOver,
+            onMouseOut,
+        ]
+    );
+
+    let subtitleContent: ReactNode | null = null;
 
     if (!subtitles || subtitles.length === 0) {
         if (!loading && displayHelp) {
-            subtitleTable = !loading && displayHelp && (
+            subtitleContent = (
                 <div className={classes.noSubtitles}>
                     <Typography variant="h6">{displayHelp}</Typography>
                 </div>
             );
         } else if (subtitles && subtitles.length === 0) {
-            subtitleTable = (
+            subtitleContent = (
                 <div className={classes.noSubtitles}>
                     <Typography variant="h6">{t('landing.noSubtitles')}</Typography>
                 </div>
             );
         }
     } else {
-        const selectableTableClassName = isResizing || dragging ? classes.unselectableTable : '';
-
-        subtitleTable = (
-            <TableContainer className={`${classes.table} ${selectableTableClassName}`}>
-                <Table>
-                    <TableBody>
-                        {subtitles.map((s: SubtitleModel, index: number) => {
-                            const dt = settings.dictionaryTracks[s.track];
-                            let selectionState: SelectionState | undefined;
-
-                            if (selectedSubtitleIndexes !== undefined) {
-                                selectionState = selectedSubtitleIndexes[index]
-                                    ? SelectionState.insideSelection
-                                    : SelectionState.outsideSelection;
-                            }
-
-                            if (highlightedJumpToSubtitleIndex !== undefined) {
-                                selectionState =
-                                    highlightedJumpToSubtitleIndex === index
-                                        ? SelectionState.insideSelection
-                                        : SelectionState.outsideSelection;
-                            }
-
-                            return (
-                                <SubtitleRow
-                                    key={index}
-                                    index={index}
-                                    compressed={compressed}
-                                    selectionState={selectionState}
-                                    showCopyButton={showCopyButton}
-                                    disabled={disabledSubtitleTracks[s.track]}
-                                    subtitle={subtitles[index]}
-                                    subtitleRef={subtitleRefs[index]}
-                                    onClickSubtitle={handleClick}
-                                    onCopySubtitle={handleCopy}
-                                    onMouseOver={onMouseOver}
-                                    onMouseOut={onMouseOut}
-                                    subtitleHtml={settings.subtitleHtml}
-                                    tokenAnnotationConfig={dt.dictionaryTokenAnnotationConfig.subtitlePlayer}
-                                />
-                            );
-                        })}
-                    </TableBody>
-                </Table>
-            </TableContainer>
+        subtitleContent = (
+            <TableVirtuoso
+                ref={virtuosoRef}
+                scrollerRef={handleScrollerRef}
+                data={subtitles}
+                context={rowContext}
+                components={subtitleTableComponents}
+                itemContent={renderSubtitleRow}
+                computeItemKey={computeSubtitleItemKey}
+                style={{ height: '100%' }}
+            />
         );
     }
 
     return (
         <Paper
             square
-            ref={containerRef}
             className={`${classes.container} asbplayer-token-container`}
             tabIndex={-1}
-            style={{ width: resizable ? width : 'auto' }}
+            style={{
+                width: resizable ? width : 'auto',
+                userSelect: isResizing || dragging ? 'none' : undefined,
+            }}
         >
-            {subtitleTable}
+            {subtitleContent}
             {resizable && (
-                <ResizeHandle
-                    isResizing={isResizing}
-                    onMouseDown={enableResize}
-                    onTouchStart={enableResize}
-                    ref={resizeHandleRef}
-                />
+                <ResizeHandle isResizing={isResizing} onMouseDown={enableResize} onTouchStart={enableResize} />
             )}
         </Paper>
     );

--- a/common/app/components/SubtitlePlayer.tsx
+++ b/common/app/components/SubtitlePlayer.tsx
@@ -27,7 +27,6 @@ import {
 import {
     AsbplayerSettings,
     DictionaryTrack,
-    dictionaryTrackEnabled,
     TokenAnnotationConfig,
     tokenAnnotationStyleValues,
 } from '@project/common/settings';
@@ -36,10 +35,7 @@ import {
     mockSurroundingSubtitles,
     surroundingSubtitlesAroundInterval,
     extractText,
-    normalizedLookupTerms,
-    normalizeSearchText,
 } from '@project/common/util';
-import { Yomitan } from '@project/common/yomitan';
 import { SubtitleCollection } from '@project/common/subtitle-collection';
 import {
     getAnnotationsHtml,
@@ -68,13 +64,12 @@ import TextField from '@mui/material/TextField';
 import Clock from '../services/clock';
 import { useAppBarHeight } from '../../hooks/use-app-bar-height';
 import { MineSubtitleParams } from '../hooks/use-app-web-socket-client';
+import { useSubtitleFind } from '../hooks/use-subtitle-find';
 import { isMobile } from 'react-device-detect';
 import ChromeExtension, { ExtensionMessage } from '../services/chrome-extension';
 import { MineSubtitleCommand, WebSocketClient } from '../../web-socket-client';
 import { clampSubtitlePlayerWidth } from './video-subtitle-split';
 import './subtitles.css';
-
-const findDelayMs = 300;
 
 let lastKnownWidth: number | undefined;
 export const minSubtitlePlayerWidth = 200;
@@ -250,28 +245,6 @@ const selectionStateForIndex = (
             highlightedJumpToSubtitleIndex === index ? SelectionState.insideSelection : SelectionState.outsideSelection;
     }
     return selectionState;
-};
-
-const parseRegexQuery = (query: string): RegExp | undefined => {
-    const regexMatch = /^\/(.+)\/([a-z]*)$/.exec(query);
-    if (!regexMatch) return;
-    try {
-        return new RegExp(regexMatch[1], regexMatch[2].replace(/[gy]/g, ''));
-    } catch (e) {
-        return;
-    }
-};
-
-const subtitleSearchableText = (subtitle: DisplaySubtitleModel): string => {
-    const tokens = subtitle.tokenization?.tokens;
-    if (!tokens?.length) return subtitle.text;
-    let readings = '';
-    for (const token of tokens) {
-        for (const reading of token.readings) {
-            if (reading.reading) readings += reading.reading;
-        }
-    }
-    return readings.length ? `${subtitle.text}\n${readings}` : subtitle.text;
 };
 
 const SubtitleScroller = React.forwardRef<HTMLDivElement, ScrollerProps & ContextProp<SubtitleRowContext>>(
@@ -714,33 +687,6 @@ export default function SubtitlePlayer({
     const [currentSubtitleIndexes, setCurrentSubtitleIndexes] = useState<{ [index: number]: boolean }>({});
     const [selectedSubtitleIndexes, setSelectedSubtitleIndexes] = useState<boolean[]>();
     const [highlightedJumpToSubtitleIndex, setHighlightedJumpToSubtitleIndex] = useState<number>();
-    const [findOpen, setFindOpen] = useState<boolean>(false);
-    const [findQuery, setFindQuery] = useState<string>('');
-    const [findExpansion, setFindExpansion] = useState<{ query: string; terms: string[] }>({ query: '', terms: [] });
-    const [currentMatchPosition, setCurrentMatchPosition] = useState<number>(0);
-    const findInputRef = useRef<HTMLInputElement | null>(null);
-    const yomitans = useMemo(
-        () =>
-            settings.dictionaryTracks
-                .filter((dictionaryTrack) => dictionaryTrackEnabled(dictionaryTrack))
-                .map((dictionaryTrack) => new Yomitan(dictionaryTrack)),
-        [settings.dictionaryTracks]
-    );
-    const yomitanVersionPromisesRef = useRef<WeakMap<Yomitan, Promise<unknown>>>(new WeakMap());
-    const ensureYomitanVersion = useCallback(async () => {
-        await Promise.allSettled(
-            yomitans.map((yomitan) => {
-                const cached = yomitanVersionPromisesRef.current.get(yomitan);
-                if (cached) return cached;
-                const promise = yomitan.version().catch((e) => {
-                    yomitanVersionPromisesRef.current.delete(yomitan);
-                    throw e;
-                });
-                yomitanVersionPromisesRef.current.set(yomitan, promise);
-                return promise;
-            })
-        );
-    }, [yomitans]);
     const disableKeyEventsRef = useRef<boolean>(disableKeyEvents);
     disableKeyEventsRef.current = disableKeyEvents;
     const lengthRef = useRef<number>(0);
@@ -757,6 +703,17 @@ export default function SubtitlePlayer({
     autoPauseContextRef.current = autoPauseContext;
     const onSubtitlesHighlightedRef = useRef<(subtitles: SubtitleModel[]) => void>(undefined);
     onSubtitlesHighlightedRef.current = onSubtitlesHighlighted;
+    const find = useSubtitleFind({
+        subtitles,
+        dictionaryTracks: settings.dictionaryTracks,
+        disableKeyEventsRef,
+        hiddenRef,
+        lastScrollTimestampRef,
+        subtitleListRef,
+        virtuosoRef,
+        visibleRangeRef,
+        setHighlightedJumpToSubtitleIndex,
+    });
 
     // This effect should be scheduled only once as re-scheduling seems to cause performance issues.
     // Therefore all of the state it operates on is contained in refs.
@@ -966,170 +923,6 @@ export default function SubtitlePlayer({
             setTimeout(() => setHighlightedJumpToSubtitleIndex(undefined), 1000);
         }
     }, [jumpToSubtitle, subtitles, onSeek, onJumpToSubtitleHandled, clock]);
-
-    useEffect(() => {
-        const trimmed = findQuery.trim();
-        if (!findOpen || !trimmed || parseRegexQuery(findQuery) !== undefined || !yomitans.length) return;
-
-        let cancelled = false;
-        const timeout = setTimeout(async () => {
-            await ensureYomitanVersion();
-            if (cancelled) return;
-            const queryForms = new Set<string>([trimmed]);
-
-            const tokenizeResults = await Promise.allSettled(
-                yomitans.map((yt) => {
-                    try {
-                        return yt.tokenize(trimmed);
-                    } catch (e) {
-                        yomitanVersionPromisesRef.current.delete(yt);
-                        throw e;
-                    }
-                })
-            );
-            for (const result of tokenizeResults) {
-                if (result.status !== 'fulfilled') continue;
-                for (const tokenParts of result.value) {
-                    const tokenText = tokenParts
-                        .map((part) => part.text)
-                        .join('')
-                        .trim();
-                    if (tokenText) queryForms.add(tokenText);
-                }
-            }
-
-            const lemmaTerms = new Set<string>();
-            for (const queryForm of queryForms) {
-                const lemmaResults = await Promise.allSettled(
-                    yomitans.map((yt) => {
-                        try {
-                            return yt.lemmatize(queryForm);
-                        } catch (e) {
-                            yomitanVersionPromisesRef.current.delete(yt);
-                            throw e;
-                        }
-                    })
-                );
-                for (const result of lemmaResults) {
-                    if (result.status !== 'fulfilled') continue;
-                    for (const lemma of result.value ?? []) lemmaTerms.add(lemma);
-                }
-            }
-
-            if (cancelled) return;
-            setFindExpansion({ query: trimmed, terms: normalizedLookupTerms(...queryForms, ...lemmaTerms) });
-        }, findDelayMs);
-
-        return () => {
-            cancelled = true;
-            clearTimeout(timeout);
-        };
-    }, [findQuery, findOpen, yomitans, ensureYomitanVersion]);
-
-    const findMatches = useMemo(() => {
-        const trimmed = findQuery.trim();
-        if (!findOpen || !subtitles || !subtitles.length || !trimmed) return [];
-
-        const matches: number[] = [];
-        const regex = parseRegexQuery(findQuery);
-        if (regex) {
-            for (const [i, subtitle] of subtitles.entries()) {
-                const searchableText = subtitleSearchableText(subtitle);
-                if (regex.test(searchableText)) matches.push(i);
-            }
-        } else {
-            const terms = normalizedLookupTerms(trimmed).concat(
-                findExpansion.query === trimmed ? findExpansion.terms : []
-            );
-            for (const [i, subtitle] of subtitles.entries()) {
-                const normalized = normalizeSearchText(subtitleSearchableText(subtitle));
-                if (terms.some((term) => normalized.includes(term))) matches.push(i);
-            }
-        }
-        return matches;
-    }, [findOpen, subtitles, findQuery, findExpansion]);
-    const findMatchesRef = useRef(findMatches);
-    findMatchesRef.current = findMatches;
-
-    const scrollToFindMatch = useCallback((subtitleIndex: number) => {
-        lastScrollTimestampRef.current = Date.now();
-        if (!hiddenRef.current) {
-            virtuosoRef.current?.scrollToIndex({
-                index: subtitleIndex,
-                align: 'center',
-                behavior: 'auto',
-            });
-        }
-        setHighlightedJumpToSubtitleIndex(subtitleIndex);
-    }, []);
-
-    useEffect(() => {
-        if (!findOpen) return;
-        const trimmed = findQuery.trim();
-        const searchCompleted =
-            !trimmed || parseRegexQuery(findQuery) !== undefined || !yomitans.length || findExpansion.query === trimmed;
-        if (!searchCompleted) return;
-        const matches = findMatches;
-        if (!matches.length) {
-            setHighlightedJumpToSubtitleIndex(undefined);
-            setCurrentMatchPosition(0);
-            return;
-        }
-        const firstVisibleIndex = visibleRangeRef.current.startIndex;
-        const matchPosition = Math.max(
-            0,
-            matches.findIndex((subtitleIndex) => subtitleIndex >= firstVisibleIndex)
-        );
-        setCurrentMatchPosition(matchPosition);
-        scrollToFindMatch(matches[matchPosition]);
-    }, [findMatches, findOpen, findQuery, findExpansion.query, yomitans.length, scrollToFindMatch]);
-
-    const navigateFindMatch = useCallback(
-        (delta: number) => {
-            const matches = findMatchesRef.current;
-            if (!matches.length) return;
-            setCurrentMatchPosition((current) => {
-                const next = (current + delta + matches.length) % matches.length;
-                scrollToFindMatch(matches[next]);
-                return next;
-            });
-        },
-        [scrollToFindMatch]
-    );
-
-    const handleFindNext = useCallback(() => navigateFindMatch(1), [navigateFindMatch]);
-    const handleFindPrevious = useCallback(() => navigateFindMatch(-1), [navigateFindMatch]);
-
-    const handleCloseFind = useCallback(() => {
-        setFindOpen(false);
-        setFindQuery('');
-        setCurrentMatchPosition(0);
-        setHighlightedJumpToSubtitleIndex(undefined);
-    }, []);
-
-    useEffect(() => {
-        const handleGlobalKeyDown = (event: KeyboardEvent) => {
-            if ((event.ctrlKey || event.metaKey) && !event.altKey && (event.key === 'f' || event.key === 'F')) {
-                if (disableKeyEventsRef.current || !subtitleListRef.current || !subtitleListRef.current.length) {
-                    return;
-                }
-                event.preventDefault();
-                event.stopPropagation();
-                setFindOpen(true);
-                requestAnimationFrame(() => {
-                    findInputRef.current?.focus();
-                    findInputRef.current?.select();
-                });
-            }
-        };
-
-        document.addEventListener('keydown', handleGlobalKeyDown, true);
-        return () => document.removeEventListener('keydown', handleGlobalKeyDown, true);
-    }, []);
-
-    const findResultsLabel = findQuery.trim()
-        ? `${findMatches.length ? currentMatchPosition + 1 : 0}/${findMatches.length}`
-        : '';
 
     const currentMockSubtitle = useCallback(() => {
         const timestamp = clock.time(length);
@@ -1578,17 +1371,17 @@ export default function SubtitlePlayer({
                 userSelect: isResizing || dragging ? 'none' : undefined,
             }}
         >
-            {findOpen && (
+            {find.open && (
                 <SubtitleFindBar
-                    inputRef={findInputRef}
-                    query={findQuery}
+                    inputRef={find.inputRef}
+                    query={find.query}
                     placeholder={t('action.findPlaceholder')}
-                    resultsLabel={findResultsLabel}
-                    hasMatches={findMatches.length > 0}
-                    onQueryChange={setFindQuery}
-                    onNext={handleFindNext}
-                    onPrevious={handleFindPrevious}
-                    onClose={handleCloseFind}
+                    resultsLabel={find.resultsLabel}
+                    hasMatches={find.matches.length > 0}
+                    onQueryChange={find.setQuery}
+                    onNext={find.next}
+                    onPrevious={find.previous}
+                    onClose={find.close}
                 />
             )}
             {subtitleContent}

--- a/common/app/components/SubtitlePlayer.tsx
+++ b/common/app/components/SubtitlePlayer.tsx
@@ -207,31 +207,6 @@ const useSubtitleRowStyles = makeStyles<Theme>((theme) => ({
     },
 }));
 
-const useFindBarStyles = makeStyles<Theme>((theme) => ({
-    findBar: {
-        position: 'absolute',
-        top: theme.spacing(1),
-        right: theme.spacing(2),
-        // Keep the bar within the panel (e.g. a narrow side panel), leaving an equal margin on both sides.
-        maxWidth: `calc(100% - ${theme.spacing(4)})`,
-        boxSizing: 'border-box',
-        zIndex: 10,
-        display: 'flex',
-        alignItems: 'center',
-        gap: theme.spacing(0.25),
-        paddingLeft: theme.spacing(1),
-        paddingRight: theme.spacing(0.5),
-        paddingTop: theme.spacing(0.5),
-        paddingBottom: theme.spacing(0.5),
-    },
-    findCount: {
-        whiteSpace: 'nowrap',
-        color: theme.palette.text.secondary,
-        minWidth: 32,
-        textAlign: 'right',
-    },
-}));
-
 export interface DisplaySubtitleModel extends IndexedSubtitleModel {
     displayTime: string;
 }
@@ -511,10 +486,26 @@ const SubtitleFindBar = ({
     onPrevious,
     onClose,
 }: SubtitleFindBarProps) => {
-    const classes = useFindBarStyles();
-
     return (
-        <Paper elevation={6} className={classes.findBar}>
+        <Paper
+            elevation={6}
+            sx={(theme) => ({
+                position: 'absolute',
+                top: theme.spacing(1),
+                right: theme.spacing(2),
+                // Keep the bar within the panel (e.g. a narrow side panel), leaving an equal margin on both sides.
+                maxWidth: `calc(100% - ${theme.spacing(4)})`,
+                boxSizing: 'border-box',
+                zIndex: 10,
+                display: 'flex',
+                alignItems: 'center',
+                gap: theme.spacing(0.25),
+                paddingLeft: theme.spacing(1),
+                paddingRight: theme.spacing(0.5),
+                paddingTop: theme.spacing(0.5),
+                paddingBottom: theme.spacing(0.5),
+            })}
+        >
             <TextField
                 inputRef={inputRef}
                 autoFocus
@@ -535,9 +526,17 @@ const SubtitleFindBar = ({
                     }
                 }}
                 slotProps={{ htmlInput: { size: placeholder.length } }}
-                style={{ flexGrow: 0, flexShrink: 1, minWidth: 0 }}
+                sx={{ flexGrow: 0, flexShrink: 1, minWidth: 0 }}
             />
-            <Typography variant="caption" className={classes.findCount}>
+            <Typography
+                variant="caption"
+                sx={(theme) => ({
+                    whiteSpace: 'nowrap',
+                    color: theme.palette.text.secondary,
+                    minWidth: 32,
+                    textAlign: 'right',
+                })}
+            >
                 {resultsLabel}
             </Typography>
             <IconButton size="small" disabled={!hasMatches} onClick={onPrevious}>

--- a/common/app/components/SubtitlePlayer.tsx
+++ b/common/app/components/SubtitlePlayer.tsx
@@ -22,7 +22,7 @@ import {
     AutoPauseContext,
     CopySubtitleWithAdditionalFieldsMessage,
     CardTextFieldValues,
-    RichSubtitleModel,
+    IndexedSubtitleModel,
 } from '@project/common';
 import {
     AsbplayerSettings,
@@ -41,7 +41,15 @@ import {
 } from '@project/common/util';
 import { Yomitan } from '@project/common/yomitan';
 import { SubtitleCollection } from '@project/common/subtitle-collection';
-import { getAnnotationsHtml, SubtitleAnnotations } from '@project/common/subtitle-annotations';
+import {
+    getAnnotationsHtml,
+    renderRichTextWindow,
+    emptyRichTextWindow,
+    RichTextWindow,
+    RenderedRichText,
+    SubtitleAnnotations,
+    renderRichTextForSubtitle,
+} from '@project/common/subtitle-annotations';
 import { KeyBinder } from '@project/common/key-binder';
 import SubtitleTextImage from '@project/common/components/SubtitleTextImage';
 import NoteAddIcon from '@mui/icons-material/NoteAdd';
@@ -224,7 +232,7 @@ const useFindBarStyles = makeStyles<Theme>((theme) => ({
     },
 }));
 
-export interface DisplaySubtitleModel extends RichSubtitleModel {
+export interface DisplaySubtitleModel extends IndexedSubtitleModel {
     displayTime: string;
 }
 
@@ -238,6 +246,7 @@ interface SubtitleRowContext {
     showCopyButton: boolean;
     disabledSubtitleTracks: { [track: number]: boolean };
     dictionaryTracks: DictionaryTrack[];
+    richTextWindowRef: React.RefObject<RichTextWindow>;
     selectedSubtitleIndexes?: boolean[];
     highlightedJumpToSubtitleIndex?: number;
     currentSubtitleIndexes: { [index: number]: boolean };
@@ -372,6 +381,7 @@ interface SubtitleRowCellsProps {
     compressed: boolean;
     showCopyButton: boolean;
     tokenAnnotationConfig?: TokenAnnotationConfig;
+    rendered?: RenderedRichText;
     onCopySubtitle: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, index: number) => void;
     onMouseOver: (e: React.MouseEvent) => void;
     onMouseOut: (e: React.MouseEvent) => void;
@@ -386,6 +396,7 @@ const SubtitleRowCells = React.memo(function SubtitleRowCells({
     compressed,
     showCopyButton,
     tokenAnnotationConfig,
+    rendered,
     onCopySubtitle,
     onMouseOver,
     onMouseOut,
@@ -401,7 +412,7 @@ const SubtitleRowCells = React.memo(function SubtitleRowCells({
         <span
             className={disabledClassName}
             dangerouslySetInnerHTML={{
-                __html: getAnnotationsHtml(subtitle.text, subtitle.richText, subtitle.richTextOnHover),
+                __html: getAnnotationsHtml(subtitle.text, rendered?.richText, rendered?.richTextOnHover),
             }}
             data-track={subtitle.track}
             style={tokenAnnotationStyleValues(tokenAnnotationConfig) as React.CSSProperties}
@@ -456,6 +467,12 @@ const renderSubtitleRow = (index: number, subtitle: DisplaySubtitleModel, contex
         compressed={context.compressed}
         showCopyButton={context.showCopyButton}
         tokenAnnotationConfig={context.dictionaryTracks[subtitle.track]?.dictionaryTokenAnnotationConfig.subtitlePlayer}
+        rendered={renderRichTextForSubtitle(
+            context.richTextWindowRef.current,
+            subtitle,
+            'subtitlePlayer',
+            context.dictionaryTracks
+        )}
         onCopySubtitle={context.onCopySubtitle}
         onMouseOver={context.onMouseOver}
         onMouseOut={context.onMouseOut}
@@ -651,6 +668,41 @@ export default function SubtitlePlayer({
     const handleScrollerRef = useCallback((element: HTMLElement | Window | null) => {
         scrollerElementRef.current = element instanceof HTMLElement ? element : null;
     }, []);
+
+    const richTextWindowRef = useRef<RichTextWindow>(emptyRichTextWindow());
+    const visibleRangeRef = useRef<ListRange>({ startIndex: 0, endIndex: 0 });
+    const handleVisibleRangeChanged = useCallback((range: ListRange) => {
+        visibleRangeRef.current = range;
+    }, []);
+
+    const handleRangeChanged = useCallback(
+        (range: ListRange) => {
+            handleVisibleRangeChanged(range);
+            if (!subtitleListRef.current?.length) return;
+            const windowSubtitles = subtitleListRef.current.slice(range.startIndex, range.endIndex + 1);
+            richTextWindowRef.current = renderRichTextWindow(
+                richTextWindowRef.current,
+                windowSubtitles,
+                'subtitlePlayer',
+                settings.dictionaryTracks
+            );
+        },
+        [settings.dictionaryTracks, handleVisibleRangeChanged]
+    );
+
+    useEffect(() => {
+        const range = richTextWindowRef.current.range;
+        richTextWindowRef.current = emptyRichTextWindow();
+        if (range && subtitles?.length) {
+            const windowSubtitles = subtitles.slice(range.min, range.max + 1);
+            richTextWindowRef.current = renderRichTextWindow(
+                richTextWindowRef.current,
+                windowSubtitles,
+                'subtitlePlayer',
+                settings.dictionaryTracks
+            );
+        }
+    }, [subtitles, settings.dictionaryTracks]);
 
     const subtitleCollectionRef = useRef<SubtitleAnnotations | SubtitleCollection<DisplaySubtitleModel>>(
         subtitleCollection
@@ -997,10 +1049,6 @@ export default function SubtitlePlayer({
     }, [findOpen, subtitles, findQuery, findExpansion]);
     const findMatchesRef = useRef(findMatches);
     findMatchesRef.current = findMatches;
-    const visibleRangeRef = useRef<ListRange>({ startIndex: 0, endIndex: 0 });
-    const handleVisibleRangeChanged = useCallback((range: ListRange) => {
-        visibleRangeRef.current = range;
-    }, []);
 
     const scrollToFindMatch = useCallback((subtitleIndex: number) => {
         lastScrollTimestampRef.current = Date.now();
@@ -1462,6 +1510,7 @@ export default function SubtitlePlayer({
             showCopyButton,
             disabledSubtitleTracks,
             dictionaryTracks: settings.dictionaryTracks,
+            richTextWindowRef,
             selectedSubtitleIndexes,
             highlightedJumpToSubtitleIndex,
             currentSubtitleIndexes,
@@ -1512,7 +1561,7 @@ export default function SubtitlePlayer({
                 components={subtitleTableComponents}
                 itemContent={renderSubtitleRow}
                 computeItemKey={computeSubtitleItemKey}
-                rangeChanged={handleVisibleRangeChanged}
+                rangeChanged={handleRangeChanged}
                 style={{ height: '100%' }}
             />
         );

--- a/common/app/components/SubtitlePlayer.tsx
+++ b/common/app/components/SubtitlePlayer.tsx
@@ -4,6 +4,7 @@ import { type Theme } from '@mui/material';
 import {
     ContextProp,
     ItemProps,
+    ListRange,
     ScrollerProps,
     TableBodyProps,
     TableComponents,
@@ -26,6 +27,7 @@ import {
 import {
     AsbplayerSettings,
     DictionaryTrack,
+    dictionaryTrackEnabled,
     TokenAnnotationConfig,
     tokenAnnotationStyleValues,
 } from '@project/common/settings';
@@ -34,12 +36,18 @@ import {
     mockSurroundingSubtitles,
     surroundingSubtitlesAroundInterval,
     extractText,
+    normalizedLookupTerms,
+    normalizeSearchText,
 } from '@project/common/util';
+import { Yomitan } from '@project/common/yomitan';
 import { SubtitleCollection } from '@project/common/subtitle-collection';
 import { getAnnotationsHtml, SubtitleAnnotations } from '@project/common/subtitle-annotations';
 import { KeyBinder } from '@project/common/key-binder';
 import SubtitleTextImage from '@project/common/components/SubtitleTextImage';
 import NoteAddIcon from '@mui/icons-material/NoteAdd';
+import CloseIcon from '@mui/icons-material/Close';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
@@ -48,6 +56,7 @@ import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import Tooltip from '../../components/Tooltip';
 import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
 import Clock from '../services/clock';
 import { useAppBarHeight } from '../../hooks/use-app-bar-height';
 import { MineSubtitleParams } from '../hooks/use-app-web-socket-client';
@@ -190,6 +199,31 @@ const useSubtitleRowStyles = makeStyles<Theme>((theme) => ({
     },
 }));
 
+const useFindBarStyles = makeStyles<Theme>((theme) => ({
+    findBar: {
+        position: 'absolute',
+        top: theme.spacing(1),
+        right: theme.spacing(2),
+        // Keep the bar within the panel (e.g. a narrow side panel), leaving an equal margin on both sides.
+        maxWidth: `calc(100% - ${theme.spacing(4)})`,
+        boxSizing: 'border-box',
+        zIndex: 10,
+        display: 'flex',
+        alignItems: 'center',
+        gap: theme.spacing(0.25),
+        paddingLeft: theme.spacing(1),
+        paddingRight: theme.spacing(0.5),
+        paddingTop: theme.spacing(0.5),
+        paddingBottom: theme.spacing(0.5),
+    },
+    findCount: {
+        whiteSpace: 'nowrap',
+        color: theme.palette.text.secondary,
+        minWidth: 32,
+        textAlign: 'right',
+    },
+}));
+
 export interface DisplaySubtitleModel extends RichSubtitleModel {
     displayTime: string;
 }
@@ -230,6 +264,28 @@ const selectionStateForIndex = (
             highlightedJumpToSubtitleIndex === index ? SelectionState.insideSelection : SelectionState.outsideSelection;
     }
     return selectionState;
+};
+
+const parseRegexQuery = (query: string): RegExp | undefined => {
+    const regexMatch = /^\/(.+)\/([a-z]*)$/.exec(query);
+    if (!regexMatch) return;
+    try {
+        return new RegExp(regexMatch[1], regexMatch[2].replace(/[gy]/g, ''));
+    } catch (e) {
+        return;
+    }
+};
+
+const subtitleSearchableText = (subtitle: DisplaySubtitleModel): string => {
+    const tokens = subtitle.tokenization?.tokens;
+    if (!tokens || !tokens.length) return subtitle.text;
+    let readings = '';
+    for (const token of tokens) {
+        for (const reading of token.readings) {
+            if (reading.reading) readings += reading.reading;
+        }
+    }
+    return readings.length ? `${subtitle.text}\n${readings}` : subtitle.text;
 };
 
 const SubtitleScroller = React.forwardRef<HTMLDivElement, ScrollerProps & ContextProp<SubtitleRowContext>>(
@@ -415,6 +471,71 @@ const subtitleTableComponents: TableComponents<DisplaySubtitleModel, SubtitleRow
     TableRow: SubtitleTableRow,
 };
 
+interface SubtitleFindBarProps {
+    inputRef: React.RefObject<HTMLInputElement | null>;
+    query: string;
+    placeholder: string;
+    resultsLabel: string;
+    hasMatches: boolean;
+    onQueryChange: (query: string) => void;
+    onNext: () => void;
+    onPrevious: () => void;
+    onClose: () => void;
+}
+
+const SubtitleFindBar = ({
+    inputRef,
+    query,
+    placeholder,
+    resultsLabel,
+    hasMatches,
+    onQueryChange,
+    onNext,
+    onPrevious,
+    onClose,
+}: SubtitleFindBarProps) => {
+    const classes = useFindBarStyles();
+
+    return (
+        <Paper elevation={6} className={classes.findBar}>
+            <TextField
+                inputRef={inputRef}
+                autoFocus
+                variant="standard"
+                placeholder={placeholder}
+                value={query}
+                onChange={(e) => onQueryChange(e.target.value)}
+                onKeyDown={(e) => {
+                    if (e.key === 'Escape') {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onClose();
+                    } else if (e.key === 'Enter') {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        if (e.shiftKey) onPrevious();
+                        else onNext();
+                    }
+                }}
+                slotProps={{ htmlInput: { size: placeholder.length } }}
+                style={{ flexGrow: 0, flexShrink: 1, minWidth: 0 }}
+            />
+            <Typography variant="caption" className={classes.findCount}>
+                {resultsLabel}
+            </Typography>
+            <IconButton size="small" disabled={!hasMatches} onClick={onPrevious}>
+                <KeyboardArrowUpIcon fontSize="small" />
+            </IconButton>
+            <IconButton size="small" disabled={!hasMatches} onClick={onNext}>
+                <KeyboardArrowDownIcon fontSize="small" />
+            </IconButton>
+            <IconButton size="small" onClick={onClose}>
+                <CloseIcon fontSize="small" />
+            </IconButton>
+        </Paper>
+    );
+};
+
 interface ResizeHandleProps extends React.HTMLAttributes<HTMLDivElement> {
     isResizing: boolean;
 }
@@ -540,6 +661,35 @@ export default function SubtitlePlayer({
     const [currentSubtitleIndexes, setCurrentSubtitleIndexes] = useState<{ [index: number]: boolean }>({});
     const [selectedSubtitleIndexes, setSelectedSubtitleIndexes] = useState<boolean[]>();
     const [highlightedJumpToSubtitleIndex, setHighlightedJumpToSubtitleIndex] = useState<number>();
+    const [findOpen, setFindOpen] = useState<boolean>(false);
+    const [findQuery, setFindQuery] = useState<string>('');
+    const [findExpansion, setFindExpansion] = useState<{ query: string; terms: string[] }>({ query: '', terms: [] });
+    const [currentMatchPosition, setCurrentMatchPosition] = useState<number>(0);
+    const findInputRef = useRef<HTMLInputElement | null>(null);
+    const yomitans = useMemo(
+        () =>
+            settings.dictionaryTracks
+                .filter((dictionaryTrack) => dictionaryTrackEnabled(dictionaryTrack))
+                .map((dictionaryTrack) => new Yomitan(dictionaryTrack)),
+        [settings.dictionaryTracks]
+    );
+    const yomitanVersionPromisesRef = useRef<WeakMap<Yomitan, Promise<unknown>>>(new WeakMap());
+    const ensureYomitanVersion = useCallback(async () => {
+        await Promise.allSettled(
+            yomitans.map((yomitan) => {
+                const cached = yomitanVersionPromisesRef.current.get(yomitan);
+                if (cached) return cached;
+                const promise = yomitan.version().catch((e) => {
+                    yomitanVersionPromisesRef.current.delete(yomitan);
+                    throw e;
+                });
+                yomitanVersionPromisesRef.current.set(yomitan, promise);
+                return promise;
+            })
+        );
+    }, [yomitans]);
+    const disableKeyEventsRef = useRef<boolean>(disableKeyEvents);
+    disableKeyEventsRef.current = disableKeyEvents;
     const lengthRef = useRef<number>(0);
     lengthRef.current = length;
     const hiddenRef = useRef<boolean>(false);
@@ -763,6 +913,174 @@ export default function SubtitlePlayer({
             setTimeout(() => setHighlightedJumpToSubtitleIndex(undefined), 1000);
         }
     }, [jumpToSubtitle, subtitles, onSeek, onJumpToSubtitleHandled, clock]);
+
+    useEffect(() => {
+        const trimmed = findQuery.trim();
+        if (!findOpen || !trimmed || parseRegexQuery(findQuery) !== undefined || !yomitans.length) return;
+
+        let cancelled = false;
+        const timeout = setTimeout(async () => {
+            await ensureYomitanVersion();
+            if (cancelled) return;
+            const queryForms = new Set<string>([trimmed]);
+
+            const tokenizeResults = await Promise.allSettled(
+                yomitans.map((yt) => {
+                    try {
+                        return yt.tokenize(trimmed);
+                    } catch (e) {
+                        yomitanVersionPromisesRef.current.delete(yt);
+                        throw e;
+                    }
+                })
+            );
+            for (const result of tokenizeResults) {
+                if (result.status !== 'fulfilled') continue;
+                for (const tokenParts of result.value) {
+                    const tokenText = tokenParts
+                        .map((part) => part.text)
+                        .join('')
+                        .trim();
+                    if (tokenText) queryForms.add(tokenText);
+                }
+            }
+
+            const lemmaTerms = new Set<string>();
+            for (const queryForm of queryForms) {
+                const lemmaResults = await Promise.allSettled(
+                    yomitans.map((yt) => {
+                        try {
+                            return yt.lemmatize(queryForm);
+                        } catch (e) {
+                            yomitanVersionPromisesRef.current.delete(yt);
+                            throw e;
+                        }
+                    })
+                );
+                for (const result of lemmaResults) {
+                    if (result.status !== 'fulfilled') continue;
+                    for (const lemma of result.value ?? []) lemmaTerms.add(lemma);
+                }
+            }
+
+            if (cancelled) return;
+            setFindExpansion({ query: trimmed, terms: normalizedLookupTerms(...queryForms, ...lemmaTerms) });
+        }, 300);
+
+        return () => {
+            cancelled = true;
+            clearTimeout(timeout);
+        };
+    }, [findQuery, findOpen, yomitans, ensureYomitanVersion]);
+
+    const findMatches = useMemo(() => {
+        const trimmed = findQuery.trim();
+        if (!findOpen || !subtitles || !subtitles.length || !trimmed) return [];
+
+        const matches: number[] = [];
+        const regex = parseRegexQuery(findQuery);
+        if (regex) {
+            for (const [i, subtitle] of subtitles.entries()) {
+                const searchableText = subtitleSearchableText(subtitle);
+                if (regex.test(searchableText)) matches.push(i);
+            }
+        } else {
+            const terms = normalizedLookupTerms(trimmed).concat(
+                findExpansion.query === trimmed ? findExpansion.terms : []
+            );
+            for (const [i, subtitle] of subtitles.entries()) {
+                const normalized = normalizeSearchText(subtitleSearchableText(subtitle));
+                if (terms.some((term) => normalized.includes(term))) matches.push(i);
+            }
+        }
+        return matches;
+    }, [findOpen, subtitles, findQuery, findExpansion]);
+    const findMatchesRef = useRef(findMatches);
+    findMatchesRef.current = findMatches;
+    const visibleRangeRef = useRef<ListRange>({ startIndex: 0, endIndex: 0 });
+    const handleVisibleRangeChanged = useCallback((range: ListRange) => {
+        visibleRangeRef.current = range;
+    }, []);
+
+    const scrollToFindMatch = useCallback((subtitleIndex: number) => {
+        lastScrollTimestampRef.current = Date.now();
+        if (!hiddenRef.current) {
+            virtuosoRef.current?.scrollToIndex({
+                index: subtitleIndex,
+                align: 'center',
+                behavior: 'auto',
+            });
+        }
+        setHighlightedJumpToSubtitleIndex(subtitleIndex);
+    }, []);
+
+    useEffect(() => {
+        if (!findOpen) return;
+        const trimmed = findQuery.trim();
+        const searchCompleted =
+            !trimmed || parseRegexQuery(findQuery) !== undefined || !yomitans.length || findExpansion.query === trimmed;
+        if (!searchCompleted) return;
+        const matches = findMatches;
+        if (!matches.length) {
+            setHighlightedJumpToSubtitleIndex(undefined);
+            setCurrentMatchPosition(0);
+            return;
+        }
+        const firstVisibleIndex = visibleRangeRef.current.startIndex;
+        const matchPosition = Math.max(
+            0,
+            matches.findIndex((subtitleIndex) => subtitleIndex >= firstVisibleIndex)
+        );
+        setCurrentMatchPosition(matchPosition);
+        scrollToFindMatch(matches[matchPosition]);
+    }, [findMatches, findOpen, findQuery, findExpansion.query, yomitans.length, scrollToFindMatch]);
+
+    const navigateFindMatch = useCallback(
+        (delta: number) => {
+            const matches = findMatchesRef.current;
+            if (!matches.length) return;
+            setCurrentMatchPosition((current) => {
+                const next = (current + delta + matches.length) % matches.length;
+                scrollToFindMatch(matches[next]);
+                return next;
+            });
+        },
+        [scrollToFindMatch]
+    );
+
+    const handleFindNext = useCallback(() => navigateFindMatch(1), [navigateFindMatch]);
+    const handleFindPrevious = useCallback(() => navigateFindMatch(-1), [navigateFindMatch]);
+
+    const handleCloseFind = useCallback(() => {
+        setFindOpen(false);
+        setFindQuery('');
+        setCurrentMatchPosition(0);
+        setHighlightedJumpToSubtitleIndex(undefined);
+    }, []);
+
+    useEffect(() => {
+        const handleGlobalKeyDown = (event: KeyboardEvent) => {
+            if ((event.ctrlKey || event.metaKey) && !event.altKey && (event.key === 'f' || event.key === 'F')) {
+                if (disableKeyEventsRef.current || !subtitleListRef.current || !subtitleListRef.current.length) {
+                    return;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                setFindOpen(true);
+                requestAnimationFrame(() => {
+                    findInputRef.current?.focus();
+                    findInputRef.current?.select();
+                });
+            }
+        };
+
+        document.addEventListener('keydown', handleGlobalKeyDown, true);
+        return () => document.removeEventListener('keydown', handleGlobalKeyDown, true);
+    }, []);
+
+    const findResultsLabel = findQuery.trim()
+        ? `${findMatches.length ? currentMatchPosition + 1 : 0}/${findMatches.length}`
+        : '';
 
     const currentMockSubtitle = useCallback(() => {
         const timestamp = clock.time(length);
@@ -1194,6 +1512,7 @@ export default function SubtitlePlayer({
                 components={subtitleTableComponents}
                 itemContent={renderSubtitleRow}
                 computeItemKey={computeSubtitleItemKey}
+                rangeChanged={handleVisibleRangeChanged}
                 style={{ height: '100%' }}
             />
         );
@@ -1209,6 +1528,19 @@ export default function SubtitlePlayer({
                 userSelect: isResizing || dragging ? 'none' : undefined,
             }}
         >
+            {findOpen && (
+                <SubtitleFindBar
+                    inputRef={findInputRef}
+                    query={findQuery}
+                    placeholder={t('action.findPlaceholder')}
+                    resultsLabel={findResultsLabel}
+                    hasMatches={findMatches.length > 0}
+                    onQueryChange={setFindQuery}
+                    onNext={handleFindNext}
+                    onPrevious={handleFindPrevious}
+                    onClose={handleCloseFind}
+                />
+            )}
             {subtitleContent}
             {resizable && (
                 <ResizeHandle isResizing={isResizing} onMouseDown={enableResize} onTouchStart={enableResize} />

--- a/common/app/components/VideoPlayer.tsx
+++ b/common/app/components/VideoPlayer.tsx
@@ -40,7 +40,13 @@ import {
     subtitleTimestampWithDelay,
 } from '@project/common/util';
 import { SubtitleCollection } from '@project/common/subtitle-collection';
-import { HoveredToken, renderRichTextOntoSubtitles, getAnnotationsHtml } from '@project/common/subtitle-annotations';
+import {
+    HoveredToken,
+    renderRichTextOntoSubtitles,
+    getAnnotationsHtml,
+    ANNOTATIONS_VIDEO_RENDER_BEHIND_MS,
+    ANNOTATIONS_VIDEO_RENDER_AHEAD_MS,
+} from '@project/common/subtitle-annotations';
 import Clock from '../services/clock';
 import Controls, { Point } from './Controls';
 import PlayerChannel from '../services/player-channel';
@@ -388,8 +394,9 @@ export default function VideoPlayer({
     const [subtitles, setSubtitles] = useState<RichSubtitleModel[]>([]);
     const subtitleCollection = useMemo<SubtitleCollection<RichSubtitleModel>>(() => {
         const newCol = new SubtitleCollection<RichSubtitleModel>({
-            returnLastShown: false,
             showingCheckRadiusMs: 150,
+            returnLastShown: true,
+            returnNextToShow: true,
         });
         newCol.setSubtitles(subtitles);
         return newCol;
@@ -430,6 +437,7 @@ export default function VideoPlayer({
     const mobileOverlayRef = useRef<HTMLDivElement>(null);
     const bottomSubtitleContainerRef = useRef<HTMLDivElement>(null);
     const domCacheRef = useRef<OffscreenDomCache | undefined>(undefined);
+    const updateSubtitleDomCacheRef = useRef<((windowSubtitles: RichSubtitleModel[]) => void) | undefined>(undefined);
     const thumbnailsRef = useRef<Map<number, string>>(new Map()); // cache thumbnails, in intervals of 5s
     const isGeneratingRef = useRef(false); // avoid subsequent calls to generate thumbnail while generating one
 
@@ -875,9 +883,20 @@ export default function VideoPlayer({
     }, [playerChannel]);
 
     useEffect(() => {
-        if (!subtitles || subtitles.length === 0) {
-            return;
-        }
+        if (!subtitles?.length) return;
+
+        const refreshWindowSubtitles = (now: number) => {
+            const windowSubtitles = subtitleCollection.subtitlesIn(
+                now - ANNOTATIONS_VIDEO_RENDER_BEHIND_MS,
+                now + ANNOTATIONS_VIDEO_RENDER_AHEAD_MS
+            );
+            if (!windowSubtitles.length) {
+                const { lastShown, nextToShow } = subtitleCollection.subtitlesAt(now);
+                for (const subtitle of lastShown ?? []) windowSubtitles.push(subtitle);
+                for (const subtitle of nextToShow ?? []) windowSubtitles.push(subtitle);
+            }
+            updateSubtitleDomCacheRef.current?.(windowSubtitles);
+        };
 
         const interval = setInterval(() => {
             const now = clock.time(length);
@@ -907,8 +926,11 @@ export default function VideoPlayer({
                         // ignore
                     });
                 }
+                refreshWindowSubtitles(now);
             }
         }, 100);
+
+        refreshWindowSubtitles(clock.time(length)); // Init
 
         return () => clearInterval(interval);
     }, [
@@ -1677,18 +1699,22 @@ export default function VideoPlayer({
             showingSubtitleHtml(
                 subtitle,
                 videoRef,
-                trackStyles[subtitle.track]?.styleString ?? trackStyles[0].styleString,
-                trackStyles[subtitle.track]?.classes ?? trackStyles[0].classes,
+                trackStyles[subtitle.track]?.styleString ?? trackStyles[0]?.styleString ?? '',
+                trackStyles[subtitle.track]?.classes ?? trackStyles[0]?.classes ?? '',
                 subtitleSettings.imageBasedSubtitleScaleFactor
             ),
         [trackStyles, subtitleSettings.imageBasedSubtitleScaleFactor]
     );
 
-    const { getSubtitleDomCache } = useSubtitleDomCache(subtitles, getSubtitleHtml);
+    const { getSubtitleDomCache, updateSubtitleDomCache } = useSubtitleDomCache(subtitles, getSubtitleHtml);
 
     useEffect(() => {
         domCacheRef.current = getSubtitleDomCache();
     }, [getSubtitleDomCache]);
+
+    useEffect(() => {
+        updateSubtitleDomCacheRef.current = updateSubtitleDomCache;
+    }, [updateSubtitleDomCache]);
 
     const handleSwipe = useCallback(
         (direction: Direction) => {

--- a/common/app/components/VideoPlayer.tsx
+++ b/common/app/components/VideoPlayer.tsx
@@ -13,7 +13,7 @@ import {
     CardTextFieldValues,
     PostMinePlayback,
     ControlType,
-    RichSubtitleModel,
+    IndexedSubtitleModel,
 } from '@project/common';
 import {
     MiscSettings,
@@ -168,25 +168,13 @@ function errorMessage(element: HTMLVideoElement) {
     return error + ': ' + (element.error?.message || '<details missing>');
 }
 
-function subtitlesForVideo<T extends RichSubtitleModel>(
-    subtitles: T[],
-    dictionaryTracks: DictionaryTrack[] | undefined
-): T[] {
-    const videoSubtitles = subtitles.map((subtitle) => ({
-        ...subtitle,
-        richText: undefined,
-        richTextOnHover: undefined,
-    }));
-    renderRichTextOntoSubtitles(videoSubtitles, 'video', dictionaryTracks);
-    return videoSubtitles;
-}
-
 const showingSubtitleHtml = (
-    subtitle: RichSubtitleModel,
+    subtitle: IndexedSubtitleModel,
     videoRef: MutableRefObject<ExperimentalHTMLVideoElement | undefined>,
     subtitleStyles: string,
     subtitleClasses: string,
-    imageBasedSubtitleScaleFactor: number
+    imageBasedSubtitleScaleFactor: number,
+    dictionaryTracks: DictionaryTrack[]
 ) => {
     if (subtitle.textImage) {
         const imageScale =
@@ -205,17 +193,18 @@ const showingSubtitleHtml = (
 `;
     }
     const allSubtitleClasses = subtitleClasses ? `${subtitleClasses} asbplayer-subtitles` : 'asbplayer-subtitles';
+    const rendered = renderRichTextOntoSubtitles([subtitle], 'video', dictionaryTracks)?.get(subtitle.index);
     return `<span class="${allSubtitleClasses}" style="${subtitleStyles}" data-track="${subtitle.track}">${getAnnotationsHtml(
         subtitle.text,
-        subtitle.richText,
-        subtitle.richTextOnHover
+        rendered?.richText,
+        rendered?.richTextOnHover
     )}</span>`;
 };
 
 interface CachedShowingSubtitleProps {
-    subtitle: RichSubtitleModel;
+    subtitle: IndexedSubtitleModel;
     domCache: OffscreenDomCache;
-    renderHtml: (subtitle: RichSubtitleModel) => string;
+    renderHtml: (subtitle: IndexedSubtitleModel) => string;
     className?: string;
     onMouseOver: React.MouseEventHandler<HTMLDivElement>;
     onMouseOut: React.MouseEventHandler<HTMLDivElement>;
@@ -391,9 +380,9 @@ export default function VideoPlayer({
     const [audioTracks, setAudioTracks] = useState<AudioTrackModel[]>();
     const [selectedAudioTrack, setSelectedAudioTrack] = useState<string>();
     const [wasPlayingOnAnkiDialogRequest, setWasPlayingOnAnkiDialogRequest] = useState<boolean>(false);
-    const [subtitles, setSubtitles] = useState<RichSubtitleModel[]>([]);
-    const subtitleCollection = useMemo<SubtitleCollection<RichSubtitleModel>>(() => {
-        const newCol = new SubtitleCollection<RichSubtitleModel>({
+    const [subtitles, setSubtitles] = useState<IndexedSubtitleModel[]>([]);
+    const subtitleCollection = useMemo<SubtitleCollection<IndexedSubtitleModel>>(() => {
+        const newCol = new SubtitleCollection<IndexedSubtitleModel>({
             showingCheckRadiusMs: 150,
             returnLastShown: true,
             returnNextToShow: true,
@@ -401,7 +390,7 @@ export default function VideoPlayer({
         newCol.setSubtitles(subtitles);
         return newCol;
     }, [subtitles]);
-    const [showSubtitles, setShowSubtitles] = useState<RichSubtitleModel[]>([]);
+    const [showSubtitles, setShowSubtitles] = useState<IndexedSubtitleModel[]>([]);
     const [miscSettings, setMiscSettings] = useState<MiscSettings>(settings);
     const [subtitleSettings, setSubtitleSettings] = useState<SubtitleSettings>(settings);
     const [ankiSettings, setAnkiSettings] = useState<AnkiSettings>(settings);
@@ -416,7 +405,7 @@ export default function VideoPlayer({
     );
     const [, setBottomSubtitlePositionOffset] = useState<number>(subtitleSettings.subtitlePositionOffset);
     const [, setTopSubtitlePositionOffset] = useState<number>(subtitleSettings.topSubtitlePositionOffset);
-    const showSubtitlesRef = useRef<RichSubtitleModel[]>([]);
+    const showSubtitlesRef = useRef<IndexedSubtitleModel[]>([]);
     showSubtitlesRef.current = showSubtitles;
     const playModesRef = useRef(playModes);
     const clock = useMemo<Clock>(() => new Clock(), []);
@@ -437,7 +426,12 @@ export default function VideoPlayer({
     const mobileOverlayRef = useRef<HTMLDivElement>(null);
     const bottomSubtitleContainerRef = useRef<HTMLDivElement>(null);
     const domCacheRef = useRef<OffscreenDomCache | undefined>(undefined);
-    const updateSubtitleDomCacheRef = useRef<((windowSubtitles: RichSubtitleModel[]) => void) | undefined>(undefined);
+    const refreshSubtitleWindowDomCacheRef = useRef<((windowSubtitles: IndexedSubtitleModel[]) => void) | undefined>(
+        undefined
+    );
+    const updateSubtitleWindowDomCacheRef = useRef<((windowSubtitles: IndexedSubtitleModel[]) => void) | undefined>(
+        undefined
+    );
     const thumbnailsRef = useRef<Map<number, string>>(new Map()); // cache thumbnails, in intervals of 5s
     const isGeneratingRef = useRef(false); // avoid subsequent calls to generate thumbnail while generating one
 
@@ -593,8 +587,6 @@ export default function VideoPlayer({
                 originalEnd: s.originalEnd,
                 track: s.track,
                 index: i,
-                richText: s.richText,
-                richTextOnHover: s.richTextOnHover,
             }))
         );
     }, []);
@@ -665,15 +657,12 @@ export default function VideoPlayer({
         });
 
         playerChannel.onSubtitles((subtitles) => {
-            const renderedSubtitles = subtitlesForVideo(
-                subtitles.map((s, i) => ({ ...s, index: i })),
-                settingsRef.current.dictionaryTracks
-            );
-            setSubtitles(renderedSubtitles);
-            setTrackCount(Math.max(...subtitles.map((s) => s.track)) + 1);
+            const videoSubtitles = subtitles.map((s, i) => ({ ...s, index: i }));
+            setSubtitles(videoSubtitles);
+            setTrackCount(Math.max(...videoSubtitles.map((s) => s.track)) + 1);
 
-            if (subtitles && subtitles.length > 0) {
-                const s = subtitles[0];
+            if (videoSubtitles.length > 0) {
+                const s = videoSubtitles[0];
                 const offset = s.start - s.originalStart;
                 setOffset(offset);
             }
@@ -682,12 +671,9 @@ export default function VideoPlayer({
             autoPauseContextRef.current?.clear();
         });
         playerChannel.onSubtitlesUpdated((updatedSubtitles) => {
-            const renderedUpdatedSubtitles = subtitlesForVideo(updatedSubtitles, settingsRef.current.dictionaryTracks);
-            for (const updatedSubtitle of renderedUpdatedSubtitles) {
-                domCacheRef.current?.delete(String(updatedSubtitle.index));
-            }
+            updateSubtitleWindowDomCacheRef.current?.(updatedSubtitles);
 
-            const updatedByIndex = new Map(renderedUpdatedSubtitles.map((s) => [s.index, s] as const));
+            const updatedByIndex = new Map(updatedSubtitles.map((s) => [s.index, s] as const));
             if (showSubtitlesRef.current.some((s) => updatedByIndex.has(s.index))) {
                 setShowSubtitles((prevShowSubtitles) =>
                     prevShowSubtitles.map((showSubtitle) => {
@@ -696,8 +682,6 @@ export default function VideoPlayer({
                         return {
                             ...showSubtitle,
                             text: updatedShowSubtitle.text,
-                            richText: updatedShowSubtitle.richText,
-                            richTextOnHover: updatedShowSubtitle.richTextOnHover,
                             tokenization: updatedShowSubtitle.tokenization,
                         };
                     })
@@ -707,12 +691,10 @@ export default function VideoPlayer({
             setSubtitles((prevSubtitles) => {
                 if (!prevSubtitles.length) return prevSubtitles;
                 const allSubtitles = prevSubtitles.slice();
-                for (const s of renderedUpdatedSubtitles) {
+                for (const s of updatedSubtitles) {
                     allSubtitles[s.index] = {
                         ...allSubtitles[s.index],
                         text: s.text,
-                        richText: s.richText,
-                        richTextOnHover: s.richTextOnHover,
                         tokenization: s.tokenization,
                     };
                 }
@@ -895,12 +877,12 @@ export default function VideoPlayer({
                 for (const subtitle of lastShown ?? []) windowSubtitles.push(subtitle);
                 for (const subtitle of nextToShow ?? []) windowSubtitles.push(subtitle);
             }
-            updateSubtitleDomCacheRef.current?.(windowSubtitles);
+            refreshSubtitleWindowDomCacheRef.current?.(windowSubtitles);
         };
 
         const interval = setInterval(() => {
             const now = clock.time(length);
-            let showSubtitles: RichSubtitleModel[] = [];
+            let showSubtitles: IndexedSubtitleModel[] = [];
             const slice = subtitleCollection.subtitlesAt(now);
 
             for (const s of slice.showing) {
@@ -1695,26 +1677,34 @@ export default function VideoPlayer({
     const trackStyles = useSubtitleStyles(subtitleSettings, trackCount ?? 1, settings.dictionaryTracks, 'video');
 
     const getSubtitleHtml = useCallback(
-        (subtitle: RichSubtitleModel) =>
+        (subtitle: IndexedSubtitleModel) =>
             showingSubtitleHtml(
                 subtitle,
                 videoRef,
                 trackStyles[subtitle.track]?.styleString ?? trackStyles[0]?.styleString ?? '',
                 trackStyles[subtitle.track]?.classes ?? trackStyles[0]?.classes ?? '',
-                subtitleSettings.imageBasedSubtitleScaleFactor
+                subtitleSettings.imageBasedSubtitleScaleFactor,
+                settings.dictionaryTracks
             ),
-        [trackStyles, subtitleSettings.imageBasedSubtitleScaleFactor]
+        [trackStyles, settings.dictionaryTracks, subtitleSettings.imageBasedSubtitleScaleFactor]
     );
 
-    const { getSubtitleDomCache, updateSubtitleDomCache } = useSubtitleDomCache(subtitles, getSubtitleHtml);
+    const { getSubtitleDomCache, refreshSubtitleWindowDomCache, updateSubtitleWindowDomCache } = useSubtitleDomCache(
+        subtitles,
+        getSubtitleHtml
+    );
 
     useEffect(() => {
         domCacheRef.current = getSubtitleDomCache();
     }, [getSubtitleDomCache]);
 
     useEffect(() => {
-        updateSubtitleDomCacheRef.current = updateSubtitleDomCache;
-    }, [updateSubtitleDomCache]);
+        refreshSubtitleWindowDomCacheRef.current = refreshSubtitleWindowDomCache;
+    }, [refreshSubtitleWindowDomCache]);
+
+    useEffect(() => {
+        updateSubtitleWindowDomCacheRef.current = updateSubtitleWindowDomCache;
+    }, [updateSubtitleWindowDomCache]);
 
     const handleSwipe = useCallback(
         (direction: Direction) => {
@@ -1833,7 +1823,7 @@ export default function VideoPlayer({
         parent.document.body.clientWidth === document.body.clientWidth;
 
     const subtitleAlignmentForTrack = (track: number) => subtitleAlignments[track] ?? subtitleAlignments[0];
-    const elementForSubtitle = (subtitle: RichSubtitleModel) => (
+    const elementForSubtitle = (subtitle: IndexedSubtitleModel) => (
         <CachedShowingSubtitle
             key={subtitle.index}
             subtitle={subtitle}

--- a/common/app/components/VideoPlayer.tsx
+++ b/common/app/components/VideoPlayer.tsx
@@ -426,10 +426,10 @@ export default function VideoPlayer({
     const mobileOverlayRef = useRef<HTMLDivElement>(null);
     const bottomSubtitleContainerRef = useRef<HTMLDivElement>(null);
     const domCacheRef = useRef<OffscreenDomCache | undefined>(undefined);
-    const refreshSubtitleWindowDomCacheRef = useRef<((windowSubtitles: IndexedSubtitleModel[]) => void) | undefined>(
-        undefined
-    );
-    const updateSubtitleWindowDomCacheRef = useRef<((windowSubtitles: IndexedSubtitleModel[]) => void) | undefined>(
+    const refreshSubtitleDomCacheForSubtitlesRef = useRef<
+        ((windowSubtitles: IndexedSubtitleModel[]) => void) | undefined
+    >(undefined);
+    const updateSubtitleDomCacheRef = useRef<((windowSubtitles: IndexedSubtitleModel[]) => void) | undefined>(
         undefined
     );
     const thumbnailsRef = useRef<Map<number, string>>(new Map()); // cache thumbnails, in intervals of 5s
@@ -671,7 +671,7 @@ export default function VideoPlayer({
             autoPauseContextRef.current?.clear();
         });
         playerChannel.onSubtitlesUpdated((updatedSubtitles) => {
-            updateSubtitleWindowDomCacheRef.current?.(updatedSubtitles);
+            updateSubtitleDomCacheRef.current?.(updatedSubtitles);
 
             const updatedByIndex = new Map(updatedSubtitles.map((s) => [s.index, s] as const));
             if (showSubtitlesRef.current.some((s) => updatedByIndex.has(s.index))) {
@@ -877,7 +877,7 @@ export default function VideoPlayer({
                 for (const subtitle of lastShown ?? []) windowSubtitles.push(subtitle);
                 for (const subtitle of nextToShow ?? []) windowSubtitles.push(subtitle);
             }
-            refreshSubtitleWindowDomCacheRef.current?.(windowSubtitles);
+            refreshSubtitleDomCacheForSubtitlesRef.current?.(windowSubtitles);
         };
 
         const interval = setInterval(() => {
@@ -1689,22 +1689,14 @@ export default function VideoPlayer({
         [trackStyles, settings.dictionaryTracks, subtitleSettings.imageBasedSubtitleScaleFactor]
     );
 
-    const { getSubtitleDomCache, refreshSubtitleWindowDomCache, updateSubtitleWindowDomCache } = useSubtitleDomCache(
+    const { getSubtitleDomCache, refreshSubtitleDomCacheForSubtitles, updateSubtitleDomCache } = useSubtitleDomCache(
         subtitles,
         getSubtitleHtml
     );
 
-    useEffect(() => {
-        domCacheRef.current = getSubtitleDomCache();
-    }, [getSubtitleDomCache]);
-
-    useEffect(() => {
-        refreshSubtitleWindowDomCacheRef.current = refreshSubtitleWindowDomCache;
-    }, [refreshSubtitleWindowDomCache]);
-
-    useEffect(() => {
-        updateSubtitleWindowDomCacheRef.current = updateSubtitleWindowDomCache;
-    }, [updateSubtitleWindowDomCache]);
+    domCacheRef.current = getSubtitleDomCache();
+    refreshSubtitleDomCacheForSubtitlesRef.current = refreshSubtitleDomCacheForSubtitles;
+    updateSubtitleDomCacheRef.current = updateSubtitleDomCache;
 
     const handleSwipe = useCallback(
         (direction: Direction) => {

--- a/common/app/components/subtitles.css
+++ b/common/app/components/subtitles.css
@@ -81,20 +81,6 @@
     line-height: 1;
 }
 
-.asb-frequency-hover {
-    ruby-position: under;
-}
-
-.asb-frequency-hover rt {
-    font-size: var(--asb-frequency-size);
-    line-height: 1;
-    display: none;
-}
-
-.asb-frequency-hover:hover rt {
-    display: revert; /* Safari doesn't support 'ruby-text' */
-}
-
 .asbplayer-subtitles-blurred {
     filter: blur(10px);
 }

--- a/common/app/hooks/use-subtitle-dom-cache.ts
+++ b/common/app/hooks/use-subtitle-dom-cache.ts
@@ -13,7 +13,7 @@ export const useSubtitleDomCache = (
         return () => domCache.clear();
     }, [subtitles, render]);
 
-    const refreshSubtitleWindowDomCache = useCallback(
+    const refreshSubtitleDomCacheForSubtitles = useCallback(
         (windowSubtitles: IndexedSubtitleModel[]) => {
             const keep = new Set(windowSubtitles.map((s) => String(s.index)));
             for (const key of domCache.keys()) {
@@ -27,7 +27,7 @@ export const useSubtitleDomCache = (
         [domCache, render]
     );
 
-    const updateSubtitleWindowDomCache = useCallback(
+    const updateSubtitleDomCache = useCallback(
         (updatedSubtitles: IndexedSubtitleModel[]) => {
             for (const subtitle of updatedSubtitles) {
                 const key = String(subtitle.index);
@@ -39,7 +39,7 @@ export const useSubtitleDomCache = (
 
     return {
         getSubtitleDomCache: () => domCache,
-        refreshSubtitleWindowDomCache,
-        updateSubtitleWindowDomCache,
+        refreshSubtitleDomCacheForSubtitles,
+        updateSubtitleDomCache,
     };
 };

--- a/common/app/hooks/use-subtitle-dom-cache.ts
+++ b/common/app/hooks/use-subtitle-dom-cache.ts
@@ -13,7 +13,7 @@ export const useSubtitleDomCache = (
         return () => domCache.clear();
     }, [subtitles, render]);
 
-    const updateSubtitleDomCache = useCallback(
+    const refreshSubtitleWindowDomCache = useCallback(
         (windowSubtitles: IndexedSubtitleModel[]) => {
             const keep = new Set(windowSubtitles.map((s) => String(s.index)));
             for (const key of domCache.keys()) {
@@ -27,8 +27,19 @@ export const useSubtitleDomCache = (
         [domCache, render]
     );
 
+    const updateSubtitleWindowDomCache = useCallback(
+        (updatedSubtitles: IndexedSubtitleModel[]) => {
+            for (const subtitle of updatedSubtitles) {
+                const key = String(subtitle.index);
+                if (domCache.has(key)) domCache.add(key, render(subtitle)); // Re-render updated subtitles that already exist in the cache
+            }
+        },
+        [domCache, render]
+    );
+
     return {
         getSubtitleDomCache: () => domCache,
-        updateSubtitleDomCache,
+        refreshSubtitleWindowDomCache,
+        updateSubtitleWindowDomCache,
     };
 };

--- a/common/app/hooks/use-subtitle-dom-cache.ts
+++ b/common/app/hooks/use-subtitle-dom-cache.ts
@@ -1,5 +1,5 @@
 import { IndexedSubtitleModel, OffscreenDomCache } from '@project/common';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export const useSubtitleDomCache = (
     subtitles: IndexedSubtitleModel[],
@@ -13,15 +13,22 @@ export const useSubtitleDomCache = (
         return () => domCache.clear();
     }, [subtitles, render]);
 
-    return {
-        getSubtitleDomCache: () => {
-            if (domCache.empty) {
-                for (const subtitle of subtitles) {
-                    domCache.add(String(subtitle.index), render(subtitle));
-                }
+    const updateSubtitleDomCache = useCallback(
+        (windowSubtitles: IndexedSubtitleModel[]) => {
+            const keep = new Set(windowSubtitles.map((s) => String(s.index)));
+            for (const key of domCache.keys()) {
+                if (!keep.has(key)) domCache.delete(key);
             }
-
-            return domCache;
+            for (const subtitle of windowSubtitles) {
+                const key = String(subtitle.index);
+                if (!domCache.has(key)) domCache.add(key, render(subtitle));
+            }
         },
+        [domCache, render]
+    );
+
+    return {
+        getSubtitleDomCache: () => domCache,
+        updateSubtitleDomCache,
     };
 };

--- a/common/app/hooks/use-subtitle-find.ts
+++ b/common/app/hooks/use-subtitle-find.ts
@@ -1,0 +1,265 @@
+import { MutableRefObject, RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type ListRange, type TableVirtuosoHandle } from 'react-virtuoso';
+import { type DictionaryTrack, dictionaryTrackEnabled } from '@project/common/settings';
+import { normalizedLookupTerms, normalizeSearchText } from '@project/common/util';
+import { Yomitan } from '@project/common/yomitan';
+import { type DisplaySubtitleModel } from '../components/SubtitlePlayer';
+
+const findDelayMs = 300;
+
+const parseRegexQuery = (query: string): RegExp | undefined => {
+    const regexMatch = /^\/(.+)\/([a-z]*)$/.exec(query);
+    if (!regexMatch) return;
+    try {
+        return new RegExp(regexMatch[1], regexMatch[2].replace(/[gy]/g, ''));
+    } catch (e) {
+        return;
+    }
+};
+
+const subtitleSearchableText = (subtitle: DisplaySubtitleModel): string => {
+    const tokens = subtitle.tokenization?.tokens;
+    if (!tokens?.length) return subtitle.text;
+    let readings = '';
+    for (const token of tokens) {
+        for (const reading of token.readings) {
+            if (reading.reading) readings += reading.reading;
+        }
+    }
+    return readings.length ? `${subtitle.text}\n${readings}` : subtitle.text;
+};
+
+interface UseSubtitleFindParams {
+    subtitles?: DisplaySubtitleModel[];
+    dictionaryTracks: DictionaryTrack[];
+    disableKeyEventsRef: MutableRefObject<boolean>;
+    hiddenRef: MutableRefObject<boolean>;
+    lastScrollTimestampRef: MutableRefObject<number>;
+    subtitleListRef: MutableRefObject<DisplaySubtitleModel[] | undefined>;
+    virtuosoRef: RefObject<TableVirtuosoHandle | null>;
+    visibleRangeRef: MutableRefObject<ListRange>;
+    setHighlightedJumpToSubtitleIndex: (index: number | undefined) => void;
+}
+
+export const useSubtitleFind = ({
+    subtitles,
+    dictionaryTracks,
+    disableKeyEventsRef,
+    hiddenRef,
+    lastScrollTimestampRef,
+    subtitleListRef,
+    virtuosoRef,
+    visibleRangeRef,
+    setHighlightedJumpToSubtitleIndex,
+}: UseSubtitleFindParams) => {
+    const [open, setOpen] = useState<boolean>(false);
+    const [query, setQuery] = useState<string>('');
+    const [expansion, setExpansion] = useState<{ query: string; terms: string[] }>({ query: '', terms: [] });
+    const [currentMatchPosition, setCurrentMatchPosition] = useState<number>(0);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const yomitans = useMemo(
+        () =>
+            dictionaryTracks
+                .filter((dictionaryTrack) => dictionaryTrackEnabled(dictionaryTrack))
+                .map((dictionaryTrack) => new Yomitan(dictionaryTrack)),
+        [dictionaryTracks]
+    );
+    const yomitanVersionPromisesRef = useRef<WeakMap<Yomitan, Promise<unknown>>>(new WeakMap());
+    const ensureYomitanVersion = useCallback(async () => {
+        await Promise.allSettled(
+            yomitans.map((yomitan) => {
+                const cached = yomitanVersionPromisesRef.current.get(yomitan);
+                if (cached) return cached;
+                const promise = yomitan.version().catch((e) => {
+                    yomitanVersionPromisesRef.current.delete(yomitan);
+                    throw e;
+                });
+                yomitanVersionPromisesRef.current.set(yomitan, promise);
+                return promise;
+            })
+        );
+    }, [yomitans]);
+
+    useEffect(() => {
+        const trimmed = query.trim();
+        if (!open || !trimmed || parseRegexQuery(query) !== undefined || !yomitans.length) return;
+
+        let cancelled = false;
+        const timeout = setTimeout(async () => {
+            await ensureYomitanVersion();
+            if (cancelled) return;
+            const queryForms = new Set<string>([trimmed]);
+
+            const tokenizeResults = await Promise.allSettled(
+                yomitans.map((yt) => {
+                    try {
+                        return yt.tokenize(trimmed);
+                    } catch (e) {
+                        yomitanVersionPromisesRef.current.delete(yt);
+                        throw e;
+                    }
+                })
+            );
+            for (const result of tokenizeResults) {
+                if (result.status !== 'fulfilled') continue;
+                for (const tokenParts of result.value) {
+                    const tokenText = tokenParts
+                        .map((part) => part.text)
+                        .join('')
+                        .trim();
+                    if (tokenText) queryForms.add(tokenText);
+                }
+            }
+
+            const lemmaTerms = new Set<string>();
+            for (const queryForm of queryForms) {
+                const lemmaResults = await Promise.allSettled(
+                    yomitans.map((yt) => {
+                        try {
+                            return yt.lemmatize(queryForm);
+                        } catch (e) {
+                            yomitanVersionPromisesRef.current.delete(yt);
+                            throw e;
+                        }
+                    })
+                );
+                for (const result of lemmaResults) {
+                    if (result.status !== 'fulfilled') continue;
+                    for (const lemma of result.value ?? []) lemmaTerms.add(lemma);
+                }
+            }
+
+            if (cancelled) return;
+            setExpansion({ query: trimmed, terms: normalizedLookupTerms(...queryForms, ...lemmaTerms) });
+        }, findDelayMs);
+
+        return () => {
+            cancelled = true;
+            clearTimeout(timeout);
+        };
+    }, [query, open, yomitans, ensureYomitanVersion]);
+
+    const matches = useMemo(() => {
+        const trimmed = query.trim();
+        if (!open || !subtitles || !subtitles.length || !trimmed) return [];
+
+        const matches: number[] = [];
+        const regex = parseRegexQuery(query);
+        if (regex) {
+            for (const [i, subtitle] of subtitles.entries()) {
+                const searchableText = subtitleSearchableText(subtitle);
+                if (regex.test(searchableText)) matches.push(i);
+            }
+        } else {
+            const terms = normalizedLookupTerms(trimmed).concat(expansion.query === trimmed ? expansion.terms : []);
+            for (const [i, subtitle] of subtitles.entries()) {
+                const normalized = normalizeSearchText(subtitleSearchableText(subtitle));
+                if (terms.some((term) => normalized.includes(term))) matches.push(i);
+            }
+        }
+        return matches;
+    }, [open, subtitles, query, expansion]);
+    const matchesRef = useRef(matches);
+    matchesRef.current = matches;
+
+    const scrollToMatch = useCallback(
+        (subtitleIndex: number) => {
+            lastScrollTimestampRef.current = Date.now();
+            if (!hiddenRef.current) {
+                virtuosoRef.current?.scrollToIndex({
+                    index: subtitleIndex,
+                    align: 'center',
+                    behavior: 'auto',
+                });
+            }
+            setHighlightedJumpToSubtitleIndex(subtitleIndex);
+        },
+        [hiddenRef, lastScrollTimestampRef, setHighlightedJumpToSubtitleIndex, virtuosoRef]
+    );
+
+    useEffect(() => {
+        if (!open) return;
+        const trimmed = query.trim();
+        const searchCompleted =
+            !trimmed || parseRegexQuery(query) !== undefined || !yomitans.length || expansion.query === trimmed;
+        if (!searchCompleted) return;
+        if (!matches.length) {
+            setHighlightedJumpToSubtitleIndex(undefined);
+            setCurrentMatchPosition(0);
+            return;
+        }
+        const firstVisibleIndex = visibleRangeRef.current.startIndex;
+        const matchPosition = Math.max(
+            0,
+            matches.findIndex((subtitleIndex) => subtitleIndex >= firstVisibleIndex)
+        );
+        setCurrentMatchPosition(matchPosition);
+        scrollToMatch(matches[matchPosition]);
+    }, [
+        matches,
+        open,
+        query,
+        expansion.query,
+        yomitans.length,
+        scrollToMatch,
+        setHighlightedJumpToSubtitleIndex,
+        visibleRangeRef,
+    ]);
+
+    const navigate = useCallback(
+        (delta: number) => {
+            const matches = matchesRef.current;
+            if (!matches.length) return;
+            setCurrentMatchPosition((current) => {
+                const next = (current + delta + matches.length) % matches.length;
+                scrollToMatch(matches[next]);
+                return next;
+            });
+        },
+        [scrollToMatch]
+    );
+
+    const next = useCallback(() => navigate(1), [navigate]);
+    const previous = useCallback(() => navigate(-1), [navigate]);
+
+    const close = useCallback(() => {
+        setOpen(false);
+        setQuery('');
+        setCurrentMatchPosition(0);
+        setHighlightedJumpToSubtitleIndex(undefined);
+    }, [setHighlightedJumpToSubtitleIndex]);
+
+    useEffect(() => {
+        const handleGlobalKeyDown = (event: KeyboardEvent) => {
+            if ((event.ctrlKey || event.metaKey) && !event.altKey && (event.key === 'f' || event.key === 'F')) {
+                if (disableKeyEventsRef.current || !subtitleListRef.current || !subtitleListRef.current.length) {
+                    return;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                setOpen(true);
+                requestAnimationFrame(() => {
+                    inputRef.current?.focus();
+                    inputRef.current?.select();
+                });
+            }
+        };
+
+        document.addEventListener('keydown', handleGlobalKeyDown, true);
+        return () => document.removeEventListener('keydown', handleGlobalKeyDown, true);
+    }, [disableKeyEventsRef, subtitleListRef]);
+
+    const resultsLabel = query.trim() ? `${matches.length ? currentMatchPosition + 1 : 0}/${matches.length}` : '';
+
+    return {
+        open,
+        query,
+        inputRef,
+        matches,
+        resultsLabel,
+        setQuery,
+        next,
+        previous,
+        close,
+    };
+};

--- a/common/app/services/player-channel.ts
+++ b/common/app/services/player-channel.ts
@@ -6,7 +6,6 @@ import {
     AudioTrackSelectedFromVideoMessage,
     AudioTrackSelectedToVideoMessage,
     CardTextFieldValues,
-    RichSubtitleModel,
     CopyMessage,
     CopyToVideoMessage,
     CurrentTimeToVideoMessage,
@@ -33,6 +32,7 @@ import {
     SubtitlesUpdatedToVideoMessage,
     SaveTokenLocalFromVideoMessage,
     SaveTokenLocalToVideoMessage,
+    IndexedSubtitleModel,
 } from '@project/common';
 import {
     AnkiSettings,
@@ -52,7 +52,7 @@ export default class PlayerChannel {
     private audioTrackSelectedCallbacks: ((id: string) => void)[];
     private closeCallbacks: (() => void)[];
     private subtitlesCallbacks: ((subtitles: SubtitleModel[], subtitleFileName: string) => void)[];
-    private subtitlesUpdatedCallbacks: ((updatedSubtitles: RichSubtitleModel[]) => void)[];
+    private subtitlesUpdatedCallbacks: ((updatedSubtitles: IndexedSubtitleModel[]) => void)[];
     private saveTokenLocalCallbacks: ((
         track: number,
         token: string,
@@ -297,7 +297,7 @@ export default class PlayerChannel {
         return () => this._remove(callback, this.subtitlesCallbacks);
     }
 
-    onSubtitlesUpdated(callback: (updatedSubtitles: RichSubtitleModel[]) => void) {
+    onSubtitlesUpdated(callback: (updatedSubtitles: IndexedSubtitleModel[]) => void) {
         this.subtitlesUpdatedCallbacks.push(callback);
         return () => this._remove(callback, this.subtitlesUpdatedCallbacks);
     }
@@ -484,7 +484,7 @@ export default class PlayerChannel {
         this.channel?.postMessage(message);
     }
 
-    subtitlesUpdated(updatedSubtitles: RichSubtitleModel[]) {
+    subtitlesUpdated(updatedSubtitles: IndexedSubtitleModel[]) {
         const message: SubtitlesUpdatedFromVideoMessage = {
             command: 'subtitlesUpdated',
             updatedSubtitles,

--- a/common/app/services/video-channel.ts
+++ b/common/app/services/video-channel.ts
@@ -7,7 +7,6 @@ import {
     AudioTrackSelectedFromVideoMessage,
     AudioTrackSelectedToVideoMessage,
     CardTextFieldValues,
-    RichSubtitleModel,
     CopyMessage,
     CopyToVideoMessage,
     CurrentTimeFromVideoMessage,
@@ -37,6 +36,7 @@ import {
     SubtitlesUpdatedToVideoMessage,
     SaveTokenLocalFromVideoMessage,
     SaveTokenLocalToVideoMessage,
+    IndexedSubtitleModel,
 } from '@project/common';
 import {
     AnkiSettings,
@@ -76,7 +76,7 @@ export default class VideoChannel {
     private appBarToggleCallbacks: (() => void)[];
     private ankiDialogRequestCallbacks: (() => void)[];
     private toggleSubtitleTrackInListCallbacks: ((track: number) => void)[];
-    private subtitlesUpdatedCallbacks: ((updatedSubtitles: RichSubtitleModel[]) => void)[];
+    private subtitlesUpdatedCallbacks: ((updatedSubtitles: IndexedSubtitleModel[]) => void)[];
     private saveTokenLocalCallbacks: ((
         track: number,
         token: string,
@@ -397,7 +397,7 @@ export default class VideoChannel {
         return () => this._remove(callback, this.toggleSubtitleTrackInListCallbacks);
     }
 
-    onSubtitlesUpdated(callback: (updatedSubtitles: RichSubtitleModel[]) => void) {
+    onSubtitlesUpdated(callback: (updatedSubtitles: IndexedSubtitleModel[]) => void) {
         this.subtitlesUpdatedCallbacks.push(callback);
         return () => this._remove(callback, this.subtitlesUpdatedCallbacks);
     }
@@ -477,7 +477,7 @@ export default class VideoChannel {
         } as SaveTokenLocalToVideoMessage);
     }
 
-    subtitlesUpdated(subtitles: RichSubtitleModel[]) {
+    subtitlesUpdated(subtitles: IndexedSubtitleModel[]) {
         this.protocol.postMessage({
             command: 'subtitlesUpdated',
             subtitles,

--- a/common/components/About.tsx
+++ b/common/components/About.tsx
@@ -195,6 +195,13 @@ const dependencies: Dependency[] = [
         licenseLink: 'https://github.com/cure53/DOMPurify/blob/main/LICENSE',
         purpose: 'HTML sanitization',
     },
+    {
+        name: 'react-virtuoso',
+        projectLink: 'https://github.com/petyosi/react-virtuoso',
+        license: 'MIT',
+        licenseLink: 'https://github.com/petyosi/react-virtuoso/blob/main/README.md#license',
+        purpose: 'Virtualized subtitle list rendering',
+    },
 ];
 
 const dependencyPurposeCounts: { [key: string]: number } = {};

--- a/common/components/Statistics.tsx
+++ b/common/components/Statistics.tsx
@@ -1863,6 +1863,10 @@ export default function Statistics({
                 : undefined,
         [statisticsSnapshot, statisticsSnapshotLoaded, rewatchProjectionsByTrack]
     );
+    // Keep a ref to the latest snapshots so callbacks that only read them at call time (e.g. mining a
+    // sentence) can stay referentially stable across the frequent snapshot updates.
+    const trackSnapshotsRef = useRef(trackSnapshots);
+    trackSnapshotsRef.current = trackSnapshots;
     const hasSnapshots = trackSnapshots && trackSnapshots.length > 0;
     const loadingSnapshots = !statisticsSnapshotLoaded;
     const allTrackProgressComplete = useMemo(
@@ -1953,12 +1957,12 @@ export default function Statistics({
     const handleMineSentence = useCallback(
         async (sentence: DictionaryStatisticsSentence) => {
             if (mediaId === undefined) return;
-            const trackSnapshot = trackSnapshots?.find((candidate) => candidate.track === sentence.track);
+            const trackSnapshot = trackSnapshotsRef.current?.find((candidate) => candidate.track === sentence.track);
             if (!trackSnapshot || trackSnapshot.progress.current < trackSnapshot.progress.total) return;
             await onMineWasRequested?.(mediaId);
             await Promise.resolve(dictionaryProvider.requestStatisticsMineSentences(mediaId, [sentence.index]));
         },
-        [dictionaryProvider, onMineWasRequested, trackSnapshots, mediaId]
+        [dictionaryProvider, onMineWasRequested, mediaId]
     );
     const canGenerateStatistics = useMemo(
         () => settings.dictionaryTracks.some((dt) => dictionaryTrackEnabled(dt)),

--- a/common/components/StatisticsSentenceDetailsDialog.tsx
+++ b/common/components/StatisticsSentenceDetailsDialog.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
     ContextProp,
     ItemProps,
+    ListRange,
     TableBodyProps,
     TableComponents,
     TableProps,
@@ -20,7 +21,14 @@ import {
     percentDisplay,
     sortDictionaryStatisticsSentenceBucketEntries,
 } from '@project/common/dictionary-statistics';
-import { getAnnotationsHtml } from '@project/common/subtitle-annotations';
+import {
+    getAnnotationsHtml,
+    renderRichTextWindow,
+    emptyRichTextWindow,
+    RichTextWindow,
+    RenderedRichText,
+    renderRichTextForSubtitle,
+} from '@project/common/subtitle-annotations';
 import { timeDurationDisplay } from '@project/common/util';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -73,6 +81,7 @@ interface SentenceTableContext {
     mineTooltip: string;
     maximumDisplayedTimestamp: number;
     dictionaryTracks: DictionaryTrack[];
+    richTextWindowRef: React.RefObject<RichTextWindow>;
     activeHighlightedSentenceIndex?: number;
     onSeekToSentence: (sentence: DictionaryStatisticsSentence) => void;
     onMineSentence: (sentence: DictionaryStatisticsSentence) => void;
@@ -141,6 +150,7 @@ interface SentenceRowCellsProps {
     mineTooltip: string;
     maximumDisplayedTimestamp: number;
     tokenAnnotationConfig?: TokenAnnotationConfig;
+    rendered?: RenderedRichText;
     onMineSentence: (sentence: DictionaryStatisticsSentence) => void;
 }
 
@@ -152,6 +162,7 @@ const SentenceRowCells = React.memo(function SentenceRowCells({
     mineTooltip,
     maximumDisplayedTimestamp,
     tokenAnnotationConfig,
+    rendered,
     onMineSentence,
 }: SentenceRowCellsProps) {
     const { t } = useTranslation();
@@ -193,7 +204,7 @@ const SentenceRowCells = React.memo(function SentenceRowCells({
                 <span
                     style={tokenAnnotationStyleValues(tokenAnnotationConfig) as React.CSSProperties}
                     dangerouslySetInnerHTML={{
-                        __html: getAnnotationsHtml(sentence.text, sentence.richText, sentence.richTextOnHover),
+                        __html: getAnnotationsHtml(sentence.text, rendered?.richText, rendered?.richTextOnHover),
                     }}
                 />
             </TableCell>
@@ -243,6 +254,12 @@ const renderSentence = (
         tokenAnnotationConfig={
             context.dictionaryTracks[entry.sentence.track]?.dictionaryTokenAnnotationConfig.subtitlePlayer
         }
+        rendered={renderRichTextForSubtitle(
+            context.richTextWindowRef.current,
+            entry.sentence,
+            'subtitlePlayer',
+            context.dictionaryTracks
+        )}
         onMineSentence={context.onMineSentence}
     />
 );
@@ -286,6 +303,37 @@ export default function StatisticsSentenceDetailsDialog({
     const sortedEntriesRef = useRef(sortedEntries);
     sortedEntriesRef.current = sortedEntries;
     const virtuosoRef = useRef<TableVirtuosoHandle>(null);
+
+    const richTextWindowRef = useRef<RichTextWindow>(emptyRichTextWindow());
+
+    const handleRangeChanged = useCallback(
+        (range: ListRange) => {
+            const entries = sortedEntriesRef.current;
+            if (!entries.length) return;
+            const windowSentences = entries.slice(range.startIndex, range.endIndex + 1).map((e) => e.sentence);
+            richTextWindowRef.current = renderRichTextWindow(
+                richTextWindowRef.current,
+                windowSentences,
+                'subtitlePlayer',
+                dictionaryTracks
+            );
+        },
+        [dictionaryTracks]
+    );
+
+    useEffect(() => {
+        const range = richTextWindowRef.current.range;
+        richTextWindowRef.current = emptyRichTextWindow();
+        if (range && sortedEntries.length) {
+            const windowSentences = sortedEntries.slice(range.min, range.max + 1).map((e) => e.sentence);
+            richTextWindowRef.current = renderRichTextWindow(
+                richTextWindowRef.current,
+                windowSentences,
+                'subtitlePlayer',
+                dictionaryTracks
+            );
+        }
+    }, [sortedEntries, dictionaryTracks]);
 
     useEffect(() => {
         if (!open || highlightedSentenceIndex === undefined) {
@@ -353,6 +401,7 @@ export default function StatisticsSentenceDetailsDialog({
             mineTooltip: mineTooltip!,
             maximumDisplayedTimestamp,
             dictionaryTracks,
+            richTextWindowRef,
             activeHighlightedSentenceIndex,
             onSeekToSentence: handleSeekToSentence,
             onMineSentence: handleMineSentence,
@@ -463,6 +512,7 @@ export default function StatisticsSentenceDetailsDialog({
                                 components={sentenceTableComponents}
                                 computeItemKey={computeSentenceItemKey}
                                 itemContent={renderSentence}
+                                rangeChanged={handleRangeChanged}
                                 increaseViewportBy={{ top: window.innerHeight, bottom: window.innerHeight }} // pre-load for fast scrolling
                             />
                             <Box sx={{ height: bottomOffset }} />

--- a/common/components/StatisticsSentenceDetailsDialog.tsx
+++ b/common/components/StatisticsSentenceDetailsDialog.tsx
@@ -1,4 +1,13 @@
-import React, { createRef, RefObject, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    ContextProp,
+    ItemProps,
+    TableBodyProps,
+    TableComponents,
+    TableProps,
+    TableVirtuoso,
+    TableVirtuosoHandle,
+} from 'react-virtuoso';
 import {
     DictionaryStatisticsSentence,
     DictionaryStatisticsSentenceBucketEntry,
@@ -18,7 +27,10 @@ import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import IconButton from '@mui/material/IconButton';
-import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
@@ -55,159 +67,193 @@ const Subtitle: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     </Typography>
 );
 
-interface SentenceProps {
-    entry: DictionaryStatisticsSentenceBucketEntry;
-    ref: RefObject<HTMLDivElement | null>;
+interface SentenceTableContext {
     small: boolean;
-    highlighted: boolean;
-    mineTooltip: string;
     miningEnabled: boolean;
-    tokenAnnotationConfig?: TokenAnnotationConfig;
+    mineTooltip: string;
     maximumDisplayedTimestamp: number;
+    dictionaryTracks: DictionaryTrack[];
+    activeHighlightedSentenceIndex?: number;
     onSeekToSentence: (sentence: DictionaryStatisticsSentence) => void;
     onMineSentence: (sentence: DictionaryStatisticsSentence) => void;
 }
 
-const Sentence: React.FC<SentenceProps> = React.memo(function Sentence({
+const SentenceTable = ({ style, context, ...rest }: TableProps & ContextProp<SentenceTableContext>) => (
+    <Table {...rest} style={style} />
+);
+
+const SentenceTableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps & ContextProp<SentenceTableContext>>(
+    function SentenceTableBody({ context, ...rest }, ref) {
+        return <TableBody {...rest} ref={ref} />;
+    }
+);
+
+const SentenceTableRow = ({
+    item,
+    context,
+    ...props
+}: ItemProps<DictionaryStatisticsSentenceBucketEntry> & ContextProp<SentenceTableContext>) => {
+    const sentence = item.sentence;
+    const highlighted = context.activeHighlightedSentenceIndex === sentence.index;
+    return (
+        <TableRow
+            {...props}
+            role="button"
+            tabIndex={0}
+            sx={{
+                cursor: 'pointer',
+                backgroundColor: (theme) => (highlighted ? alpha(theme.palette.primary.main, 0.16) : undefined),
+                '&:hover': {
+                    backgroundColor: (theme) =>
+                        highlighted ? alpha(theme.palette.primary.main, 0.24) : theme.palette.action.hover,
+                },
+                '& .asb-token-highlight:hover': {
+                    backgroundColor: 'rgb(0, 123, 255)',
+                },
+            }}
+            onClick={(event) => {
+                const selection = document.getSelection();
+                const row = event.currentTarget;
+                const selectingText =
+                    selection !== null &&
+                    selection.type === 'Range' &&
+                    !selection.isCollapsed &&
+                    selection.anchorNode !== null &&
+                    row.contains(selection.anchorNode);
+                if (selectingText) return;
+                context.onSeekToSentence(sentence);
+            }}
+            onKeyDown={(event) => {
+                if (event.key !== 'Enter' && event.key !== ' ') {
+                    return;
+                }
+                event.preventDefault();
+                context.onSeekToSentence(sentence);
+            }}
+        />
+    );
+};
+
+interface SentenceRowCellsProps {
+    entry: DictionaryStatisticsSentenceBucketEntry;
+    small: boolean;
+    miningEnabled: boolean;
+    mineTooltip: string;
+    maximumDisplayedTimestamp: number;
+    tokenAnnotationConfig?: TokenAnnotationConfig;
+    onMineSentence: (sentence: DictionaryStatisticsSentence) => void;
+}
+
+// Memoized with stable props so that frequent statistics-snapshot updates don't re-render.
+const SentenceRowCells = React.memo(function SentenceRowCells({
     entry,
-    ref,
     small,
-    highlighted,
     miningEnabled,
-    tokenAnnotationConfig,
     mineTooltip,
     maximumDisplayedTimestamp,
-    onSeekToSentence,
+    tokenAnnotationConfig,
     onMineSentence,
-}) {
+}: SentenceRowCellsProps) {
     const { t } = useTranslation();
     const sentence = entry.sentence;
     const comprehensionBand =
         dictionaryStatisticsComprehensionBands[entry.comprehensionBandIndex] ??
         dictionaryStatisticsComprehensionBands[dictionaryStatisticsComprehensionBands.length - 1];
     return (
-        <Paper
-            key={sentence.index}
-            variant="outlined"
-            ref={ref}
-            sx={{
-                display: 'flex',
-                alignItems: 'stretch',
-                overflow: 'hidden',
-                transition: (theme) =>
-                    theme.transitions.create(['background-color', 'border-color'], {
-                        duration: 1000,
-                    }),
-                backgroundColor: (theme) => (highlighted ? alpha(theme.palette.primary.main, 0.16) : 'transparent'),
-                borderColor: (theme) => (highlighted ? theme.palette.primary.main : undefined),
-            }}
-        >
-            <Box
-                role="button"
-                tabIndex={0}
+        <>
+            <TableCell sx={{ verticalAlign: 'top', whiteSpace: 'nowrap', width: small ? 'auto' : 72 }}>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                    <Typography variant="body2" color="text.secondary">
+                        {`#${sentence.index + 1}`}
+                    </Typography>
+                    <Tooltip title={t('statistics.comprehension')}>
+                        <Typography
+                            variant="caption"
+                            sx={{
+                                color: comprehensionBand.color,
+                                lineHeight: 1.2,
+                                fontWeight: 600,
+                                width: 'fit-content',
+                            }}
+                        >
+                            {percentDisplay(entry.comprehensionPercent)}
+                        </Typography>
+                    </Tooltip>
+                </Box>
+            </TableCell>
+            <TableCell
+                className="asb-subtitles"
                 sx={{
-                    flex: 1,
-                    minWidth: 0,
-                    px: 2,
-                    py: 1.5,
-                    cursor: 'pointer',
-                    '&:hover': { backgroundColor: 'action.hover' },
-                }}
-                onClick={() => onSeekToSentence(sentence)}
-                onKeyDown={(event) => {
-                    if (event.key !== 'Enter' && event.key !== ' ') return;
-                    event.preventDefault();
-                    onSeekToSentence(sentence);
+                    verticalAlign: 'top',
+                    width: '100%',
+                    overflowWrap: 'anywhere',
+                    whiteSpace: 'pre-wrap',
                 }}
             >
-                <Box
+                <span
+                    style={tokenAnnotationStyleValues(tokenAnnotationConfig) as React.CSSProperties}
+                    dangerouslySetInnerHTML={{
+                        __html: getAnnotationsHtml(sentence.text, sentence.richText, sentence.richTextOnHover),
+                    }}
+                />
+            </TableCell>
+            <TableCell sx={{ verticalAlign: 'top', p: 0.5, textAlign: 'center' }}>
+                <Tooltip title={mineTooltip}>
+                    <span>
+                        <IconButton
+                            disabled={!miningEnabled}
+                            onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                onMineSentence(sentence);
+                            }}
+                        >
+                            <NoteAddIcon />
+                        </IconButton>
+                    </span>
+                </Tooltip>
+            </TableCell>
+            {!small && (
+                <TableCell
                     sx={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        gap: 2,
-                        alignItems: 'flex-start',
+                        verticalAlign: 'top',
+                        whiteSpace: 'nowrap',
+                        textAlign: 'right',
+                        color: 'text.secondary',
                     }}
                 >
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 0.5,
-                            flexShrink: 0,
-                            minWidth: small ? 'auto' : 72,
-                        }}
-                    >
-                        <Typography variant="body2" color="text.secondary">
-                            {`#${sentence.index + 1}`}
-                        </Typography>
-                        <Tooltip title={t('statistics.comprehension')}>
-                            <Typography
-                                variant="caption"
-                                sx={{
-                                    color: comprehensionBand.color,
-                                    lineHeight: 1.2,
-                                    fontWeight: 600,
-                                    width: 'fit-content',
-                                }}
-                            >
-                                {percentDisplay(entry.comprehensionPercent)}
-                            </Typography>
-                        </Tooltip>
-                    </Box>
-                    <Box
-                        sx={{
-                            flex: 1,
-                            minWidth: 0,
-                            overflowWrap: 'anywhere',
-                            whiteSpace: 'pre-wrap',
-                        }}
-                    >
-                        <span
-                            className="asb-subtitles"
-                            style={tokenAnnotationStyleValues(tokenAnnotationConfig) as React.CSSProperties}
-                            dangerouslySetInnerHTML={{
-                                __html: getAnnotationsHtml(sentence.text, sentence.richText, sentence.richTextOnHover),
-                            }}
-                        />
-                    </Box>
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'flex-end',
-                            flexShrink: 0,
-                            ml: 'auto',
-                        }}
-                    >
-                        <Tooltip title={mineTooltip!}>
-                            <span>
-                                <IconButton
-                                    disabled={!miningEnabled}
-                                    onClick={(event) => {
-                                        event.preventDefault();
-                                        event.stopPropagation();
-                                        onMineSentence(sentence);
-                                    }}
-                                >
-                                    <NoteAddIcon />
-                                </IconButton>
-                            </span>
-                        </Tooltip>
-                        {!small && (
-                            <Typography
-                                variant="body2"
-                                color="text.secondary"
-                                sx={{ whiteSpace: 'nowrap', pl: 0.5, textAlign: 'right' }}
-                            >
-                                {timeDurationDisplay(sentence.start, maximumDisplayedTimestamp, true)}
-                            </Typography>
-                        )}
-                    </Box>
-                </Box>
-            </Box>
-        </Paper>
+                    {timeDurationDisplay(sentence.start, maximumDisplayedTimestamp, true)}
+                </TableCell>
+            )}
+        </>
     );
 });
+
+const renderSentence = (
+    _index: number,
+    entry: DictionaryStatisticsSentenceBucketEntry,
+    context: SentenceTableContext
+) => (
+    <SentenceRowCells
+        entry={entry}
+        small={context.small}
+        miningEnabled={context.miningEnabled}
+        mineTooltip={context.mineTooltip}
+        maximumDisplayedTimestamp={context.maximumDisplayedTimestamp}
+        tokenAnnotationConfig={
+            context.dictionaryTracks[entry.sentence.track]?.dictionaryTokenAnnotationConfig.subtitlePlayer
+        }
+        onMineSentence={context.onMineSentence}
+    />
+);
+
+const computeSentenceItemKey = (_index: number, entry: DictionaryStatisticsSentenceBucketEntry) => entry.sentence.index;
+
+const sentenceTableComponents: TableComponents<DictionaryStatisticsSentenceBucketEntry, SentenceTableContext> = {
+    Table: SentenceTable,
+    TableBody: SentenceTableBody,
+    TableRow: SentenceTableRow,
+};
 
 export default function StatisticsSentenceDetailsDialog({
     open,
@@ -228,18 +274,18 @@ export default function StatisticsSentenceDetailsDialog({
         defaultDictionaryStatisticsSentenceSortState()
     );
     const [activeHighlightedSentenceIndex, setActiveHighlightedSentenceIndex] = useState<number>();
-    const entryRefs = useMemo(() => {
-        const refs: Record<number, RefObject<HTMLDivElement | null>> = {};
-        for (const entry of entries) {
-            refs[entry.sentence.index] = createRef<HTMLDivElement | null>();
-        }
-        return refs;
-    }, [entries]);
     const mineTooltip = miningEnabled ? t('action.mine') : (miningDisabledReason ?? t('action.mine'));
     const maximumDisplayedTimestamp = useMemo(
         () => entries.reduce((maximum, entry) => Math.max(maximum, entry.sentence.end), 0),
         [entries]
     );
+
+    const sortedEntries = useMemo(() => {
+        return sortDictionaryStatisticsSentenceBucketEntries(entries, sortState);
+    }, [entries, sortState]);
+    const sortedEntriesRef = useRef(sortedEntries);
+    sortedEntriesRef.current = sortedEntries;
+    const virtuosoRef = useRef<TableVirtuosoHandle>(null);
 
     useEffect(() => {
         if (!open || highlightedSentenceIndex === undefined) {
@@ -249,9 +295,12 @@ export default function StatisticsSentenceDetailsDialog({
 
         setActiveHighlightedSentenceIndex(highlightedSentenceIndex);
         const scrollTimeout = window.setTimeout(() => {
-            entryRefs[highlightedSentenceIndex].current?.scrollIntoView({
-                block: 'center',
-            });
+            const index = sortedEntriesRef.current.findIndex(
+                (entry) => entry.sentence.index === highlightedSentenceIndex
+            );
+            if (index !== -1) {
+                virtuosoRef.current?.scrollToIndex({ index, align: 'center' });
+            }
         }, 0);
         const highlightTimeout = window.setTimeout(() => {
             setActiveHighlightedSentenceIndex((current) =>
@@ -263,11 +312,7 @@ export default function StatisticsSentenceDetailsDialog({
             window.clearTimeout(scrollTimeout);
             window.clearTimeout(highlightTimeout);
         };
-    }, [open, entryRefs, highlightedSentenceIndex]);
-
-    const sortedEntries = useMemo(() => {
-        return sortDictionaryStatisticsSentenceBucketEntries(entries, sortState);
-    }, [entries, sortState]);
+    }, [open, highlightedSentenceIndex]);
 
     const sortOptions: { sort: DictionaryStatisticsSentenceSort; label: string }[] = [
         { sort: 'index', label: t('statistics.sentenceIndex') },
@@ -284,10 +329,45 @@ export default function StatisticsSentenceDetailsDialog({
         }
         setBottomOffset(div.getBoundingClientRect().height);
     }, []);
+    const [scrollParent, setScrollParent] = useState<HTMLElement | null>(null);
     const theme = useTheme();
     const smallScreen = useMediaQuery(theme.breakpoints.down(450));
     const sortLabel = sortOptions.find((s) => s.sort === sortState.sort)!.label;
     const ArrowIcon = sortState.direction === 'asc' ? ArrowUpwardIcon : ArrowDownwardIcon;
+    const onSeekToSentenceRef = useRef(onSeekToSentence);
+    onSeekToSentenceRef.current = onSeekToSentence;
+    const onMineSentenceRef = useRef(onMineSentence);
+    onMineSentenceRef.current = onMineSentence;
+    const handleSeekToSentence = useCallback(
+        (sentence: DictionaryStatisticsSentence) => onSeekToSentenceRef.current(sentence),
+        []
+    );
+    const handleMineSentence = useCallback(
+        (sentence: DictionaryStatisticsSentence) => onMineSentenceRef.current(sentence),
+        []
+    );
+    const listContext = useMemo<SentenceTableContext>(
+        () => ({
+            small: smallScreen,
+            miningEnabled,
+            mineTooltip: mineTooltip!,
+            maximumDisplayedTimestamp,
+            dictionaryTracks,
+            activeHighlightedSentenceIndex,
+            onSeekToSentence: handleSeekToSentence,
+            onMineSentence: handleMineSentence,
+        }),
+        [
+            smallScreen,
+            miningEnabled,
+            mineTooltip,
+            maximumDisplayedTimestamp,
+            dictionaryTracks,
+            activeHighlightedSentenceIndex,
+            handleSeekToSentence,
+            handleMineSentence,
+        ]
+    );
 
     return (
         <Dialog fullWidth maxWidth="md" open={open} onClose={onClose}>
@@ -300,7 +380,7 @@ export default function StatisticsSentenceDetailsDialog({
                 </IconButton>
             </Toolbar>
 
-            <DialogContent>
+            <DialogContent ref={setScrollParent}>
                 <Box
                     ref={handleCaptionBoxRef}
                     sx={{
@@ -373,39 +453,21 @@ export default function StatisticsSentenceDetailsDialog({
                 {sortedEntries.length === 0 ? (
                     <Typography color="text.secondary">{t('statistics.sentenceDetailsEmpty')}</Typography>
                 ) : (
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 1,
-                            '& .asb-token-highlight:hover': {
-                                backgroundColor: 'rgb(0, 123, 255)',
-                            },
-                        }}
-                    >
-                        {sortedEntries.map((entry) => {
-                            const isHighlighted = activeHighlightedSentenceIndex === entry.sentence.index;
-                            const dictionaryTrack = dictionaryTracks[entry.sentence.track];
-                            return (
-                                <Sentence
-                                    key={entry.sentence.index}
-                                    ref={entryRefs[entry.sentence.index]}
-                                    entry={entry}
-                                    small={smallScreen}
-                                    highlighted={isHighlighted}
-                                    maximumDisplayedTimestamp={maximumDisplayedTimestamp}
-                                    mineTooltip={mineTooltip!}
-                                    miningEnabled={miningEnabled}
-                                    tokenAnnotationConfig={
-                                        dictionaryTrack.dictionaryTokenAnnotationConfig.subtitlePlayer
-                                    }
-                                    onMineSentence={onMineSentence}
-                                    onSeekToSentence={onSeekToSentence}
-                                />
-                            );
-                        })}
-                        <Box sx={{ height: bottomOffset }} />
-                    </Box>
+                    scrollParent && (
+                        <>
+                            <TableVirtuoso
+                                ref={virtuosoRef}
+                                customScrollParent={scrollParent}
+                                data={sortedEntries}
+                                context={listContext}
+                                components={sentenceTableComponents}
+                                computeItemKey={computeSentenceItemKey}
+                                itemContent={renderSentence}
+                                increaseViewportBy={{ top: window.innerHeight, bottom: window.innerHeight }} // pre-load for fast scrolling
+                            />
+                            <Box sx={{ height: bottomOffset }} />
+                        </>
+                    )
                 )}
             </DialogContent>
         </Dialog>

--- a/common/components/SubtitleTextImage.tsx
+++ b/common/components/SubtitleTextImage.tsx
@@ -16,7 +16,13 @@ export default function SubtitleTextImage({ subtitle, availableWidth, scale }: P
 
     return (
         <div style={{ maxWidth: width, margin: 'auto' }}>
-            <img style={{ width: '100%' }} alt="subtitle" src={subtitle.textImage.dataUrl} />
+            <img
+                width={subtitle.textImage.image.width}
+                height={subtitle.textImage.image.height}
+                style={{ width: '100%', height: 'auto', display: 'block' }}
+                alt="subtitle"
+                src={subtitle.textImage.dataUrl}
+            />
         </div>
     );
 }

--- a/common/components/WordBrowserDialog.tsx
+++ b/common/components/WordBrowserDialog.tsx
@@ -55,7 +55,7 @@ import {
     TokenState,
     TokenStatus,
 } from '@project/common/settings';
-import { getTokenStatus, normalizeForSearch } from '@project/common/util';
+import { getTokenStatus, normalizedLookupTerms } from '@project/common/util';
 import { Yomitan } from '@project/common/yomitan';
 import Box from '@mui/material/Box';
 
@@ -163,27 +163,6 @@ interface CyclingFilterListProps<T extends FilterModeValue> {
     selectedFilters: FilterMap<T>;
     onToggle: (value: T) => void;
     renderMenuItemLabel: (value: T) => React.ReactNode;
-}
-
-function normalizeSearchText(text: string) {
-    return text.normalize('NFKC').trim().toLocaleLowerCase();
-}
-
-function normalizedLookupTerms(...texts: Array<string | null | undefined>) {
-    return Array.from(
-        new Set(
-            texts
-                .flatMap((text) => {
-                    if (!text) return [];
-                    const normalized = normalizeForSearch(text);
-                    if (!normalized.length || normalized === text) return [text];
-                    return [text, normalized];
-                })
-                .filter((text) => Boolean(text))
-                .map(normalizeSearchText)
-                .filter((text) => text.length)
-        )
-    );
 }
 
 function matchesSearchTerm(searchTerms: string[], term: string) {

--- a/common/copy-history/copy-history-repository.ts
+++ b/common/copy-history/copy-history-repository.ts
@@ -27,8 +27,6 @@ class CopyHistoryDatabase extends Dexie {
                             originalEnd: item.originalEnd,
                             track: item.track,
                             index: item.index,
-                            richText: item.richText,
-                            richTextOnHover: item.richTextOnHover,
                         };
                         item.subtitle = subtitle;
                         delete item.text;

--- a/common/dictionary-statistics/dictionary-statistics.ts
+++ b/common/dictionary-statistics/dictionary-statistics.ts
@@ -24,8 +24,6 @@ export interface DictionaryStatisticsSentence {
     end: number;
     track: number;
     index: number;
-    richText?: string;
-    richTextOnHover?: string;
     tokenization?: Tokenization;
 }
 

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -34,7 +34,8 @@
         "revert": "Zurücksetzen",
         "userGuide": "Benutzeranleitung",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "Über asbplayer",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -34,7 +34,8 @@
         "revert": "Revert",
         "userGuide": "User guide",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "About asbplayer",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -34,7 +34,8 @@
         "revert": "Revertir",
         "userGuide": "Guía de usuario",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "Acerca de asbplayer",

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -34,7 +34,8 @@
         "revert": "Revert",
         "userGuide": "User guide",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "Tietoja asbplayeristä",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -34,7 +34,8 @@
         "revert": "Revert",
         "userGuide": "User guide",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "À propos d'asbplayer",

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -34,7 +34,8 @@
         "revert": "Kembalikan",
         "userGuide": "Panduan Pengguna",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "Tentang asbplayer",

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -34,7 +34,8 @@
         "revert": "Ripristina",
         "userGuide": "Guida Utente",
         "search": "Cerca",
-        "reload": "Ricarica"
+        "reload": "Ricarica",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "A proposito di asbplayer",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -34,7 +34,8 @@
         "revert": "元に戻す",
         "userGuide": "ユーザーガイド",
         "search": "検索",
-        "reload": "再読み込み"
+        "reload": "再読み込み",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "asbplayerについて",

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -34,7 +34,8 @@
         "revert": "Revert",
         "userGuide": "User guide",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "asbplayer 소개",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -34,7 +34,8 @@
         "revert": "Revert",
         "userGuide": "User guide",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "About asbplayer",

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -34,7 +34,8 @@
         "revert": "Reverter",
         "userGuide": "Guia de usuario",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "Sobre o asbplayer",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -34,7 +34,8 @@
         "revert": "Revert",
         "userGuide": "User guide",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "О asbplayer",

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -34,7 +34,8 @@
         "revert": "还原",
         "userGuide": "用户指南",
         "search": "Search",
-        "reload": "Reload"
+        "reload": "Reload",
+        "findPlaceholder": "Search by text or /regex/"
     },
     "about": {
         "title": "关于 asbplayer",

--- a/common/package.json
+++ b/common/package.json
@@ -17,6 +17,7 @@
         "jsonschema": "^1.5.0",
         "lamejs": "1.2.0",
         "pgs-parser": "0.1.0",
+        "react-virtuoso": "^4.18.7",
         "sanitize-filename": "^1.6.3",
         "semver": "^7.3.7",
         "uuid": "8.3.2",

--- a/common/settings/settings.ts
+++ b/common/settings/settings.ts
@@ -536,8 +536,10 @@ export function compareDTField<K extends keyof DictionaryTrack>(
     return dictionaryTrackComparators[key](a[key], b[key]);
 }
 
-export function areDictionaryTracksEqual(dt1: DictionaryTrack, dt2: DictionaryTrack): boolean {
+export function areDictionaryTracksEqual(dt1: DictionaryTrack | undefined, dt2: DictionaryTrack | undefined): boolean {
     if (dt1 === dt2) return true;
+    if (!dt1 || !dt2) return false;
+
     for (const key in dictionaryTrackComparators) {
         if (!compareDTField(key as keyof DictionaryTrack, dt1, dt2)) {
             return false;

--- a/common/src/message.ts
+++ b/common/src/message.ts
@@ -27,9 +27,9 @@ import {
     CopyHistoryItem,
     AnkiDialogSettings,
     AnkiExportMode,
-    RichSubtitleModel,
     BrowserFeatures,
     Tokenization,
+    IndexedSubtitleModel,
 } from './model';
 import { AsbPlayerToVideoCommandV2 } from './command';
 import {
@@ -415,7 +415,7 @@ export interface SubtitlesToVideoMessage extends Message {
 
 export interface SubtitlesUpdatedToVideoMessage extends Message {
     readonly command: 'subtitlesUpdated';
-    readonly subtitles: RichSubtitleModel[];
+    readonly subtitles: IndexedSubtitleModel[];
 }
 
 export interface RequestCurrentSubtitleMessage extends Message {
@@ -428,7 +428,7 @@ export interface RequestSubtitlesMessage extends Message {
 
 export interface SubtitlesUpdatedFromVideoMessage extends Message {
     readonly command: 'subtitlesUpdated';
-    readonly updatedSubtitles: RichSubtitleModel[];
+    readonly updatedSubtitles: IndexedSubtitleModel[];
 }
 
 export interface RequestSubtitlesFromAppMessage extends MessageWithId {
@@ -747,7 +747,7 @@ export interface AckMessage extends MessageWithId {
 }
 
 export interface RequestSubtitlesResponse {
-    subtitles: RichSubtitleModel[];
+    subtitles: IndexedSubtitleModel[];
     subtitleFileNames: string[];
 }
 

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -55,20 +55,13 @@ export interface SubtitleModel {
     readonly track: number;
     readonly index?: number;
     readonly tokenization?: Tokenization;
-    readonly richText?: string;
-    readonly richTextOnHover?: string;
 }
 
 export interface IndexedSubtitleModel extends SubtitleModel {
     readonly index: number;
 }
 
-export interface RichSubtitleModel extends IndexedSubtitleModel {
-    richText?: string;
-    richTextOnHover?: string;
-}
-
-export interface TokenizedSubtitleModel extends RichSubtitleModel {
+export interface TokenizedSubtitleModel extends IndexedSubtitleModel {
     originalText?: string;
     tokenization?: Tokenization;
 }

--- a/common/src/offscreen-dom-cache.ts
+++ b/common/src/offscreen-dom-cache.ts
@@ -16,6 +16,14 @@ export default class OffscreenDomCache {
         this._empty = true;
     }
 
+    has(key: string) {
+        return this._cachedContentElements[key] !== undefined;
+    }
+
+    keys() {
+        return Object.keys(this._cachedContentElements);
+    }
+
     add(key: string, html: string) {
         let cached = this._cachedContentElements[key];
         if (!cached) {

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -1962,6 +1962,9 @@ export const getAnnotationsForRender = (dt: DictionaryTrack, target: TokenAnnota
     };
 };
 
+export const ANNOTATIONS_VIDEO_RENDER_BEHIND_MS = 15000; // Seeking backwards is usually 5-10s
+export const ANNOTATIONS_VIDEO_RENDER_AHEAD_MS = 60000; // Seeking forward is usually 5-30s
+
 export const renderRichTextOntoSubtitles = (
     subtitles: RichSubtitleModel[],
     tokenAnnotationTarget: TokenAnnotationConfigTarget,

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -84,7 +84,6 @@ const ASB_TOKEN_CLASS = 'asb-token';
 const ASB_TOKEN_HIGHLIGHT_CLASS = 'asb-token-highlight';
 const ASB_READING_CLASS = 'asb-reading';
 const ASB_FREQUENCY_CLASS = 'asb-frequency';
-// const ASB_FREQUENCY_HOVER_CLASS = 'asb-frequency-hover';
 const ASB_PITCH_ACCENT_CLASS = 'asb-pitch-accent';
 const ASB_PITCH_ACCENT_MORA_CLASS = 'asb-pitch-accent-mora';
 const ASB_PITCH_ACCENT_MORA_HIGH_CLASS = 'asb-pitch-accent-mora-high';
@@ -644,12 +643,11 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                 );
             });
         if (!needsReset) {
-            // Preserve existing cache here so callers don't need to be aware of it
+            // Preserve the existing tokenization cache here so callers don't need to be aware of it.
+            // Don't update richText or richTextOnHover as they are derived per render target and not cached internally.
             for (const s of subtitles) {
                 (s as InternalSubtitleModel).text = this._subtitles[s.index].text;
                 s.tokenization = this._subtitles[s.index].tokenization;
-                s.richText = this._subtitles[s.index].richText;
-                s.richTextOnHover = this._subtitles[s.index].richTextOnHover;
                 (s as InternalSubtitleModel).__tokenized = this._subtitles[s.index].__tokenized;
             }
         }

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -645,7 +645,6 @@ export class SubtitleAnnotations extends SubtitleCollection<IndexedSubtitleModel
             });
         if (!needsReset) {
             // Preserve the existing tokenization cache here so callers don't need to be aware of it.
-            // Don't update richText or richTextOnHover as they are derived per render target and not cached internally.
             for (const s of subtitles) {
                 (s as InternalSubtitleModel).text = this._subtitles[s.index].text;
                 s.tokenization = this._subtitles[s.index].tokenization;
@@ -1967,7 +1966,7 @@ export interface RenderedRichText {
     richTextOnHover?: string;
 }
 
-export interface CachedRenderedRichText extends RenderedRichText {
+interface CachedRenderedRichText extends RenderedRichText {
     text: string;
     tokenization?: Tokenization;
     tokenAnnotationTarget: TokenAnnotationConfigTarget;
@@ -1981,9 +1980,9 @@ const cachedRichTextIsCurrent = (
     dictionaryTracks: DictionaryTrack[] | undefined
 ) =>
     cached.text === subtitle.text &&
-    cached.tokenization === subtitle.tokenization &&
+    areTokenizationsEqual(cached.tokenization, subtitle.tokenization) &&
     cached.tokenAnnotationTarget === tokenAnnotationTarget &&
-    cached.dictionaryTracks === dictionaryTracks;
+    cached.dictionaryTracks?.every((dt, i) => areDictionaryTracksEqual(dt, dictionaryTracks?.[i]));
 
 interface IndexRange {
     min: number;
@@ -2052,11 +2051,9 @@ export const renderRichTextWindow = (
     tokenAnnotationTarget: TokenAnnotationConfigTarget,
     dictionaryTracks: DictionaryTrack[] | undefined
 ): RichTextWindow => {
-    if (!windowSubtitles.length) return { range: undefined, buffer: new Map() };
-    const range: IndexRange = {
-        min: Math.min(...windowSubtitles.map((s) => s.index)),
-        max: Math.max(...windowSubtitles.map((s) => s.index)),
-    };
+    if (!windowSubtitles.length) return emptyRichTextWindow();
+    const windowSubtitleIndexes = windowSubtitles.map((s) => s.index);
+    const range: IndexRange = { min: Math.min(...windowSubtitleIndexes), max: Math.max(...windowSubtitleIndexes) };
     const buffer = new Map<number, CachedRenderedRichText>();
 
     const toRender: RichTextRenderable[] = [];

--- a/common/subtitle-annotations/subtitle-annotations.ts
+++ b/common/subtitle-annotations/subtitle-annotations.ts
@@ -8,7 +8,7 @@ import {
     DictionaryBuildWaniKaniCacheStateErrorCode,
     DictionaryBuildWaniKaniCacheStateType,
     Fetcher,
-    RichSubtitleModel,
+    IndexedSubtitleModel,
     Token,
     Tokenization,
     TokenizedSubtitleModel,
@@ -483,8 +483,6 @@ interface InternalSubtitleModel extends TokenizedSubtitleModel {
 
 function untokenize(s: InternalSubtitleModel) {
     s.__tokenized = undefined;
-    s.richText = undefined;
-    s.richTextOnHover = undefined;
     if (s.tokenization) {
         s.tokenization.tokens = s.tokenization.tokens.filter((t) => !(t as InternalToken).__internal);
         if (s.tokenization.tokens.length) {
@@ -512,7 +510,7 @@ function originalTokenization(tokenization: Tokenization | undefined): Tokenizat
     };
 }
 
-export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
+export class SubtitleAnnotations extends SubtitleCollection<IndexedSubtitleModel> {
     private _subtitles: InternalSubtitleModel[];
     private totalSubtitlesPerTrack: Map<number, number>;
     private readonly dictionaryProvider: DictionaryProvider;
@@ -523,7 +521,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
     private generateStatistics?: boolean; // A manual trigger will keep this a true for the remainder of this class's lifetime, unless auto is toggled off.
     private generateStatisticsRequested: boolean; // Prevent premature cancellation during statistics generation
     private subtitlesInterval?: ReturnType<typeof setInterval>;
-    private showingSubtitles?: RichSubtitleModel[];
+    private showingSubtitles?: IndexedSubtitleModel[];
     private showingNeedsRefreshCount: number;
     private buildLowerThreshold: number;
     private buildUpperThreshold: number;
@@ -560,7 +558,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
     private shouldCancelBuild: boolean; // Set to true to stop current build, checked after each async calls
     private tokenRequestFailedForTracks: Set<number>;
 
-    private readonly subtitleAnnotationsUpdated: (updatedSubtitles: RichSubtitleModel[], dt: DictionaryTrack[]) => void;
+    private readonly subtitleAnnotationsUpdated: (
+        updatedSubtitles: IndexedSubtitleModel[],
+        dt: DictionaryTrack[]
+    ) => void;
     private readonly getMediaTimeMs?: () => number;
 
     private removeBuildAnkiCacheStateChangeCB?: () => void;
@@ -574,7 +575,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         settingsProvider: SettingsProvider,
         options: SubtitleCollectionOptions,
         mediaId: string,
-        subtitleAnnotationsUpdated: (updatedSubtitles: RichSubtitleModel[], dt: DictionaryTrack[]) => void,
+        subtitleAnnotationsUpdated: (updatedSubtitles: IndexedSubtitleModel[], dt: DictionaryTrack[]) => void,
         getMediaTimeMs?: () => number,
         fetcher?: Fetcher
     ) {
@@ -1126,7 +1127,7 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         }, 100);
     }
 
-    private _getAnnotationsIndexes(init?: boolean, subtitles?: RichSubtitleModel[]) {
+    private _getAnnotationsIndexes(init?: boolean, subtitles?: IndexedSubtitleModel[]) {
         if (!subtitles?.length) {
             if (this.getMediaTimeMs) {
                 const slice = this.subtitlesAt(this.getMediaTimeMs());
@@ -1288,13 +1289,11 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                                     return;
                                 }
                                 builtNewTokenization = true;
-                                const updatedSubtitles: RichSubtitleModel[] = [];
+                                const updatedSubtitles: IndexedSubtitleModel[] = [];
                                 if (tokenizationModel) {
                                     const { tokenization, reconstructedText } = tokenizationModel;
                                     const subtitle = this.subtitles[index];
                                     subtitle.tokenization = tokenization;
-                                    subtitle.richText = undefined;
-                                    subtitle.richTextOnHover = undefined;
                                     if (subtitle.originalText === undefined) subtitle.originalText = subtitle.text;
                                     subtitle.text = reconstructedText;
                                     subtitle.__tokenized = true;
@@ -1302,11 +1301,6 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
                                     this._recordTokenOccurrences(index, reconstructedText, tokenization, ts);
                                     if (generatingStatistics) {
                                         const sentence = { ...subtitle };
-                                        renderRichTextOntoSubtitles(
-                                            [sentence],
-                                            'subtitlePlayer',
-                                            this.trackStates.map((ts) => ts.dt)
-                                        );
                                         this.dictionaryStatistics.ingest(sentence); // Treat the entire source entry as a single sentence
                                         if (
                                             sentence.tokenization!.tokens.every(
@@ -1420,7 +1414,10 @@ export class SubtitleAnnotations extends SubtitleCollection<RichSubtitleModel> {
         }
     }
 
-    private async _buildTokenAndLemmaMap(profile: string | undefined, subtitles: RichSubtitleModel[]): Promise<void> {
+    private async _buildTokenAndLemmaMap(
+        profile: string | undefined,
+        subtitles: IndexedSubtitleModel[]
+    ): Promise<void> {
         const eventsPerTrack = new Map<number, string[]>();
         for (const subtitle of subtitles) {
             const eventsForTrack = eventsPerTrack.get(subtitle.track);
@@ -1965,34 +1962,67 @@ export const getAnnotationsForRender = (dt: DictionaryTrack, target: TokenAnnota
 export const ANNOTATIONS_VIDEO_RENDER_BEHIND_MS = 15000; // Seeking backwards is usually 5-10s
 export const ANNOTATIONS_VIDEO_RENDER_AHEAD_MS = 60000; // Seeking forward is usually 5-30s
 
-export const renderRichTextOntoSubtitles = (
-    subtitles: RichSubtitleModel[],
+export interface RenderedRichText {
+    richText?: string;
+    richTextOnHover?: string;
+}
+
+export interface CachedRenderedRichText extends RenderedRichText {
+    text: string;
+    tokenization?: Tokenization;
+    tokenAnnotationTarget: TokenAnnotationConfigTarget;
+    dictionaryTracks?: DictionaryTrack[];
+}
+
+const cachedRichTextIsCurrent = (
+    cached: CachedRenderedRichText,
+    subtitle: RichTextRenderable,
     tokenAnnotationTarget: TokenAnnotationConfigTarget,
     dictionaryTracks: DictionaryTrack[] | undefined
-) => {
-    if (dictionaryTracks?.length !== defaultSettings.dictionaryTracks.length) {
-        for (const s of subtitles) {
-            s.richText = undefined;
-            s.richTextOnHover = undefined;
-        }
-        return;
-    }
+) =>
+    cached.text === subtitle.text &&
+    cached.tokenization === subtitle.tokenization &&
+    cached.tokenAnnotationTarget === tokenAnnotationTarget &&
+    cached.dictionaryTracks === dictionaryTracks;
+
+interface IndexRange {
+    min: number;
+    max: number;
+}
+
+export interface RichTextWindow {
+    range?: IndexRange;
+    buffer: Map<number, CachedRenderedRichText>;
+}
+
+export const emptyRichTextWindow = (): RichTextWindow => ({ buffer: new Map() });
+
+interface RichTextRenderable {
+    index: number;
+    text: string;
+    track: number;
+    tokenization?: Tokenization;
+}
+
+export const renderRichTextOntoSubtitles = (
+    subtitles: RichTextRenderable[],
+    tokenAnnotationTarget: TokenAnnotationConfigTarget,
+    dictionaryTracks: DictionaryTrack[] | undefined
+): Map<number, RenderedRichText> => {
+    const rendered = new Map<number, RenderedRichText>();
+    if (dictionaryTracks?.length !== defaultSettings.dictionaryTracks.length) return rendered;
 
     const trackAnnotations = dictionaryTracks.map((dt) => getAnnotationsForRender(dt, tokenAnnotationTarget));
     const allowAsciiReading = false; // Allowing is only for preview purposes for status names to show reading
 
     for (const subtitle of subtitles) {
-        if (!subtitle.tokenization) {
-            subtitle.richText = undefined;
-            subtitle.richTextOnHover = undefined;
-            continue;
-        }
+        if (!subtitle.tokenization) continue;
         const ta = trackAnnotations[subtitle.track];
         const hasExternalReading = subtitle.tokenization.tokens.some(
             (token) => !(token as InternalToken).__internal && token.readings.length > 0
         ); // Display external readings even if no annotations are enabled, unnecessary for richTextOnHover
 
-        subtitle.richText =
+        const richText =
             ta.isRichTextEnabled || hasExternalReading
                 ? computeRichText(subtitle.text, subtitle.tokenization, {
                       dt: ta.dt,
@@ -2000,14 +2030,83 @@ export const renderRichTextOntoSubtitles = (
                       allowAsciiReading,
                   })
                 : undefined;
-        subtitle.richTextOnHover = ta.isRichTextOnHoverEnabled
+        const richTextOnHover = ta.isRichTextOnHoverEnabled
             ? computeRichText(subtitle.text, subtitle.tokenization, {
                   dt: ta.dt,
                   enabledAnnotations: ta.richTextOnHoverEnabledAnnotations,
                   allowAsciiReading,
               })
             : undefined;
+
+        if (richText !== undefined || richTextOnHover !== undefined) {
+            rendered.set(subtitle.index, { richText, richTextOnHover });
+        }
     }
+
+    return rendered;
+};
+
+export const renderRichTextWindow = (
+    prev: RichTextWindow,
+    windowSubtitles: RichTextRenderable[],
+    tokenAnnotationTarget: TokenAnnotationConfigTarget,
+    dictionaryTracks: DictionaryTrack[] | undefined
+): RichTextWindow => {
+    if (!windowSubtitles.length) return { range: undefined, buffer: new Map() };
+    const range: IndexRange = {
+        min: Math.min(...windowSubtitles.map((s) => s.index)),
+        max: Math.max(...windowSubtitles.map((s) => s.index)),
+    };
+    const buffer = new Map<number, CachedRenderedRichText>();
+
+    const toRender: RichTextRenderable[] = [];
+    for (const subtitle of windowSubtitles) {
+        if (prev.range && subtitle.index >= prev.range.min && subtitle.index <= prev.range.max) {
+            const reused = prev.buffer.get(subtitle.index);
+            if (reused && cachedRichTextIsCurrent(reused, subtitle, tokenAnnotationTarget, dictionaryTracks)) {
+                buffer.set(subtitle.index, reused);
+                continue;
+            }
+        }
+        toRender.push(subtitle);
+    }
+    if (toRender.length) {
+        const rendered = renderRichTextOntoSubtitles(toRender, tokenAnnotationTarget, dictionaryTracks);
+        for (const subtitle of toRender) {
+            const value = rendered.get(subtitle.index);
+            buffer.set(subtitle.index, {
+                ...value,
+                text: subtitle.text,
+                tokenization: subtitle.tokenization,
+                tokenAnnotationTarget,
+                dictionaryTracks,
+            });
+        }
+    }
+
+    return { range, buffer };
+};
+
+export const renderRichTextForSubtitle = (
+    window: RichTextWindow,
+    subtitle: RichTextRenderable,
+    tokenAnnotationTarget: TokenAnnotationConfigTarget,
+    dictionaryTracks: DictionaryTrack[] | undefined
+): RenderedRichText | undefined => {
+    const cached = window.buffer.get(subtitle.index);
+    if (cached && cachedRichTextIsCurrent(cached, subtitle, tokenAnnotationTarget, dictionaryTracks)) return cached;
+
+    const rendered = renderRichTextOntoSubtitles([subtitle], tokenAnnotationTarget, dictionaryTracks).get(
+        subtitle.index
+    );
+    window.buffer.set(subtitle.index, {
+        ...rendered,
+        text: subtitle.text,
+        tokenization: subtitle.tokenization,
+        tokenAnnotationTarget,
+        dictionaryTracks,
+    });
+    return rendered;
 };
 
 interface TokenStyleState {

--- a/common/subtitle-collection/subtitle-collection.ts
+++ b/common/subtitle-collection/subtitle-collection.ts
@@ -102,4 +102,8 @@ export class SubtitleCollection<T extends SubtitleModel> {
 
         return { showing, lastShown, nextToShow, startedShowing, willStopShowing };
     }
+
+    subtitlesIn(startTimestamp: number, endTimestamp: number): T[] {
+        return this.tree.search([startTimestamp, endTimestamp]) as T[];
+    }
 }

--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -226,8 +226,6 @@ export function mockSurroundingSubtitles(
             originalEnd: afterTimestamp - offset,
             track: middleSubtitle.track,
             index: middleSubtitle.index,
-            richText: middleSubtitle.richText,
-            richTextOnHover: middleSubtitle.richTextOnHover,
         });
     }
 
@@ -241,8 +239,6 @@ export function mockSurroundingSubtitles(
             originalEnd: middleSubtitle.start - offset,
             track: middleSubtitle.track,
             index: middleSubtitle.index,
-            richText: middleSubtitle.richText,
-            richTextOnHover: middleSubtitle.richTextOnHover,
         });
     }
 

--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -523,6 +523,27 @@ export function normalizeForSearch(text: string): string {
         .normalize('NFC');
 }
 
+export function normalizeSearchText(text: string): string {
+    return text.normalize('NFKC').trim().toLocaleLowerCase();
+}
+
+export function normalizedLookupTerms(...texts: Array<string | null | undefined>): string[] {
+    return Array.from(
+        new Set(
+            texts
+                .flatMap((text) => {
+                    if (!text) return [];
+                    const normalized = normalizeForSearch(text);
+                    if (!normalized.length || normalized === text) return [text];
+                    return [text, normalized];
+                })
+                .filter((text) => Boolean(text))
+                .map(normalizeSearchText)
+                .filter((text) => text.length)
+        )
+    );
+}
+
 // https://stackoverflow.com/questions/63116039/camelcase-to-kebab-case
 function kebabize(str: string) {
     const kebabized = str.replace(/[A-Z]+(?![a-z])|[A-Z]/g, ($, ofs) => (ofs ? '-' : '') + $.toLowerCase());

--- a/common/yomitan/yomitan.ts
+++ b/common/yomitan/yomitan.ts
@@ -371,7 +371,7 @@ export class Yomitan {
 
     private cacheFromTokenize(
         tokenizeResult: TokenizeResult,
-        tokensForText: TokenPartResult[][],
+        tokensForText: TokenPart[][],
         newlines: { text: string; index: number }[]
     ): void {
         let currIndex = 0;
@@ -387,7 +387,7 @@ export class Yomitan {
                 tokensForText.push([{ text, reading: '' }]);
                 currIndex += text.length;
             }
-            tokensForText.push(tokenParts);
+            tokensForText.push(tokenParts.map((p) => ({ text: p.text, reading: p.reading })));
             const token = tokenText.trim();
 
             if (!this.lemmatizeCache.has(token)) this.extractLemmaFromMecab(token, tokenPart);

--- a/extension/src/controllers/subtitle-controller.ts
+++ b/extension/src/controllers/subtitle-controller.ts
@@ -9,7 +9,6 @@ import {
     Fetcher,
     HttpPostMessage,
     IndexedSubtitleModel,
-    RichSubtitleModel,
 } from '@project/common';
 import {
     AutoCopyableTracks,
@@ -221,7 +220,7 @@ export default class SubtitleController {
         }
     }
 
-    private _windowSubtitles(): RichSubtitleModel[] {
+    private _windowSubtitles(): IndexedSubtitleModel[] {
         const now = this.context.video.currentTime * 1000;
         const windowSubtitles = this.subtitleAnnotations.subtitlesIn(
             now - ANNOTATIONS_VIDEO_RENDER_BEHIND_MS,
@@ -236,30 +235,27 @@ export default class SubtitleController {
     }
 
     private _refreshCachedHtmlWindow() {
-        const windowSubtitles = this._windowSubtitles();
-        const keep = new Set(windowSubtitles.map((s) => String(s.index)));
-        const overlays = [
-            { overlay: this.bottomSubtitlesElementOverlay, shouldRender: this.shouldRenderBottomOverlay },
-            { overlay: this.topSubtitlesElementOverlay, shouldRender: this.shouldRenderTopOverlay },
-        ];
+        const bottomWindowSubtitles: IndexedSubtitleModel[] = [];
+        const topWindowSubtitles: IndexedSubtitleModel[] = [];
+        for (const subtitle of this._windowSubtitles()) {
+            if (this._getSubtitleTrackAlignment(subtitle.track) === 'bottom') bottomWindowSubtitles.push(subtitle);
+            else topWindowSubtitles.push(subtitle);
+        }
 
-        let needsRender = false;
-        for (const { overlay } of overlays) {
-            if (!(overlay instanceof CachingElementOverlay)) continue;
+        const updateOverlay = (subtitles: IndexedSubtitleModel[], overlay: ElementOverlay, shouldRender: boolean) => {
+            if (!(overlay instanceof CachingElementOverlay)) return;
+            const keep = new Set(subtitles.map((s) => String(s.index)));
             for (const key of overlay.cachedHtmlKeys()) {
                 if (!keep.has(key)) overlay.removeCachedHtml(key);
             }
-            if (windowSubtitles.some((s) => !overlay.hasCachedHtml(String(s.index)))) needsRender = true;
-        }
-        if (!needsRender) return;
+            if (!shouldRender) return;
+            const uncachedSubtitles = subtitles.filter((s) => !overlay.hasCachedHtml(String(s.index)));
+            const htmls = this._buildSubtitlesHtml(uncachedSubtitles);
+            for (const html of htmls) overlay.cacheHtml(html.key, html.html());
+        };
 
-        const htmls = this._buildSubtitlesHtml(windowSubtitles);
-        for (const { overlay, shouldRender } of overlays) {
-            if (!shouldRender || !(overlay instanceof CachingElementOverlay)) continue;
-            for (const html of htmls) {
-                if (!overlay.hasCachedHtml(html.key)) overlay.cacheHtml(html.key, html.html());
-            }
-        }
+        updateOverlay(bottomWindowSubtitles, this.bottomSubtitlesElementOverlay, this.shouldRenderBottomOverlay);
+        updateOverlay(topWindowSubtitles, this.topSubtitlesElementOverlay, this.shouldRenderTopOverlay);
     }
 
     get bottomSubtitlePositionOffset(): number {
@@ -421,7 +417,7 @@ export default class SubtitleController {
         return { subtitleOverlayParams, topSubtitleOverlayParams, notificationOverlayParams };
     }
 
-    private _subtitleAnnotationsUpdated(updatedSubtitles: RichSubtitleModel[]): void {
+    private _subtitleAnnotationsUpdated(updatedSubtitles: IndexedSubtitleModel[]): void {
         const updatedIndexes = new Set(updatedSubtitles.map((s) => s.index));
         const updatedWindowSubtitles = this._windowSubtitles().filter((s) => updatedIndexes.has(s.index));
         if (updatedWindowSubtitles.length) {
@@ -599,9 +595,10 @@ export default class SubtitleController {
     }
 
     private _buildSubtitlesHtml(subtitles: IndexedSubtitleModel[]) {
-        if (this.dictionaryTrackSettings) renderRichTextOntoSubtitles(subtitles, 'video', this.dictionaryTrackSettings);
+        const buffer = renderRichTextOntoSubtitles(subtitles, 'video', this.dictionaryTrackSettings);
 
         return subtitles.map((subtitle) => {
+            const rendered = buffer.get(subtitle.index);
             return {
                 html: () => {
                     if (subtitle.textImage) {
@@ -627,8 +624,8 @@ export default class SubtitleController {
                         return this._buildTextHtml(
                             subtitle.text,
                             subtitle.track,
-                            subtitle.richText,
-                            subtitle.richTextOnHover
+                            rendered?.richText,
+                            rendered?.richTextOnHover
                         );
                     }
                 },

--- a/extension/src/controllers/subtitle-controller.ts
+++ b/extension/src/controllers/subtitle-controller.ts
@@ -31,6 +31,8 @@ import {
     renderRichTextOntoSubtitles,
     getAnnotationsHtml,
     SubtitleAnnotations,
+    ANNOTATIONS_VIDEO_RENDER_BEHIND_MS,
+    ANNOTATIONS_VIDEO_RENDER_AHEAD_MS,
 } from '@project/common/subtitle-annotations';
 import { arrayEquals, computeStyleString, surroundingSubtitles } from '@project/common/util';
 import i18n from 'i18next';
@@ -203,7 +205,7 @@ export default class SubtitleController {
     }
 
     cacheHtml() {
-        const htmls = this._buildSubtitlesHtml(this.subtitles);
+        const htmls = this._buildSubtitlesHtml(this._windowSubtitles());
 
         if (this.shouldRenderBottomOverlay && this.bottomSubtitlesElementOverlay instanceof CachingElementOverlay) {
             this.bottomSubtitlesElementOverlay.uncacheHtml();
@@ -215,6 +217,47 @@ export default class SubtitleController {
             this.topSubtitlesElementOverlay.uncacheHtml();
             for (const html of htmls) {
                 this.topSubtitlesElementOverlay.cacheHtml(html.key, html.html());
+            }
+        }
+    }
+
+    private _windowSubtitles(): RichSubtitleModel[] {
+        const now = this.context.video.currentTime * 1000;
+        const windowSubtitles = this.subtitleAnnotations.subtitlesIn(
+            now - ANNOTATIONS_VIDEO_RENDER_BEHIND_MS,
+            now + ANNOTATIONS_VIDEO_RENDER_AHEAD_MS
+        );
+        if (!windowSubtitles.length) {
+            const { lastShown, nextToShow } = this.subtitleAnnotations.subtitlesAt(now);
+            for (const subtitle of lastShown ?? []) windowSubtitles.push(subtitle);
+            for (const subtitle of nextToShow ?? []) windowSubtitles.push(subtitle);
+        }
+        return windowSubtitles;
+    }
+
+    private _refreshCachedHtmlWindow() {
+        const windowSubtitles = this._windowSubtitles();
+        const keep = new Set(windowSubtitles.map((s) => String(s.index)));
+        const overlays = [
+            { overlay: this.bottomSubtitlesElementOverlay, shouldRender: this.shouldRenderBottomOverlay },
+            { overlay: this.topSubtitlesElementOverlay, shouldRender: this.shouldRenderTopOverlay },
+        ];
+
+        let needsRender = false;
+        for (const { overlay } of overlays) {
+            if (!(overlay instanceof CachingElementOverlay)) continue;
+            for (const key of overlay.cachedHtmlKeys()) {
+                if (!keep.has(key)) overlay.removeCachedHtml(key);
+            }
+            if (windowSubtitles.some((s) => !overlay.hasCachedHtml(String(s.index)))) needsRender = true;
+        }
+        if (!needsRender) return;
+
+        const htmls = this._buildSubtitlesHtml(windowSubtitles);
+        for (const { overlay, shouldRender } of overlays) {
+            if (!shouldRender || !(overlay instanceof CachingElementOverlay)) continue;
+            for (const html of htmls) {
+                if (!overlay.hasCachedHtml(html.key)) overlay.cacheHtml(html.key, html.html());
             }
         }
     }
@@ -379,23 +422,30 @@ export default class SubtitleController {
     }
 
     private _subtitleAnnotationsUpdated(updatedSubtitles: RichSubtitleModel[]): void {
-        const htmls = this._buildSubtitlesHtml(updatedSubtitles);
-        for (const [index, updatedSubtitle] of updatedSubtitles.entries()) {
-            const html = htmls[index];
-            if (this._getSubtitleTrackAlignment(updatedSubtitle.track) === 'bottom') {
-                if (
-                    this.shouldRenderBottomOverlay &&
-                    this.bottomSubtitlesElementOverlay instanceof CachingElementOverlay
-                ) {
-                    this.bottomSubtitlesElementOverlay.cacheHtml(html.key, html.html());
+        const updatedIndexes = new Set(updatedSubtitles.map((s) => s.index));
+        const updatedWindowSubtitles = this._windowSubtitles().filter((s) => updatedIndexes.has(s.index));
+        if (updatedWindowSubtitles.length) {
+            const htmls = this._buildSubtitlesHtml(updatedWindowSubtitles);
+            for (const [index, updatedWindowSubtitle] of updatedWindowSubtitles.entries()) {
+                const html = htmls[index];
+                if (this._getSubtitleTrackAlignment(updatedWindowSubtitle.track) === 'bottom') {
+                    if (
+                        this.shouldRenderBottomOverlay &&
+                        this.bottomSubtitlesElementOverlay instanceof CachingElementOverlay
+                    ) {
+                        this.bottomSubtitlesElementOverlay.cacheHtml(html.key, html.html());
+                    }
+                } else {
+                    if (
+                        this.shouldRenderTopOverlay &&
+                        this.topSubtitlesElementOverlay instanceof CachingElementOverlay
+                    ) {
+                        this.topSubtitlesElementOverlay.cacheHtml(html.key, html.html());
+                    }
                 }
-            } else {
-                if (this.shouldRenderTopOverlay && this.topSubtitlesElementOverlay instanceof CachingElementOverlay) {
-                    this.topSubtitlesElementOverlay.cacheHtml(html.key, html.html());
+                if (this.showingSubtitles?.some((s) => s.index === updatedWindowSubtitle.index)) {
+                    this.refreshCurrentSubtitle = true;
                 }
-            }
-            if (this.showingSubtitles?.some((s) => s.index === updatedSubtitle.index)) {
-                this.refreshCurrentSubtitle = true;
             }
         }
         const command: VideoToExtensionCommand<SubtitlesUpdatedFromVideoMessage> = {
@@ -455,6 +505,7 @@ export default class SubtitleController {
             if (subtitlesAreNew) {
                 this.showingSubtitles = showingSubtitles;
                 this._autoCopyToClipboard(showingSubtitles);
+                this._refreshCachedHtmlWindow();
             }
 
             const shouldRenderOffset =

--- a/extension/src/entrypoints/video.content/video.css
+++ b/extension/src/entrypoints/video.content/video.css
@@ -176,20 +176,6 @@
     line-height: 1;
 }
 
-.asb-frequency-hover {
-    ruby-position: under;
-}
-
-.asb-frequency-hover rt {
-    font-size: var(--asb-frequency-size);
-    line-height: 1;
-    display: none;
-}
-
-.asb-frequency-hover:hover rt {
-    display: revert; /* Safari doesn't support 'ruby-text' */
-}
-
 .asbplayer-ui-frame {
     position: fixed !important;
     top: 0 !important;

--- a/extension/src/services/element-overlay.ts
+++ b/extension/src/services/element-overlay.ts
@@ -135,6 +135,18 @@ export class CachingElementOverlay implements ElementOverlay {
         this.domCache.add(key, html);
     }
 
+    hasCachedHtml(key: string) {
+        return this.domCache.has(key);
+    }
+
+    removeCachedHtml(key: string) {
+        this.domCache.delete(key);
+    }
+
+    cachedHtmlKeys() {
+        return this.domCache.keys();
+    }
+
     setHtml(htmls: KeyedHtml[]) {
         if (document.fullscreenElement) {
             this._displayFullscreenContentElementsWithHtml(htmls);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3561,6 +3561,7 @@ __metadata:
     jsonschema: ^1.5.0
     lamejs: 1.2.0
     pgs-parser: 0.1.0
+    react-virtuoso: ^4.18.7
     sanitize-filename: ^1.6.3
     semver: ^7.3.7
     ts-jest: ^29.2.5
@@ -12788,6 +12789,16 @@ __metadata:
     react: ">=16.6.0"
     react-dom: ">=16.6.0"
   checksum: 75602840106aa9c6545149d6d7ae1502fb7b7abadcce70a6954c4b64a438ff1cd16fc77a0a1e5197cdd72da398f39eb929ea06f9005c45b132ed34e056ebdeb1
+  languageName: node
+  linkType: hard
+
+"react-virtuoso@npm:^4.18.7":
+  version: 4.18.7
+  resolution: "react-virtuoso@npm:4.18.7"
+  peerDependencies:
+    react: ">=16 || >=17 || >= 18 || >= 19"
+    react-dom: ">=16 || >=17 || >= 18 || >=19"
+  checksum: 7f6b74bb232a026ad7f5a3d630bfb4fbab7e140394e31c51bbb8dc1b68ac8a8991c334f1242a2c6177611e37c818bd20b754bf2dc8336974e469a476b04c5f44
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Rather than trying to fight with sub-optimal solutions, I instead just went for virtualization with `react-virtuoso` for `SubtitlePlayer` and `StatisticsSentenceDetailsDialog`. This gives the biggest upflift in all areas and is easier to manage, it also guards against any potential complication in the future. There are a few things that broke due to virtualization that I had to address but there may be more subtle ones.

Since the rows are now virtualized, I added an override for the browsers `CTRL+F` to allow the expected behavior of searching the entire subtitle.
- We will search the `text` and `reading` (considered `frequency` as well but opted not to) on each subtitle with the same normalization helpers found in `WordBrowser` (romaji, lemma, etc). It's not fully permissive like `ANY_FORM_COLLECTED`, for that we would need to store the lemmas that `SubtitleAnnotations` queried from yomitan to lookup against, but I don't think it's worth doing right now.
- I added support for regex searching using `/regex/`.
- As a bonus, users can now search the subtitles when they are loaded in the side panel (still uses the browsers native search if side panel is not focused).

I also made a change in the hover behavior so that its triggered when hovering over the the subtitle row rather than the subtitles themselves. This makes it more stable as the change in annotations can move the pointer off the subtitles causing a flicker between hover and non-hover especially between spaces and multiple lines. I've previously made this change for video subtitles.

I added a smaller buffer for the video annotations as well. Even though these aren't as problematic, it should help with the memory usage as well with no real downside.

Finally, I made the rich text rendering fully JIT. I got rid of `richText` and `richTextOnHover` from the subtitle objects since we are always rendering it only when we need it and it gets destroyed once it's outside the virtualized view for the subtitle list or time range for video subtitles.

Profiling with all these changes shows there is no more long term memory we can clear up. The browser task manager may still show usage up to `1GGB` for large subtitles temporarily but in reality it's not that high. Real memory usage is around the `100MB` mark.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Copilot:Opus-4.8