### PR TITLE
feat: add subtitle sync to a reference

### DIFF
--- a/common/app/components/Controls.tsx
+++ b/common/app/components/Controls.tsx
@@ -37,6 +37,7 @@ import { SubtitleAlignment } from '@project/common/settings';
 import Clock from '../services/clock';
 import PlaybackPreferences from '../services/playback-preferences';
 import Tooltip from '../../components/Tooltip';
+import SubtitleSyncButton, { SubtitleSyncData } from './SubtitleSyncButton';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -578,6 +579,7 @@ interface ControlsProps {
     subtitleAlignmentEnabled?: boolean;
     subtitleAlignment?: SubtitleAlignment;
     onSubtitleAlignment?: (alignment: SubtitleAlignment) => void;
+    subtitleSync?: SubtitleSyncData;
     hideToolbar?: boolean;
     onLoadFiles?: () => void;
     blurOverlayEnabled?: boolean;
@@ -637,6 +639,7 @@ export default function Controls({
     subtitleAlignment,
     subtitleAlignmentEnabled,
     onSubtitleAlignment,
+    subtitleSync,
     hideToolbar,
     onLoadFiles,
     blurOverlayEnabled,
@@ -1064,6 +1067,13 @@ export default function Controls({
                                 )}
                                 <Grid item style={{ flexGrow: 1 }}></Grid>
                                 <ResponsiveButtonGroup>
+                                    {subtitleSync && (
+                                        <SubtitleSyncButton
+                                            {...subtitleSync}
+                                            color="inherit"
+                                            className={classes.button}
+                                        />
+                                    )}
                                     {subtitleAlignmentEnabled && subtitleAlignment !== undefined && (
                                         <Tooltip title={t('controls.subtitleAlignment')!}>
                                             <IconButton color="inherit" onClick={handleSubtitleAlignment}>

--- a/common/app/components/Player.tsx
+++ b/common/app/components/Player.tsx
@@ -1453,6 +1453,12 @@ const Player = React.memo(function Player({
                             onUnloadVideo={() => videoFileUrl && onUnloadVideo(videoFileUrl)}
                             onOffsetChange={handleOffsetChange}
                             onPlayMode={handlePlayMode}
+                            subtitleSync={{
+                                subtitles: subtitles ?? [],
+                                subtitleFileNames: subtitleFiles?.map((f) => f.name) ?? [],
+                                subtitleReader,
+                                onApplyOffset: handleOffsetChange,
+                            }}
                             disableKeyEvents={disableKeyEvents}
                             playbackPreferences={playbackPreferences}
                             showOnMouseMovement={true}

--- a/common/app/components/SubtitleSyncButton.tsx
+++ b/common/app/components/SubtitleSyncButton.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import IconButton, { IconButtonProps } from '@mui/material/IconButton';
+import SyncAltIcon from '@mui/icons-material/SyncAlt';
+import Tooltip from '../../components/Tooltip';
+import { SubtitleModel } from '@project/common';
+import { SubtitleReader } from '@project/common/subtitle-reader';
+import SubtitleSyncDialog from './SubtitleSyncDialog';
+
+export interface SubtitleSyncData {
+    subtitles: SubtitleModel[];
+    subtitleFileNames: string[];
+    subtitleReader: SubtitleReader;
+    onApplyOffset: (offset: number) => void;
+}
+
+interface Props extends SubtitleSyncData {
+    color?: IconButtonProps['color'];
+    className?: string;
+}
+
+const SubtitleSyncButton = ({
+    subtitles,
+    subtitleFileNames,
+    subtitleReader,
+    onApplyOffset,
+    color,
+    className,
+}: Props) => {
+    const { t } = useTranslation();
+    const [open, setOpen] = useState(false);
+
+    if (subtitles.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            <Tooltip title={t('controls.subtitleSync')!}>
+                <IconButton color={color} onClick={() => setOpen(true)}>
+                    <SyncAltIcon className={className} />
+                </IconButton>
+            </Tooltip>
+            {open && (
+                <SubtitleSyncDialog
+                    subtitles={subtitles}
+                    subtitleFileNames={subtitleFileNames}
+                    subtitleReader={subtitleReader}
+                    onApplyOffset={onApplyOffset}
+                    onClose={() => setOpen(false)}
+                />
+            )}
+        </>
+    );
+};
+
+export default SubtitleSyncButton;

--- a/common/app/components/SubtitleSyncDialog.tsx
+++ b/common/app/components/SubtitleSyncDialog.tsx
@@ -1,0 +1,210 @@
+import { ChangeEvent, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { SubtitleModel, SubtitleSyncResult, detectSubtitleOffset } from '@project/common';
+import { SubtitleReader } from '@project/common/subtitle-reader';
+
+const UPLOAD = 'upload';
+const LOW_CONFIDENCE = 0.5;
+
+type Cue = Pick<SubtitleModel, 'originalStart' | 'originalEnd'>;
+
+interface Props {
+    subtitles: SubtitleModel[];
+    subtitleFileNames: string[];
+    subtitleReader: SubtitleReader;
+    onApplyOffset: (offset: number) => void;
+    onClose: () => void;
+}
+
+const SubtitleSyncDialog = ({ subtitles, subtitleFileNames, subtitleReader, onApplyOffset, onClose }: Props) => {
+    const { t } = useTranslation();
+    const tracks = useMemo(() => Array.from(new Set(subtitles.map((s) => s.track))).sort((a, b) => a - b), [subtitles]);
+    const trackLabel = useCallback(
+        (track: number) => subtitleFileNames[track] ?? t('subtitleSync.trackLabel', { number: track + 1 }),
+        [subtitleFileNames, t]
+    );
+
+    const [primaryTrack, setPrimaryTrack] = useState(tracks[0] ?? 0);
+    const [reference, setReference] = useState(UPLOAD);
+    const [file, setFile] = useState<File>();
+    const [result, setResult] = useState<SubtitleSyncResult>();
+    const [previousOffset, setPreviousOffset] = useState<number>();
+    const [error, setError] = useState(false);
+    const [loading, setLoading] = useState(false);
+
+    const applied = previousOffset !== undefined;
+    const detected = result !== undefined && result.confidence > 0;
+    const canDetect = reference !== UPLOAD || file !== undefined;
+
+    const resetDetection = () => {
+        setResult(undefined);
+        setError(false);
+    };
+
+    const handlePrimaryChange = (value: string) => {
+        setPrimaryTrack(Number(value));
+        if (reference === value) {
+            setReference(UPLOAD);
+        }
+        resetDetection();
+    };
+
+    const handleReferenceChange = (value: string) => {
+        setReference(value);
+        resetDetection();
+    };
+
+    const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+        const selected = e.target.files?.[0];
+        e.target.value = ''; // allow re-selecting the same file
+        if (selected) {
+            setFile(selected);
+            resetDetection();
+        }
+    };
+
+    const handleDetect = async () => {
+        setError(false);
+        setLoading(true);
+
+        try {
+            const primaryCues = subtitles.filter((s) => s.track === primaryTrack);
+            let referenceCues: Cue[];
+
+            if (reference === UPLOAD) {
+                if (!file) {
+                    return;
+                }
+
+                const nodes = await subtitleReader.subtitles([file]);
+                referenceCues = nodes.map((n) => ({ originalStart: n.start, originalEnd: n.end }));
+            } else {
+                referenceCues = subtitles.filter((s) => s.track === Number(reference));
+            }
+
+            setResult(detectSubtitleOffset(primaryCues, referenceCues));
+        } catch {
+            setError(true);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleApply = () => {
+        if (!result) {
+            return;
+        }
+
+        setPreviousOffset(subtitles.length > 0 ? subtitles[0].start - subtitles[0].originalStart : 0);
+        onApplyOffset(result.offset);
+    };
+
+    const handleUndo = () => {
+        if (previousOffset === undefined) {
+            return;
+        }
+
+        onApplyOffset(previousOffset);
+        setPreviousOffset(undefined);
+    };
+
+    return (
+        <Dialog open onClose={onClose} fullWidth maxWidth="xs">
+            <DialogTitle>{t('subtitleSync.title')}</DialogTitle>
+            <DialogContent>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+                    <Typography variant="body2" color="text.secondary">
+                        {t('subtitleSync.description')}
+                    </Typography>
+                    {tracks.length > 1 && (
+                        <TextField
+                            select
+                            fullWidth
+                            disabled={applied}
+                            label={t('subtitleSync.primaryTrack')}
+                            value={String(primaryTrack)}
+                            onChange={(e) => handlePrimaryChange(e.target.value)}
+                        >
+                            {tracks.map((track) => (
+                                <MenuItem key={track} value={String(track)}>
+                                    {trackLabel(track)}
+                                </MenuItem>
+                            ))}
+                        </TextField>
+                    )}
+                    <TextField
+                        select
+                        fullWidth
+                        disabled={applied}
+                        label={t('subtitleSync.reference')}
+                        value={reference}
+                        onChange={(e) => handleReferenceChange(e.target.value)}
+                    >
+                        <MenuItem value={UPLOAD}>{t('subtitleSync.uploadFile')}</MenuItem>
+                        {tracks
+                            .filter((track) => track !== primaryTrack)
+                            .map((track) => (
+                                <MenuItem key={track} value={String(track)}>
+                                    {trackLabel(track)}
+                                </MenuItem>
+                            ))}
+                    </TextField>
+                    {reference === UPLOAD && (
+                        <Button variant="outlined" component="label" disabled={applied}>
+                            {file?.name ?? t('subtitleSync.chooseFile')}
+                            <input type="file" hidden onChange={handleFileChange} />
+                        </Button>
+                    )}
+                    {loading && <CircularProgress size={24} sx={{ alignSelf: 'center' }} />}
+                    {error && <Alert severity="error">{t('subtitleSync.fileError')}</Alert>}
+                    {!applied &&
+                        result &&
+                        (result.confidence > 0 ? (
+                            <Stack spacing={1}>
+                                <Typography>{t('subtitleSync.detectedOffset', { offset: result.offset })}</Typography>
+                                <Typography variant="body2" color="text.secondary">
+                                    {t('subtitleSync.confidence', { percent: Math.round(result.confidence * 100) })}
+                                </Typography>
+                                {result.confidence < LOW_CONFIDENCE && (
+                                    <Alert severity="warning">{t('subtitleSync.lowConfidence')}</Alert>
+                                )}
+                            </Stack>
+                        ) : (
+                            <Alert severity="warning">{t('subtitleSync.noMatch')}</Alert>
+                        ))}
+                    {applied && result && (
+                        <Alert severity="success">{t('subtitleSync.applied', { offset: result.offset })}</Alert>
+                    )}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>{t('action.close')}</Button>
+                {applied ? (
+                    <Button onClick={handleUndo}>{t('subtitleSync.undo')}</Button>
+                ) : (
+                    <>
+                        <Button onClick={handleDetect} disabled={!canDetect || loading}>
+                            {t('subtitleSync.detect')}
+                        </Button>
+                        <Button variant="contained" onClick={handleApply} disabled={!detected}>
+                            {t('subtitleSync.apply')}
+                        </Button>
+                    </>
+                )}
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default SubtitleSyncDialog;

--- a/common/app/components/VideoPlayer.tsx
+++ b/common/app/components/VideoPlayer.tsx
@@ -47,6 +47,8 @@ import {
     ANNOTATIONS_VIDEO_RENDER_BEHIND_MS,
     ANNOTATIONS_VIDEO_RENDER_AHEAD_MS,
 } from '@project/common/subtitle-annotations';
+import { SubtitleReader } from '@project/common/subtitle-reader';
+import pgsParserWorkerFactory from '../../subtitle-reader/pgs-parser-worker.ts?worker';
 import Clock from '../services/clock';
 import Controls, { Point } from './Controls';
 import PlayerChannel from '../services/player-channel';
@@ -390,6 +392,22 @@ export default function VideoPlayer({
         newCol.setSubtitles(subtitles);
         return newCol;
     }, [subtitles]);
+    const subtitleReader = useMemo(
+        () =>
+            new SubtitleReader({
+                regexFilter: settings.subtitleRegexFilter,
+                regexFilterTextReplacement: settings.subtitleRegexFilterTextReplacement,
+                subtitleHtml: settings.subtitleHtml,
+                convertNetflixRuby: settings.convertNetflixRuby,
+                pgsParserWorkerFactory: async () => new pgsParserWorkerFactory(),
+            }),
+        [
+            settings.subtitleRegexFilter,
+            settings.subtitleRegexFilterTextReplacement,
+            settings.subtitleHtml,
+            settings.convertNetflixRuby,
+        ]
+    );
     const [showSubtitles, setShowSubtitles] = useState<IndexedSubtitleModel[]>([]);
     const [miscSettings, setMiscSettings] = useState<MiscSettings>(settings);
     const [subtitleSettings, setSubtitleSettings] = useState<SubtitleSettings>(settings);
@@ -1993,6 +2011,12 @@ export default function VideoPlayer({
                 subtitleAlignment={subtitleAlignments[0]}
                 subtitleAlignmentEnabled={subtitleAlignments.length === 1}
                 onSubtitleAlignment={handleSubtitleAlignment}
+                subtitleSync={{
+                    subtitles,
+                    subtitleFileNames: [],
+                    subtitleReader,
+                    onApplyOffset: handleOffsetChange,
+                }}
                 hideToolbar={isMobile}
                 onLoadFiles={popOut ? undefined : handleLoadFiles}
                 blurOverlayEnabled={blurOverlayVisible}

--- a/common/index.ts
+++ b/common/index.ts
@@ -5,5 +5,6 @@ export * from './src/command';
 export * from './src/model';
 export * from './src/message';
 export * from './src/fetcher';
+export * from './src/subtitle-sync/offset';
 export { default as AutoPauseContext } from './src/auto-pause-context';
 export { default as OffscreenDomCache } from './src/offscreen-dom-cache';

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "Hide Subtitle List",
         "currentTimestamp": "Current Timestamp",
         "showBlurOverlay": "Show Blur Overlay",
-        "hideBlurOverlay": "Hide Blur Overlay"
+        "hideBlurOverlay": "Hide Blur Overlay",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "Leer",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "Hide Subtitle List",
         "currentTimestamp": "Current Timestamp",
         "showBlurOverlay": "Show Blur Overlay",
-        "hideBlurOverlay": "Hide Blur Overlay"
+        "hideBlurOverlay": "Hide Blur Overlay",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "Blank",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "Ocultar Lista de Subtítulos",
         "currentTimestamp": "Marca de tiempo actual",
         "showBlurOverlay": "Mostrar efecto de desenfoque superpuesto",
-        "hideBlurOverlay": "Ocultar efecto de desenfoque superpuesto"
+        "hideBlurOverlay": "Ocultar efecto de desenfoque superpuesto",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "En Blanco",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "Piilota tekstityslista",
         "currentTimestamp": "Nykyisen aikaleima",
         "showBlurOverlay": "Show Blur Overlay",
-        "hideBlurOverlay": "Hide Blur Overlay"
+        "hideBlurOverlay": "Hide Blur Overlay",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "Tyhjä",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "Masquer la liste des sous-titres",
         "currentTimestamp": "Horodatage actuel",
         "showBlurOverlay": "Show Blur Overlay",
-        "hideBlurOverlay": "Hide Blur Overlay"
+        "hideBlurOverlay": "Hide Blur Overlay",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "Vide",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "Sembunyikan Daftar Takarir",
         "currentTimestamp": "Penanda Waktu Saat Ini",
         "showBlurOverlay": "Tampilkan Overlay Blur",
-        "hideBlurOverlay": "Sembunyikan Overlay Blur"
+        "hideBlurOverlay": "Sembunyikan Overlay Blur",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "Kosong",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "Nascondi elenco sottotitoli",
         "currentTimestamp": "Marca temporale corrente",
         "showBlurOverlay": "Mostra sovrapposizione sfocata",
-        "hideBlurOverlay": "Nascondi sovrapposizione sfocata"
+        "hideBlurOverlay": "Nascondi sovrapposizione sfocata",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "Vuoto",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "字幕リストを非表示",
         "currentTimestamp": "タイムスタンプ",
         "showBlurOverlay": "ぼかしオーバーレイを表示",
-        "hideBlurOverlay": "ぼかしオーバーレイを非表示"
+        "hideBlurOverlay": "ぼかしオーバーレイを非表示",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "空白",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "자막 목록 숨기기",
         "currentTimestamp": "현재 위치 (시간)",
         "showBlurOverlay": "Show Blur Overlay",
-        "hideBlurOverlay": "Hide Blur Overlay"
+        "hideBlurOverlay": "Hide Blur Overlay",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "자막 없음",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "Schowaj listę napisów",
         "currentTimestamp": "Current Timestamp",
         "showBlurOverlay": "Show Blur Overlay",
-        "hideBlurOverlay": "Hide Blur Overlay"
+        "hideBlurOverlay": "Hide Blur Overlay",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "Puste",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "Ocultar lista de legendas",
         "currentTimestamp": "Timestamp atual",
         "showBlurOverlay": "Show Blur Overlay",
-        "hideBlurOverlay": "Hide Blur Overlay"
+        "hideBlurOverlay": "Hide Blur Overlay",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "Em branco",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "Скрыть панель списка субтитров",
         "currentTimestamp": "Текущая метка времени",
         "showBlurOverlay": "Show Blur Overlay",
-        "hideBlurOverlay": "Hide Blur Overlay"
+        "hideBlurOverlay": "Hide Blur Overlay",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "Пусто",
@@ -736,5 +737,23 @@
         "searchCategory": "Search category",
         "categoryAnime": "Anime",
         "categoryDrama": "Drama"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -189,7 +189,8 @@
         "hideSubtitlePlayer": "收起字幕列表",
         "currentTimestamp": "当前时间",
         "showBlurOverlay": "Show Blur Overlay",
-        "hideBlurOverlay": "Hide Blur Overlay"
+        "hideBlurOverlay": "Hide Blur Overlay",
+        "subtitleSync": "Sync to Reference"
     },
     "copyHistory": {
         "blank": "空白",
@@ -736,5 +737,23 @@
         "searchCategory": "搜索类别",
         "categoryAnime": "动画",
         "categoryDrama": "剧集"
+    },
+    "subtitleSync": {
+        "title": "Sync subtitles to a reference",
+        "description": "Shift the subtitle timing to match a correctly-timed reference.",
+        "primaryTrack": "Subtitle to adjust",
+        "reference": "Reference",
+        "uploadFile": "Upload a file…",
+        "chooseFile": "Choose file",
+        "trackLabel": "Track {{number}}",
+        "detect": "Detect offset",
+        "detectedOffset": "Detected offset: {{offset}} ms",
+        "confidence": "Confidence: {{percent}}%",
+        "lowConfidence": "Low confidence: the detected offset may be wrong.",
+        "noMatch": "Could not detect a reliable offset. Try a different reference.",
+        "fileError": "Could not read that subtitle file.",
+        "apply": "Apply",
+        "undo": "Undo",
+        "applied": "Applied offset: {{offset}} ms"
     }
 }

--- a/common/src/subtitle-sync/offset.test.ts
+++ b/common/src/subtitle-sync/offset.test.ts
@@ -1,0 +1,47 @@
+import { detectSubtitleOffset } from './offset';
+
+describe('detectSubtitleOffset', () => {
+    // Irregular cue spacing so the cross-correlation has a single unambiguous peak.
+    const starts = [
+        1000, 3500, 4200, 8000, 9100, 12000, 15000, 15800, 20000, 23000, 24500, 28000, 31000, 33000, 37000, 40000,
+        41200, 45000, 48000, 52000,
+    ];
+    const cues = (offset: number) => starts.map((s) => ({ originalStart: s + offset, originalEnd: s + offset + 700 }));
+
+    it('recovers a positive offset when the reference is ahead of the primary', () => {
+        const primary = cues(0);
+        const reference = cues(2000); // reference dialogue occurs 2s later than the primary
+
+        const result = detectSubtitleOffset(primary, reference);
+
+        expect(result.offset).toBeGreaterThan(1800);
+        expect(result.offset).toBeLessThan(2200);
+        expect(result.confidence).toBeGreaterThan(0.7);
+    });
+
+    it('recovers a negative offset when the reference is behind the primary', () => {
+        const primary = cues(1500); // primary dialogue occurs 1.5s later than the reference
+        const reference = cues(0);
+
+        const result = detectSubtitleOffset(primary, reference);
+
+        expect(result.offset).toBeLessThan(-1300);
+        expect(result.offset).toBeGreaterThan(-1700);
+        expect(result.confidence).toBeGreaterThan(0.7);
+    });
+
+    it('returns zero offset and high confidence for already-aligned tracks', () => {
+        const primary = cues(0);
+        const reference = cues(0);
+
+        const result = detectSubtitleOffset(primary, reference);
+
+        expect(result.offset).toBe(0);
+        expect(result.confidence).toBeGreaterThan(0.9);
+    });
+
+    it('returns zero confidence when either track is empty', () => {
+        expect(detectSubtitleOffset([], cues(0)).confidence).toBe(0);
+        expect(detectSubtitleOffset(cues(0), []).confidence).toBe(0);
+    });
+});

--- a/common/src/subtitle-sync/offset.ts
+++ b/common/src/subtitle-sync/offset.ts
@@ -1,0 +1,99 @@
+import type { SubtitleModel } from '../model';
+
+/** Timeline resolution. Coarse enough that a full episode scores in milliseconds. */
+const FRAME_MS = 100;
+/** Largest offset (in either direction) the search will consider. */
+const MAX_OFFSET_MS = 120_000;
+/** Tracks with fewer active frames than this fraction can't be correlated reliably (signs/songs). */
+const MIN_DENSITY = 0.1;
+
+export interface SubtitleSyncResult {
+    /** Milliseconds to add to the primary track's cue timings so it aligns to the reference. */
+    offset: number;
+    /** Jaccard overlap of the best alignment, in [0, 1]. */
+    confidence: number;
+}
+
+type Cue = Pick<SubtitleModel, 'originalStart' | 'originalEnd'>;
+
+/** Binary timeline where a frame is true when any cue is active during it. */
+function buildTimeline(cues: Cue[], durationMs: number): boolean[] {
+    const timeline = new Array<boolean>(Math.ceil(durationMs / FRAME_MS)).fill(false);
+
+    for (const { originalStart, originalEnd } of cues) {
+        const startFrame = Math.floor(originalStart / FRAME_MS);
+        const endFrame = Math.min(Math.ceil(originalEnd / FRAME_MS), timeline.length);
+
+        for (let i = startFrame; i < endFrame; i++) {
+            timeline[i] = true;
+        }
+    }
+
+    return timeline;
+}
+
+const activeFrames = (timeline: boolean[]) => timeline.reduce((count, active) => count + (active ? 1 : 0), 0);
+
+/**
+ * Detect the constant offset (ms) to add to a primary subtitle track so its cue timing aligns to a
+ * reference track. Compares timing only, so it is language-agnostic. The returned offset matches the
+ * player's convention (added to a cue's original timing), so it can be handed straight to the offset
+ * handler. Confidence is the Jaccard overlap of the best alignment; callers decide how to treat a low
+ * value. Returns zero confidence when alignment is not meaningful (empty or too-sparse tracks).
+ */
+export function detectSubtitleOffset(primary: Cue[], reference: Cue[]): SubtitleSyncResult {
+    if (primary.length === 0 || reference.length === 0) {
+        return { offset: 0, confidence: 0 };
+    }
+
+    const maxEnd = (cues: Cue[]) => cues.reduce((max, c) => Math.max(max, c.originalEnd), 0);
+    const span = Math.max(maxEnd(primary), maxEnd(reference));
+
+    if (!isFinite(span) || span <= 0) {
+        return { offset: 0, confidence: 0 };
+    }
+
+    const primaryTimeline = buildTimeline(primary, span);
+    const referenceTimeline = buildTimeline(reference, span);
+    const frameCount = primaryTimeline.length;
+    const primaryActiveTotal = activeFrames(primaryTimeline);
+    const referenceActiveTotal = activeFrames(referenceTimeline);
+
+    if (primaryActiveTotal / frameCount < MIN_DENSITY || referenceActiveTotal / frameCount < MIN_DENSITY) {
+        return { offset: 0, confidence: 0 };
+    }
+
+    const maxLag = Math.min(Math.ceil(MAX_OFFSET_MS / FRAME_MS), frameCount - 1);
+    // Without this, a coincidental one-frame overlap at an extreme lag scores a perfect Jaccard of 1.
+    const minOverlap = Math.max(3, Math.floor(0.2 * Math.min(primaryActiveTotal, referenceActiveTotal)));
+
+    let bestLag = 0;
+    let bestScore = 0;
+
+    // Positive lag => reference is later than the primary, so the primary shifts forward to match.
+    for (let lag = -maxLag; lag <= maxLag; lag++) {
+        let both = 0;
+        let primaryActive = 0;
+        let referenceActive = 0;
+
+        for (let i = Math.max(0, -lag); i < Math.min(frameCount, frameCount - lag); i++) {
+            const p = primaryTimeline[i];
+            const r = referenceTimeline[i + lag];
+            if (p) primaryActive++;
+            if (r) referenceActive++;
+            if (p && r) both++;
+        }
+
+        if (both < minOverlap) {
+            continue;
+        }
+
+        const score = both / (primaryActive + referenceActive - both);
+        if (score > bestScore || (score === bestScore && Math.abs(lag) < Math.abs(bestLag))) {
+            bestScore = score;
+            bestLag = lag;
+        }
+    }
+
+    return { offset: bestLag * FRAME_MS, confidence: bestScore };
+}

--- a/docs/docs/guides/subtitle-timing.md
+++ b/docs/docs/guides/subtitle-timing.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Subtitle timing
 
-Subtitle files will very often not be aligned to the video source you load them into. To work around this, asbplayer provides ways to manually adjust subtitle timing.
+Subtitle files will very often not be aligned to the video source you load them into. To work around this, asbplayer provides ways to adjust subtitle timing.
 
 ## Keyboard shortcuts
 
@@ -26,3 +26,12 @@ The overlay UI provides buttons that perform the same functions as the keyboard 
 1. Scroll the rightmost section to the **middle** control.
 2. Click the left or right button to align the left or right subtitle to the current timestamp.
 3. Click and **hold** the left or right button to move the current timestamp `100ms` to the left or right.
+
+## Sync to a reference
+
+If you have another subtitle that is already correctly timed, asbplayer can detect the offset for you instead of adjusting it by hand. The reference can be an uploaded subtitle file or another subtitle track you already loaded. Only timing is compared, so the reference does not need to be in the same language.
+
+1. Click the **Sync to Reference** button in the player controls, or in the extension side panel.
+2. Choose a reference: **Upload a file…**, or select another loaded track.
+3. Click **Detect offset**. asbplayer shows the detected offset and a confidence percentage, and warns when the confidence is low.
+4. Click **Apply** to shift the subtitle, or **Undo** to revert.

--- a/extension/src/ui/components/SidePanel.tsx
+++ b/extension/src/ui/components/SidePanel.tsx
@@ -16,6 +16,7 @@ import {
     DownloadImageMessage,
     DownloadAudioMessage,
     CardExportedMessage,
+    OffsetToVideoMessage,
 } from '@project/common';
 import type { AsbplayerInstance, Command, Message, OpenStatisticsOverlayMessage } from '@project/common';
 import type { BulkExportStartedPayload } from '../../controllers/bulk-export-controller';
@@ -26,6 +27,7 @@ import { useI18n } from '../hooks/use-i18n';
 import { SubtitleReader } from '@project/common/subtitle-reader';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Player from '@project/common/app/components/Player';
+import SubtitleSyncButton from '@project/common/app/components/SubtitleSyncButton';
 import { PlaybackPreferences } from '@project/common/app';
 import { AlertColor } from '@mui/material/Alert';
 import Alert from '@project/common/app/components/Alert';
@@ -303,6 +305,23 @@ export default function SidePanel({ dictionaryProvider, settingsProvider, settin
         };
         browser.runtime.sendMessage(message);
     }, [syncedVideoTab, settings.clickToMineDefaultAction]);
+
+    const handleApplySyncOffset = useCallback(
+        (offset: number) => {
+            if (syncedVideoTab === undefined) {
+                return;
+            }
+
+            const command: AsbPlayerToVideoCommandV2<OffsetToVideoMessage> = {
+                sender: 'asbplayerv2',
+                message: { command: 'offset', value: offset, echo: true },
+                tabId: syncedVideoTab.id,
+                src: syncedVideoTab.src,
+            };
+            browser.runtime.sendMessage(command);
+        },
+        [syncedVideoTab]
+    );
 
     const handleLoadSubtitles = useCallback(() => {
         if (currentTabId === undefined) {
@@ -732,6 +751,16 @@ export default function SidePanel({ dictionaryProvider, settingsProvider, settin
                                 onShowMiningHistory={handleShowCopyHistory}
                                 miningHistoryCount={copyHistoryItems.length}
                                 onShowStatistics={handleShowStatistics}
+                                subtitleSyncButton={
+                                    subtitles && subtitles.length > 0 ? (
+                                        <SubtitleSyncButton
+                                            subtitles={subtitles}
+                                            subtitleFileNames={subtitleFileNames ?? []}
+                                            subtitleReader={subtitleReader}
+                                            onApplyOffset={handleApplySyncOffset}
+                                        />
+                                    ) : undefined
+                                }
                             />
                             <SidePanelBottomControls
                                 disabled={currentTabId !== syncedVideoTab?.id}

--- a/extension/src/ui/components/SidePanelTopControls.tsx
+++ b/extension/src/ui/components/SidePanelTopControls.tsx
@@ -8,7 +8,7 @@ import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 import Fade from '@mui/material/Fade';
 import Badge from '@mui/material/Badge';
-import { ForwardedRef, useEffect, useState } from 'react';
+import { ForwardedRef, ReactNode, useEffect, useState } from 'react';
 import React from 'react';
 import Tooltip from '@project/common/components/Tooltip';
 import { useTranslation } from 'react-i18next';
@@ -23,6 +23,7 @@ interface Props {
     miningHistoryCount: number;
     onShowStatistics: () => void;
     disableBulkExport?: boolean;
+    subtitleSyncButton?: ReactNode;
 }
 
 const SidePanelTopControls = React.forwardRef(function SidePanelTopControls(
@@ -36,6 +37,7 @@ const SidePanelTopControls = React.forwardRef(function SidePanelTopControls(
         miningHistoryCount,
         onShowStatistics,
         disableBulkExport,
+        subtitleSyncButton,
     }: Props,
     ref: ForwardedRef<HTMLDivElement>
 ) {
@@ -58,6 +60,7 @@ const SidePanelTopControls = React.forwardRef(function SidePanelTopControls(
                             </IconButton>
                         </Tooltip>
                     </Grid>
+                    {subtitleSyncButton && <Grid item>{subtitleSyncButton}</Grid>}
                     {canDownloadSubtitles && (
                         <>
                             <Grid item>


### PR DESCRIPTION
closes https://github.com/asbplayer/asbplayer/issues/441

Add a control that aligns the loaded subtitle track to a reference by comparing cue timing, then applies the detected offset.

A pure, language-agnostic aligner (Jaccard cross-correlation over a coarse timeline) computes the constant offset between two subtitle tracks plus a confidence score. A dialog lets the user pick the reference (an uploaded file or another loaded track), shows the detected offset and confidence, warns on low confidence, and supports undo.

The trigger is a shared button surfaced in the player controls (web app and over-video player) and in the extension side panel, where it applies the offset to the synced tab via the existing offset command.

(_fyi: i've been using a slightly advanced version of this in [a fork](https://github.com/zakwarsame/asbplayer) which detects and loads cc captions in the drop-down; but decided to abstract just the core algorithm with minimal UI here_)

#### demo

https://github.com/user-attachments/assets/72719a3e-b557-4b4c-8714-87619f45080f


### testing steps used in the demo

1. episode: https://www.miruro.tv/watch/101348/vinland-saga?ep=4
2. switch server to bun ([screenshot for reference](https://github.com/user-attachments/assets/266b3d26-7241-4e11-b759-61c32524fff4))
3. load un-aligned japanese subtitle: https://files.catbox.moe/79mqrx.srt
4. sync with reference to english version: https://files.catbox.moe/zey62f.srt
5. notice offset

idea credit: @Kellenok

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
