### PR TITLE
Fix Netflix subtitle detection and furigana positioning

### DIFF
--- a/common/app/components/App.tsx
+++ b/common/app/components/App.tsx
@@ -105,6 +105,7 @@ const subtitleExtensions = [
     '.vtt',
     '.sup',
     '.nfvtt',
+    '.nfimsc',
     '.ytxml',
     '.ytsrv3',
     '.dfxp',

--- a/common/subtitle-reader/subtitle-reader.test.ts
+++ b/common/subtitle-reader/subtitle-reader.test.ts
@@ -1,0 +1,98 @@
+// These deps ship as ESM that the repo's ts-jest setup does not transform, and the
+// IMSC path under test never uses them (they back the srt/ass/vtt branches).
+jest.mock('@qgustavor/srt-parser', () => ({ __esModule: true, default: class {} }));
+jest.mock('ass-compiler', () => ({ compile: () => ({ dialogues: [] }) }));
+jest.mock('videojs-vtt.js', () => ({ WebVTT: {} }));
+
+import SubtitleReader from './subtitle-reader';
+import { SubtitleHtml } from '@project/common';
+
+const createReader = (convertNetflixRuby = false) =>
+    new SubtitleReader({
+        regexFilter: '',
+        regexFilterTextReplacement: '',
+        subtitleHtml: SubtitleHtml.render,
+        convertNetflixRuby,
+        pgsParserWorkerFactory: () => Promise.reject(new Error('PGS worker is not used in these tests')),
+    });
+
+const nfimscFile = (xml: string) => ({ name: 'test.nfimsc', text: async () => xml }) as unknown as File;
+
+const parse = (xml: string, convertNetflixRuby = false) =>
+    createReader(convertNetflixRuby).subtitles([nfimscFile(xml)]);
+
+describe('SubtitleReader Netflix IMSC parsing', () => {
+    it('parses Netflix IMSC cues', async () => {
+        // Prefixed elements, namespaced ttp:tickRate, a dur-only cue, a second
+        // <div>, and a nested <span> all in one document.
+        const xml =
+            '<tt:tt xmlns:tt="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ttp:tickRate="10000000">' +
+            '<tt:body>' +
+            '<tt:div>' +
+            '<tt:p begin="10000000t" end="30000000t"><tt:span>Hello</tt:span> world</tt:p>' +
+            '<tt:p begin="40000000t" dur="20000000t">Second line</tt:p>' +
+            '</tt:div>' +
+            '<tt:div>' +
+            '<tt:p begin="70000000t" end="90000000t">Third line</tt:p>' +
+            '</tt:div>' +
+            '</tt:body>' +
+            '</tt:tt>';
+
+        const subtitles = await parse(xml);
+
+        expect(subtitles).toHaveLength(3);
+        expect(subtitles[0]).toMatchObject({ start: 1000, end: 3000, text: 'Hello world' });
+        expect(subtitles[1]).toMatchObject({ start: 4000, end: 6000, text: 'Second line' });
+        expect(subtitles[2]).toMatchObject({ start: 7000, end: 9000, text: 'Third line' });
+    });
+
+    it('converts IMSC ruby styles through the Netflix ruby tokenization', async () => {
+        // The ruby container references two styles ("plain container") to exercise
+        // multi-id style resolution.
+        const xml =
+            '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:tickRate="10000000">' +
+            '<head><styling>' +
+            '<style xml:id="plain" tts:fontStyle="normal"/>' +
+            '<style xml:id="container" tts:ruby="container"/>' +
+            '<style xml:id="base" tts:ruby="base"/>' +
+            '<style xml:id="text" tts:ruby="text"/>' +
+            '</styling></head>' +
+            '<body><div>' +
+            '<p begin="10000000t" end="30000000t"><span style="plain container"><span style="base">日本</span><span style="text">にほん</span></span></p>' +
+            '</div></body>' +
+            '</tt>';
+
+        const withRuby = await parse(xml, true);
+        expect(withRuby).toHaveLength(1);
+        expect(withRuby[0].text).toBe('日本');
+        expect(withRuby[0].tokenization).toEqual({
+            tokens: [{ pos: [0, 2], readings: [{ pos: [0, 2], reading: 'にほん' }], states: [] }],
+        });
+
+        const withoutRuby = await parse(xml, false);
+        expect(withoutRuby).toHaveLength(1);
+        expect(withoutRuby[0].text).toBe('日本(にほん)');
+        expect(withoutRuby[0].tokenization).toBeUndefined();
+    });
+
+    it('drops tick cues when the tick rate is missing', async () => {
+        const xml =
+            '<tt xmlns="http://www.w3.org/ns/ttml">' +
+            '<body><div><p begin="100t" end="200t">Should be dropped</p></div></body>' +
+            '</tt>';
+
+        const subtitles = await parse(xml);
+
+        expect(subtitles).toHaveLength(0);
+    });
+});
+
+describe('SubtitleReader dfxp timestamp handling', () => {
+    it('drops cues whose timestamps are not finite', async () => {
+        const xml = '<tt><body><div><p begin="100t" end="200t">Dropped</p></div></body></tt>';
+        const file = { name: 'test.dfxp', text: async () => xml } as unknown as File;
+        const subtitles = await createReader().subtitles([file]);
+
+        expect(subtitles).toHaveLength(0);
+    });
+});

--- a/common/subtitle-reader/subtitle-reader.test.ts
+++ b/common/subtitle-reader/subtitle-reader.test.ts
@@ -75,6 +75,58 @@ describe('SubtitleReader Netflix IMSC parsing', () => {
         expect(withoutRuby[0].tokenization).toBeUndefined();
     });
 
+    it('binds a ruby reading to its own base when preceded by kanji or kana', async () => {
+        // The base 子 is preceded by the kana ひろ. The reading must bind to 子 alone,
+        // not to the whole ひろ子 run.
+        const xml =
+            '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:tickRate="10000000">' +
+            '<head><styling>' +
+            '<style xml:id="container" tts:ruby="container"/>' +
+            '<style xml:id="base" tts:ruby="base"/>' +
+            '<style xml:id="text" tts:ruby="text"/>' +
+            '</styling></head>' +
+            '<body><div>' +
+            '<p begin="10000000t" end="30000000t">ひろ<span style="container"><span style="base">子</span><span style="text">こ</span></span>そんな</p>' +
+            '</div></body>' +
+            '</tt>';
+
+        const withRuby = await parse(xml, true);
+        expect(withRuby).toHaveLength(1);
+        expect(withRuby[0].text).toBe('ひろ子そんな');
+        expect(withRuby[0].text).not.toContain('\u2063');
+        expect(withRuby[0].tokenization).toEqual({
+            tokens: [{ pos: [2, 3], readings: [{ pos: [0, 1], reading: 'こ' }], states: [] }],
+        });
+
+        const withoutRuby = await parse(xml, false);
+        expect(withoutRuby).toHaveLength(1);
+        expect(withoutRuby[0].text).toBe('ひろ子(こ)そんな');
+        expect(withoutRuby[0].text).not.toContain('\u2063');
+        expect(withoutRuby[0].tokenization).toBeUndefined();
+    });
+
+    it('does not fence a reading containing a closing paren', async () => {
+        // The reading )こ cannot be matched by netflixRubyRegex, so no marker is inserted
+        // and the cue passes through as literal text with no tokenization.
+        const xml =
+            '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:tickRate="10000000">' +
+            '<head><styling>' +
+            '<style xml:id="container" tts:ruby="container"/>' +
+            '<style xml:id="base" tts:ruby="base"/>' +
+            '<style xml:id="text" tts:ruby="text"/>' +
+            '</styling></head>' +
+            '<body><div>' +
+            '<p begin="10000000t" end="30000000t">ひろ<span style="container"><span style="base">子</span><span style="text">)こ</span></span>そんな</p>' +
+            '</div></body>' +
+            '</tt>';
+
+        const withRuby = await parse(xml, true);
+        expect(withRuby).toHaveLength(1);
+        expect(withRuby[0].text).toBe('ひろ子()こ)そんな');
+        expect(withRuby[0].text).not.toContain('\u2063');
+        expect(withRuby[0].tokenization).toBeUndefined();
+    });
+
     it('drops tick cues when the tick rate is missing', async () => {
         const xml =
             '<tt xmlns="http://www.w3.org/ns/ttml">' +

--- a/common/subtitle-reader/subtitle-reader.ts
+++ b/common/subtitle-reader/subtitle-reader.ts
@@ -350,6 +350,10 @@ export default class SubtitleReader {
             return await this._parsePgs(file, track);
         }
 
+        if (file.name.endsWith('.nfimsc')) {
+            return this._parseNetflixImsc(await file.text(), track);
+        }
+
         if (file.name.endsWith('.dfxp') || file.name.endsWith('ttml2')) {
             const text = await file.text();
             const parser = new DOMParser();
@@ -366,11 +370,19 @@ export default class SubtitleReader {
                     continue;
                 }
 
+                const start = this._parseTtmlTimestamp(beginAttribute);
+                const end = this._parseTtmlTimestamp(endAttribute);
+
+                // Skip cues whose timestamps did not parse to a finite number.
+                if (!Number.isFinite(start) || !Number.isFinite(end)) {
+                    continue;
+                }
+
                 const text = this._decodeHTML(elm.innerHTML.replaceAll(/<br(\s[^\s]+)?(\/)?>/g, '\n'));
                 subtitles.push({
                     text: this._filterText(text),
-                    start: this._parseTtmlTimestamp(beginAttribute),
-                    end: this._parseTtmlTimestamp(endAttribute),
+                    start,
+                    end,
                     track,
                 });
             }
@@ -439,13 +451,168 @@ export default class SubtitleReader {
             };
         });
     }
-    private _parseTtmlTimestamp(timestamp: string) {
+    private _parseTtmlTimestamp(timestamp: string, tickRate?: number) {
+        // Tick-based time (e.g. IMSC 1.1): "<ticks>t" resolved against ttp:tickRate.
+        const tickMatch = /^([0-9]+(?:\.[0-9]+)?)t$/.exec(timestamp);
+
+        if (tickMatch) {
+            const ticks = parseFloat(tickMatch[1]);
+            // Without a tick rate the value is unparseable, so let the caller drop it.
+            return tickRate && tickRate > 0 ? Math.floor((ticks / tickRate) * 1000) : NaN;
+        }
+
+        // Offset time with a metric unit, e.g. "1234ms", "12.5s", "90m", "1h".
+        const offsetMatch = /^([0-9]+(?:\.[0-9]+)?)(h|m|s|ms)$/.exec(timestamp);
+
+        if (offsetMatch) {
+            const value = parseFloat(offsetMatch[1]);
+
+            switch (offsetMatch[2]) {
+                case 'h':
+                    return Math.floor(value * 3600000);
+                case 'm':
+                    return Math.floor(value * 60000);
+                case 's':
+                    return Math.floor(value * 1000);
+                case 'ms':
+                    return Math.floor(value);
+            }
+        }
+
+        // Clock time: [[HH:]MM:]SS[.mmm]
         const parts = timestamp.split(':');
         const milliseconds = Math.floor(parseFloat(parts[parts.length - 1]) * 1000);
         const minutes = parts.length < 2 ? 0 : Number(parts[parts.length - 2]);
         const hours = parts.length < 3 ? 0 : Number(parts[parts.length - 3]);
 
         return milliseconds + minutes * 60000 + hours * 3600000;
+    }
+
+    // Parses the Netflix IMSC 1.1 (TTML) shape seen in subtitle downloads: tick-based
+    // timestamps resolved against ttp:tickRate, and furigana as tts:ruby styles
+    // (a container span wrapping a base span and a text span).
+    private _parseNetflixImsc(text: string, track: number): SubtitleNode[] {
+        const parameterNamespace = 'http://www.w3.org/ns/ttml#parameter';
+        const stylingNamespace = 'http://www.w3.org/ns/ttml#styling';
+        const doc = new DOMParser().parseFromString(text, 'application/xml');
+        const root = doc.documentElement;
+
+        // Resolve namespaced attributes by URI, falling back to the conventional prefix.
+        const tickRateAttribute =
+            root.getAttributeNS(parameterNamespace, 'tickRate') ?? root.getAttribute('ttp:tickRate');
+        const tickRate = Number(tickRateAttribute ?? '') || undefined;
+
+        // Map each style id to its ruby role (container/base/text), where defined.
+        const rubyRoleByStyleId: { [id: string]: string } = {};
+
+        for (const style of Array.from(doc.getElementsByTagNameNS('*', 'style'))) {
+            const id = style.getAttribute('xml:id');
+            const role = style.getAttributeNS(stylingNamespace, 'ruby') ?? style.getAttribute('tts:ruby');
+
+            if (id !== null && role !== null) {
+                rubyRoleByStyleId[id] = role;
+            }
+        }
+
+        // A style attribute may list several style ids, so use the first ruby one.
+        const rubyRoleOf = (element: Element) => {
+            const styleRef = element.getAttribute('style');
+
+            if (styleRef === null) {
+                return undefined;
+            }
+
+            for (const id of styleRef.trim().split(/\s+/)) {
+                const role = rubyRoleByStyleId[id];
+
+                if (role !== undefined) {
+                    return role;
+                }
+            }
+
+            return undefined;
+        };
+
+        const subtitles: SubtitleNode[] = [];
+
+        // Collect every <p> regardless of how many <div>s the body splits them across.
+        for (const paragraph of Array.from(doc.getElementsByTagNameNS('*', 'p'))) {
+            const begin = paragraph.getAttribute('begin');
+            const end = paragraph.getAttribute('end');
+            const dur = paragraph.getAttribute('dur');
+
+            if (begin === null || (end === null && dur === null)) {
+                continue;
+            }
+
+            const start = this._parseTtmlTimestamp(begin, tickRate);
+            const stop =
+                end !== null
+                    ? this._parseTtmlTimestamp(end, tickRate)
+                    : start + this._parseTtmlTimestamp(dur!, tickRate);
+
+            // Skip cues whose timestamps did not parse to a finite number.
+            if (!Number.isFinite(start) || !Number.isFinite(stop)) {
+                continue;
+            }
+
+            subtitles.push({
+                start,
+                end: stop,
+                text: this._filterText(this._imscParagraphText(paragraph, rubyRoleOf)),
+                track,
+            });
+        }
+
+        return subtitles;
+    }
+
+    // Flattens an IMSC <p> to text. Furigana renders inline as base(reading)
+    // so the existing _convertNetflixRubyToHtml pass tokenizes it.
+    private _imscParagraphText(node: Node, rubyRoleOf: (element: Element) => string | undefined): string {
+        let text = '';
+
+        for (const child of Array.from(node.childNodes)) {
+            if (child.nodeType === Node.TEXT_NODE) {
+                text += child.nodeValue ?? '';
+            } else if (child.nodeType === Node.ELEMENT_NODE) {
+                const element = child as Element;
+                const tag = this._dropTagNamespace(element.tagName).toLowerCase();
+
+                if (tag === 'br') {
+                    text += '\n';
+                } else if (rubyRoleOf(element) === 'container') {
+                    text += this._imscRubyText(element, rubyRoleOf);
+                } else {
+                    text += this._imscParagraphText(element, rubyRoleOf);
+                }
+            }
+        }
+
+        return text;
+    }
+
+    private _imscRubyText(container: Element, rubyRoleOf: (element: Element) => string | undefined): string {
+        let base = '';
+        let reading = '';
+
+        for (const child of Array.from(container.childNodes)) {
+            if (child.nodeType === Node.TEXT_NODE) {
+                base += child.nodeValue ?? '';
+            } else if (child.nodeType === Node.ELEMENT_NODE) {
+                const element = child as Element;
+
+                if (rubyRoleOf(element) === 'text') {
+                    reading += element.textContent ?? '';
+                } else {
+                    base += this._imscParagraphText(element, rubyRoleOf);
+                }
+            }
+        }
+
+        reading = reading.trim();
+
+        return reading.length > 0 ? `${base}(${reading})` : base;
     }
 
     private _xmlNodePath(parent: Element, path: string[]): Element[] {

--- a/common/subtitle-reader/subtitle-reader.ts
+++ b/common/subtitle-reader/subtitle-reader.ts
@@ -7,7 +7,23 @@ import DOMPurify from 'dompurify';
 
 const vttClassRegex = /<(\/)?c(\.[^>]*)?>/g;
 const assNewLineRegex = RegExp(/\\[nN]/, 'ig');
-const netflixRubyRegex = /([\p{sc=Hira}\p{sc=Kana}\p{sc=Han}々〆〤ヶ]+)\((?=[^)]*[\p{sc=Hira}\p{sc=Kana}])([^)]+)\)/gu;
+// Character classes shared by the Netflix ruby regexes below so they cannot drift apart.
+const netflixRubyKanaClass = '\\p{sc=Hira}\\p{sc=Kana}';
+const netflixRubyBaseClass = `${netflixRubyKanaClass}\\p{sc=Han}々〆〤ヶ`;
+// Invisible sentinel placed before a ruby base so netflixRubyRegex cannot capture back
+// into preceding kanji or kana. U+2063 is an invisible separator that in practice never
+// appears in subtitle text and is a valid scalar, so extension loaders accept it in
+// bundled files. The optional leading match consumes it.
+const netflixRubyBaseMarker = '\u2063';
+const netflixRubyRegex = new RegExp(
+    `${netflixRubyBaseMarker}?([${netflixRubyBaseClass}]+)\\((?=[^)]*[${netflixRubyKanaClass}])([^)]+)\\)`,
+    'gu'
+);
+// A base is fenceable when every character is rubyable and the reading has kana before
+// any closing paren, which is when netflixRubyRegex matches, so an inserted marker is
+// always consumed.
+const netflixRubyBaseRegex = new RegExp(`^[${netflixRubyBaseClass}]+$`, 'u');
+const netflixRubyReadingRegex = new RegExp(`^[^)]*[${netflixRubyKanaClass}]`, 'u');
 const helperElement = document.createElement('div');
 
 interface SubtitleNode {
@@ -104,14 +120,22 @@ export default class SubtitleReader {
             .filter((node) => node.textImage !== undefined || node.text !== '')
             .sort((n1, n2) => n1.start - n2.start);
 
-        if (flatten) {
-            return this._deduplicate(allNodes);
+        if (this._convertNetflixRuby) {
+            if (flatten) {
+                // Flattened output keeps inline base(reading) without tokenizing, so
+                // the ruby base markers are simply dropped here.
+                for (const node of allNodes) {
+                    node.text = node.text.replaceAll(netflixRubyBaseMarker, '');
+                }
+            } else {
+                for (const node of allNodes) {
+                    this._convertNetflixRubyToHtml(node);
+                }
+            }
         }
 
-        if (this._convertNetflixRuby) {
-            for (const node of allNodes) {
-                this._convertNetflixRubyToHtml(node);
-            }
+        if (flatten) {
+            return this._deduplicate(allNodes);
         }
 
         return allNodes;
@@ -612,7 +636,21 @@ export default class SubtitleReader {
 
         reading = reading.trim();
 
-        return reading.length > 0 ? `${base}(${reading})` : base;
+        if (reading.length === 0) {
+            return base;
+        }
+
+        // Fence the base from any preceding CJK so tokenization binds the reading to this
+        // base alone. Only when the shared regex is sure to match, so the marker is consumed.
+        if (this._convertNetflixRuby && this._rubyBaseIsFenceable(base, reading)) {
+            return `${netflixRubyBaseMarker}${base}(${reading})`;
+        }
+
+        return `${base}(${reading})`;
+    }
+
+    private _rubyBaseIsFenceable(base: string, reading: string): boolean {
+        return netflixRubyBaseRegex.test(base) && netflixRubyReadingRegex.test(reading);
     }
 
     private _xmlNodePath(parent: Element, path: string[]): Element[] {

--- a/extension/src/entrypoints/netflix-page.ts
+++ b/extension/src/entrypoints/netflix-page.ts
@@ -5,10 +5,6 @@ declare const netflix: any | undefined;
 
 export default defineUnlistedScript(() => {
     setTimeout(() => {
-        const webvtt = 'webvtt-lssdh-ios8';
-        const manifestPattern = new RegExp('manifest|licensedManifest');
-        const subTracks = new Map();
-
         function getAPI() {
             if (typeof netflix === 'undefined') {
                 return undefined;
@@ -40,50 +36,84 @@ export default defineUnlistedScript(() => {
             return undefined;
         }
 
-        function extractUrlLegacy(track: any) {
-            if (track.isForcedNarrative || track.isNoneTrack || !track.cdnlist?.length || !track.ttDownloadables) {
-                return undefined;
+        // Reads subtitle download URLs from the most recent player session (the last id
+        // from getAllPlayerSessionIds). Walks that session state and matches objects by
+        // structure (type === 'timedtext' with a urls array), which avoids depending on the
+        // minified property paths inside the player object that may change between releases.
+        function timedTextUrls(): Map<string, string> {
+            const urls = new Map<string, string>();
+            const sessionIds = getVideoPlayer()?.getAllPlayerSessionIds?.() || [];
+
+            if (sessionIds.length === 0) {
+                return urls;
             }
 
-            const webvttDL = track.ttDownloadables[webvtt];
+            const activeSessionId = sessionIds[sessionIds.length - 1];
+            const root =
+                netflix?.appContext?.state?.playerApp?.getState?.()?.videoPlayer?.cadmiumPlayerRepository
+                    ?.playersById?.[activeSessionId];
 
-            if (!webvttDL?.downloadUrls) {
-                return undefined;
+            if (!root) {
+                return urls;
             }
 
-            return webvttDL.downloadUrls[track.cdnlist.find((cdn: any) => webvttDL.downloadUrls[cdn.id])?.id];
-        }
+            const seen = new WeakSet<object>();
+            const stack: { node: any; depth: number }[] = [{ node: root, depth: 0 }];
 
-        function extractUrl(track: any) {
-            if (track.isForcedNarrative || track.isNoneTrack || !track.ttDownloadables) {
-                return undefined;
-            }
+            // Timedtext objects sit about 12 levels below the session root, so the depth
+            // 20 cap below leaves margin without walking unrelated deep state.
+            while (stack.length > 0) {
+                const { node, depth } = stack.pop()!;
 
-            const webvttDL = track.ttDownloadables[webvtt];
-
-            if (!webvttDL?.urls || webvttDL.urls.length === 0) {
-                return 'lazy';
-            }
-
-            return webvttDL.urls[0].url;
-        }
-
-        function storeSubTrack(video: any) {
-            const timedTextracks = video.timedtexttracks || [];
-
-            for (const track of timedTextracks) {
-                const url = extractUrlLegacy(track) ?? extractUrl(track);
-
-                if (url === undefined) {
+                if (node === null || typeof node !== 'object' || depth > 20 || seen.has(node)) {
                     continue;
                 }
 
-                if (!subTracks.has(video.movieId)) {
-                    subTracks.set(video.movieId, new Map());
+                seen.add(node);
+
+                if (node instanceof ArrayBuffer || ArrayBuffer.isView(node)) {
+                    continue;
                 }
 
-                subTracks.get(video.movieId).set(track.new_track_id, url);
+                try {
+                    if (
+                        node.type === 'timedtext' &&
+                        typeof node.trackId === 'string' &&
+                        Array.isArray(node.urls) &&
+                        node.urls.length > 0 &&
+                        typeof node.urls[0]?.url === 'string' &&
+                        !urls.has(node.trackId)
+                    ) {
+                        urls.set(node.trackId, node.urls[0].url);
+                    }
+                } catch (e) {
+                    // Ignore properties that throw on access
+                }
+
+                if (Array.isArray(node)) {
+                    for (const value of node) {
+                        if (value !== null && typeof value === 'object') {
+                            stack.push({ node: value, depth: depth + 1 });
+                        }
+                    }
+                } else {
+                    for (const key of Object.keys(node)) {
+                        let value;
+
+                        try {
+                            value = node[key];
+                        } catch (e) {
+                            continue;
+                        }
+
+                        if (value !== null && typeof value === 'object') {
+                            stack.push({ node: value, depth: depth + 1 });
+                        }
+                    }
+                }
             }
+
+            return urls;
         }
 
         document.addEventListener('asbplayer-netflix-seek', (e) => {
@@ -133,8 +163,10 @@ export default defineUnlistedScript(() => {
             return basename;
         }
 
-        const dataForTrack = (track: any, storedTracks: Map<string, string>): VideoDataSubtitleTrack | undefined => {
-            if (!track.bcp47) {
+        const dataForTrack = (track: any, urlsByTrackId?: Map<string, string>): VideoDataSubtitleTrack | undefined => {
+            // Skip the "Off" track, forced-narrative tracks, and image-based (bitmap)
+            // subtitles, which can't be parsed as text.
+            if (!track.bcp47 || track.isNoneTrack || track.isForcedNarrative || track.isImageBased) {
                 return undefined;
             }
 
@@ -147,8 +179,9 @@ export default defineUnlistedScript(() => {
                 language,
                 // 'lazy' is a sentinel value indicating to the content script that it should
                 // make a lazy language-specific request to get the URL
-                url: storedTracks.get(track.trackId) ?? 'lazy',
-                extension: 'nfvtt',
+                url: urlsByTrackId?.get(track.trackId) ?? 'lazy',
+                // Netflix subtitle downloads on this path are IMSC 1.1 (TTML)
+                extension: 'nfimsc',
             });
         };
 
@@ -163,13 +196,9 @@ export default defineUnlistedScript(() => {
             }
 
             response.basename = await determineBasenameWithRetries(titleId, 5);
-            const storedTracks = subTracks.get(titleId) || new Map();
-            response.subtitles = np
-                .getTimedTextTrackList()
-                .filter((track: any) => storedTracks.has(track.trackId))
-                .map((track: any) => {
-                    return dataForTrack(track, storedTracks);
-                })
+            const urlsByTrackId = timedTextUrls();
+            response.subtitles = (np.getTimedTextTrackList() ?? [])
+                .map((track: any) => dataForTrack(track, urlsByTrackId))
                 .filter((data: VideoDataSubtitleTrack | undefined) => data !== undefined);
             return response;
         };
@@ -214,21 +243,18 @@ export default defineUnlistedScript(() => {
             try {
                 const event = e as CustomEvent;
                 const language = event.detail as string;
-                const storedTracks = subTracks.get(np.getMovieId()) || new Map();
                 const track = np
                     .getTimedTextTrackList()
-                    ?.find((track: any) => dataForTrack(track, storedTracks)?.language === language);
+                    ?.find((track: any) => dataForTrack(track)?.language === language);
 
                 if (track === undefined) {
                     fail();
                     return;
                 }
 
-                const alreadyStoredTrack = storedTracks.get(track.trackId);
-
-                if (alreadyStoredTrack !== undefined && alreadyStoredTrack !== 'lazy') {
-                    // If track is already stored (e.g. from previous request) then
-                    // send response now and early-out
+                if (timedTextUrls().has(track.trackId)) {
+                    // URL is already present in player state (e.g. from a previous request)
+                    // so send the response now and early-out
                     document.dispatchEvent(
                         new CustomEvent('asbplayer-synced-language-data', {
                             detail: await buildResponse(),
@@ -237,15 +263,13 @@ export default defineUnlistedScript(() => {
                     return;
                 }
 
-                // Trigger tracks to be refetched by temporarily setting the text track to the desired language
+                // This track has no URL yet. Temporarily set it as the active text track to
+                // make Netflix fetch one.
                 await np.setTimedTextTrack(track);
                 shouldRevert = true;
 
-                // Wait for the track to appear
-                const succeeded = await poll(() => {
-                    const t = storedTracks.get(track.trackId);
-                    return t !== undefined && t !== 'lazy';
-                });
+                // Wait for the URL to appear in player state
+                const succeeded = await poll(() => timedTextUrls().has(track.trackId));
 
                 if (!succeeded) {
                     fail();
@@ -283,28 +307,6 @@ export default defineUnlistedScript(() => {
             },
             false
         );
-
-        const originalStringify = JSON.stringify;
-        JSON.stringify = function (value) {
-            if ('string' === typeof value?.url && -1 < value.url.search(manifestPattern)) {
-                for (let objectValue of Object.values(value)) {
-                    (objectValue as any)?.profiles?.unshift(webvtt);
-                }
-            }
-
-            // @ts-ignore
-            return originalStringify.apply(this, arguments);
-        };
-
-        const originalParse = JSON.parse;
-        JSON.parse = function () {
-            // @ts-ignore
-            const value = originalParse.apply(this, arguments);
-
-            if (value?.result?.movieId) storeSubTrack(value.result);
-
-            return value;
-        };
 
         Function.prototype.apply = new Proxy(Function.prototype.apply, {
             apply: function (target, originalThis, args) {


### PR DESCRIPTION
### Problem
* asbplayer stopped detecting subtitles on Netflix.
* Netflix furigana readings rendered over the wrong character.

### Cause
* Detection: Netflix now processes the manifest inside its player core rather than on the main thread, so the subtitle track URLs no longer pass through the `window.JSON` hooks the Netflix page script used to collect them, and `buildResponse()` filters out every track. The subtitle files on this path are now IMSC 1.1 (TTML) instead of webvtt.
* Furigana: the ruby tokenization matched the whole run of kanji and kana ending at a reading, so a reading was bound to the preceding characters along with its base. A reading centers over its base, so widening the base drifted the reading onto the wrong character. In `ひろ子`, `こ` belongs to `子` but rendered over `ろ`.

### Fix
* Read subtitle URLs from the most recent player session state instead of the `window.JSON` hooks, walking that state for timed-text URL objects rather than hardcoding the deeper subtitle URL path. Playback controls are unchanged, and lazy per-language fetch is preserved.
* Add a `.nfimsc` IMSC 1.1 parser: tick timestamps against `ttp:tickRate`, `dur`, namespaced elements and attributes, multiple `<div>`s, `tts:ruby` rendered as `base(reading)`, and a finite-timestamp guard. `_parseTtmlTimestamp` gains tick and offset handling and keeps its clock-time behavior for the Amazon Prime Video path.
* Guard the `.dfxp`/`.ttml2` path against non-finite timestamps so the new tick handling in `_parseTtmlTimestamp` cannot leak `NaN` into that path.
* Register the `.nfimsc` extension.
* Fence each ruby base during IMSC parsing so tokenization binds a reading to only its own base instead of the preceding characters, correcting the furigana position.

### Tested
* `yarn verify` passes
* Unit tests cover the `.nfimsc` parser (tick timestamps, `dur`, namespaced markup, multiple `<div>`s, nested spans, ruby on and off, missing tick rate), the `.dfxp`/`.ttml2` finite-timestamp guard, and ruby fencing (a preceded reading binds to its base, a reading containing a closing paren stays literal).
* On live Netflix: track detection, on-demand language loading, ruby rendering with the setting on and off, and furigana sitting over their own base in cases that previously drifted (`田の実`, `ひろ子`).
* Loaded/tested the Chrome and Firefox builds with no issues.

### Additional notes
No cross-site impact expected. The `.nfimsc` parser is Netflix only, and the shared `_parseTtmlTimestamp` change stays backward compatible for the clock-time timestamps the Amazon Prime Video `.dfxp`/`.ttml2` path uses. The ruby fix is gated behind the existing furigana setting and only changes how a reading binds to its base.

One of the test URLs for the #1047 fix was https://www.netflix.com/watch/82122787 . A couple testable timestamps are 4:14 and 14:06.

Fixes #1047
Fixes #1051

- [X] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
