### PR TITLE
Refactor `subtitle-annotations.ts` and fix version mismatch

### DIFF
--- a/common/annotations/dom-annotations.ts
+++ b/common/annotations/dom-annotations.ts
@@ -1,0 +1,60 @@
+export const ASB_TOKEN_CLASS = 'asb-token';
+export const ASB_TOKEN_HIGHLIGHT_CLASS = 'asb-token-highlight';
+export const ASB_READING_CLASS = 'asb-reading';
+export const ASB_FREQUENCY_CLASS = 'asb-frequency';
+export const ASB_PITCH_ACCENT_CLASS = 'asb-pitch-accent';
+export const ASB_PITCH_ACCENT_MORA_CLASS = 'asb-pitch-accent-mora';
+export const ASB_PITCH_ACCENT_MORA_HIGH_CLASS = 'asb-pitch-accent-mora-high';
+export const ASB_PITCH_ACCENT_MORA_LOW_CLASS = 'asb-pitch-accent-mora-low';
+export const ASB_PITCH_ACCENT_LINE_CLASS = 'asb-pitch-accent-line';
+
+export class HoveredToken {
+    private _hoveredElement: HTMLElement | null;
+
+    constructor() {
+        this._hoveredElement = null;
+    }
+
+    handleMouseOver(mouseEvent: MouseEvent): void {
+        if (!(mouseEvent.target instanceof HTMLElement)) return;
+        this._hoveredElement = mouseEvent.target;
+    }
+
+    handleMouseOut(mouseEvent: MouseEvent): void {
+        if (!(mouseEvent.target instanceof HTMLElement) || this._hoveredElement === mouseEvent.target) {
+            this._hoveredElement = null;
+        }
+    }
+
+    parse(): { token: string; track: number } | null {
+        const tokenEl = this._hoveredElement?.closest(`.${ASB_TOKEN_CLASS}`);
+        if (!tokenEl) return null;
+
+        const trackStr = tokenEl.closest('[data-track]')?.getAttribute('data-track');
+        if (!trackStr) return null;
+
+        let token = '';
+        for (const child of tokenEl.childNodes) token += this._extractTokenFromNode(child);
+        token = token.trim();
+        if (!token.length) return null;
+        return { token, track: parseInt(trackStr) };
+    }
+
+    private _extractTokenFromNode(node: Node): string {
+        if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? '';
+        if (node.nodeType !== Node.ELEMENT_NODE) return '';
+
+        let token = '';
+        const el = node as HTMLElement;
+        if (el.tagName === 'RUBY') {
+            for (const child of el.childNodes) {
+                if (child.nodeType === Node.ELEMENT_NODE && (child as HTMLElement).tagName === 'RT') continue;
+                token += this._extractTokenFromNode(child);
+            }
+            return token;
+        }
+
+        for (const child of el.childNodes) token += this._extractTokenFromNode(child);
+        return token;
+    }
+}

--- a/common/annotations/index.ts
+++ b/common/annotations/index.ts
@@ -1,0 +1,4 @@
+export * from './dom-annotations';
+export * from './render-annotations';
+export * from './subtitle-annotations';
+export * from './token-collection';

--- a/common/annotations/render-annotations.ts
+++ b/common/annotations/render-annotations.ts
@@ -1,0 +1,421 @@
+import { Token, Tokenization, TokenReading } from '@project/common';
+import {
+    areDictionaryTracksEqual,
+    DictionaryTrack,
+    dictionaryTrackEnabled,
+    TokenStyling,
+    getEnabledAnnotations,
+    getEnabledAnnotationsForHover,
+    EnabledAnnotations,
+    defaultSettings,
+    shouldUseAnnotation,
+    TokenAnnotationConfigTarget,
+} from '@project/common/settings';
+import {
+    HAS_LETTER_REGEX,
+    iterateOverStringInBlocks,
+    ONLY_ASCII_LETTERS_REGEX,
+    areTokenizationsEqual,
+    isKanaOnly,
+    getKanaMoras,
+    isKanaMoraPitchHigh,
+    isAttachedParticlePitchHigh,
+    PitchAccentContext,
+    clearPitchAccentContext,
+} from '@project/common/util';
+import {
+    ASB_FREQUENCY_CLASS,
+    ASB_PITCH_ACCENT_CLASS,
+    ASB_PITCH_ACCENT_LINE_CLASS,
+    ASB_PITCH_ACCENT_MORA_CLASS,
+    ASB_PITCH_ACCENT_MORA_HIGH_CLASS,
+    ASB_PITCH_ACCENT_MORA_LOW_CLASS,
+    ASB_READING_CLASS,
+    ASB_TOKEN_CLASS,
+    ASB_TOKEN_HIGHLIGHT_CLASS,
+} from '@project/common/annotations';
+
+export const ANNOTATIONS_VIDEO_RENDER_BEHIND_MS = 15000; // Seeking backwards is usually 5-10s
+export const ANNOTATIONS_VIDEO_RENDER_AHEAD_MS = 60000; // Seeking forward is usually 5-30s
+
+export interface InternalToken extends Token {
+    __internal?: boolean;
+}
+
+export const getAnnotationsHtml = (text: string, richText: string | undefined, richTextOnHover: string | undefined) => {
+    if (!richTextOnHover) return richText ?? text;
+    return `<span class="asbplayer-subtitle-text">${richText ?? text}</span><span class="asbplayer-subtitle-rich">${richTextOnHover}</span>`;
+};
+
+export const getAnnotationsForRender = (dt: DictionaryTrack, target: TokenAnnotationConfigTarget) => {
+    const enabledAnnotations = getEnabledAnnotations(dt);
+    const enabledAnnotationsUnhover = getEnabledAnnotationsForHover(enabledAnnotations, dt, target, false);
+    const enabledAnnotationsHover = getEnabledAnnotationsForHover(enabledAnnotations, dt, target, true);
+    return {
+        dt,
+        isRichTextEnabled: Object.values(enabledAnnotationsUnhover).some((v) => v),
+        richTextEnabledAnnotations: enabledAnnotationsUnhover, // Hide annotations configured to appear only on hover
+        isRichTextOnHoverEnabled: Object.values(enabledAnnotationsHover).some((v) => v),
+        richTextOnHoverEnabledAnnotations: enabledAnnotations, // Show all enabled annotations on hover
+    };
+};
+
+export interface RenderedRichText {
+    richText?: string;
+    richTextOnHover?: string;
+}
+
+interface CachedRenderedRichText extends RenderedRichText {
+    text: string;
+    tokenization?: Tokenization;
+    tokenAnnotationTarget: TokenAnnotationConfigTarget;
+    dictionaryTracks?: DictionaryTrack[];
+}
+
+const cachedRichTextIsCurrent = (
+    cached: CachedRenderedRichText,
+    subtitle: RichTextRenderable,
+    tokenAnnotationTarget: TokenAnnotationConfigTarget,
+    dictionaryTracks: DictionaryTrack[] | undefined
+) =>
+    cached.text === subtitle.text &&
+    areTokenizationsEqual(cached.tokenization, subtitle.tokenization) &&
+    cached.tokenAnnotationTarget === tokenAnnotationTarget &&
+    cached.dictionaryTracks?.every((dt, i) => areDictionaryTracksEqual(dt, dictionaryTracks?.[i]));
+
+interface IndexRange {
+    min: number;
+    max: number;
+}
+
+export interface RichTextWindow {
+    range?: IndexRange;
+    buffer: Map<number, CachedRenderedRichText>;
+}
+
+export const emptyRichTextWindow = (): RichTextWindow => ({ buffer: new Map() });
+
+interface RichTextRenderable {
+    index: number;
+    text: string;
+    track: number;
+    tokenization?: Tokenization;
+}
+
+export const renderRichTextOntoSubtitles = (
+    subtitles: RichTextRenderable[],
+    tokenAnnotationTarget: TokenAnnotationConfigTarget,
+    dictionaryTracks: DictionaryTrack[] | undefined
+): Map<number, RenderedRichText> => {
+    const rendered = new Map<number, RenderedRichText>();
+    if (dictionaryTracks?.length !== defaultSettings.dictionaryTracks.length) return rendered;
+
+    const trackAnnotations = dictionaryTracks.map((dt) => getAnnotationsForRender(dt, tokenAnnotationTarget));
+    const allowAsciiReading = false; // Allowing is only for preview purposes for status names to show reading
+
+    for (const subtitle of subtitles) {
+        if (!subtitle.tokenization) continue;
+        const ta = trackAnnotations[subtitle.track];
+        const hasExternalReading = subtitle.tokenization.tokens.some(
+            (token) => !(token as InternalToken).__internal && token.readings.length > 0
+        ); // Display external readings even if no annotations are enabled, unnecessary for richTextOnHover
+
+        const richText =
+            ta.isRichTextEnabled || hasExternalReading
+                ? computeRichText(subtitle.text, subtitle.tokenization, {
+                      dt: ta.dt,
+                      enabledAnnotations: ta.richTextEnabledAnnotations,
+                      allowAsciiReading,
+                  })
+                : undefined;
+        const richTextOnHover = ta.isRichTextOnHoverEnabled
+            ? computeRichText(subtitle.text, subtitle.tokenization, {
+                  dt: ta.dt,
+                  enabledAnnotations: ta.richTextOnHoverEnabledAnnotations,
+                  allowAsciiReading,
+              })
+            : undefined;
+
+        if (richText !== undefined || richTextOnHover !== undefined) {
+            rendered.set(subtitle.index, { richText, richTextOnHover });
+        }
+    }
+
+    return rendered;
+};
+
+export const renderRichTextWindow = (
+    prev: RichTextWindow,
+    windowSubtitles: RichTextRenderable[],
+    tokenAnnotationTarget: TokenAnnotationConfigTarget,
+    dictionaryTracks: DictionaryTrack[] | undefined
+): RichTextWindow => {
+    if (!windowSubtitles.length) return emptyRichTextWindow();
+    const windowSubtitleIndexes = windowSubtitles.map((s) => s.index);
+    const range: IndexRange = { min: Math.min(...windowSubtitleIndexes), max: Math.max(...windowSubtitleIndexes) };
+    const buffer = new Map<number, CachedRenderedRichText>();
+
+    const toRender: RichTextRenderable[] = [];
+    for (const subtitle of windowSubtitles) {
+        if (prev.range && subtitle.index >= prev.range.min && subtitle.index <= prev.range.max) {
+            const reused = prev.buffer.get(subtitle.index);
+            if (reused && cachedRichTextIsCurrent(reused, subtitle, tokenAnnotationTarget, dictionaryTracks)) {
+                buffer.set(subtitle.index, reused);
+                continue;
+            }
+        }
+        toRender.push(subtitle);
+    }
+    if (toRender.length) {
+        const rendered = renderRichTextOntoSubtitles(toRender, tokenAnnotationTarget, dictionaryTracks);
+        for (const subtitle of toRender) {
+            const value = rendered.get(subtitle.index);
+            buffer.set(subtitle.index, {
+                ...value,
+                text: subtitle.text,
+                tokenization: subtitle.tokenization,
+                tokenAnnotationTarget,
+                dictionaryTracks,
+            });
+        }
+    }
+
+    return { range, buffer };
+};
+
+export const renderRichTextForSubtitle = (
+    window: RichTextWindow,
+    subtitle: RichTextRenderable,
+    tokenAnnotationTarget: TokenAnnotationConfigTarget,
+    dictionaryTracks: DictionaryTrack[] | undefined
+): RenderedRichText | undefined => {
+    const cached = window.buffer.get(subtitle.index);
+    if (cached && cachedRichTextIsCurrent(cached, subtitle, tokenAnnotationTarget, dictionaryTracks)) return cached;
+
+    const rendered = renderRichTextOntoSubtitles([subtitle], tokenAnnotationTarget, dictionaryTracks).get(
+        subtitle.index
+    );
+    window.buffer.set(subtitle.index, {
+        ...rendered,
+        text: subtitle.text,
+        tokenization: subtitle.tokenization,
+        tokenAnnotationTarget,
+        dictionaryTracks,
+    });
+    return rendered;
+};
+
+interface TokenStyleState {
+    dt: DictionaryTrack;
+    enabledAnnotations: EnabledAnnotations;
+    allowAsciiReading: boolean;
+}
+
+export const computeRichText = (fullText: string, tokenization: Tokenization, ss: TokenStyleState) => {
+    if (tokenization.error) return `<span ${ERROR_STYLE}>${fullText}</span>`;
+    if (!tokenization.tokens.length) return;
+
+    const parts: string[] = [];
+    const prevPitch: PitchAccentContext = {}; // Context from the previous token to correctly determine pitch for attached particle
+    iterateOverStringInBlocks(
+        fullText,
+        (_, blockIndex) => tokenization.tokens[blockIndex],
+        (left, right, token?: Token) => {
+            if (token === undefined) {
+                clearPitchAccentContext(prevPitch);
+                parts.push(fullText.substring(left, right));
+            } else {
+                parts.push(applyTokenStyle(fullText, token, prevPitch, ss));
+            }
+        }
+    );
+    return parts.join('');
+};
+
+const ERROR_STYLE = `style="text-decoration: line-through red 3px;"`;
+const LOGIC_ERROR_STYLE = `style="text-decoration: line-through red 3px double;"`;
+
+const applyTokenStyle = (fullText: string, token: Token, prevPitch: PitchAccentContext, ss: TokenStyleState) => {
+    const rawTokenText = fullText.substring(token.pos[0], token.pos[1]);
+    if (!HAS_LETTER_REGEX.test(rawTokenText)) {
+        clearPitchAccentContext(prevPitch);
+        return rawTokenText;
+    }
+    const tokenText = applyFrequencyAnnotation(applyReadingAnnotation(rawTokenText, token, prevPitch, ss), token, ss);
+    if (token.status === null) return `<span ${ERROR_STYLE}>${tokenText}</span>`;
+    if (token.status === undefined && dictionaryTrackEnabled(ss.dt))
+        return `<span ${LOGIC_ERROR_STYLE}>${tokenText}</span>`; // External tokens may flash this on initial load
+    if (!ss.enabledAnnotations.color) return tokenText;
+
+    const s = `<span class="${ASB_TOKEN_CLASS}${ss.dt.dictionaryHighlightOnHover ? ` ${ASB_TOKEN_HIGHLIGHT_CLASS}` : ''}"`; // Only allow collection and highlighting if colors is enabled so that user has feedback
+    const config = ss.dt.dictionaryTokenStatusConfig[token.status!];
+    if (!config.display) return `${s}>${tokenText}</span>`;
+    if (
+        token.pitchAccent != null &&
+        ss.enabledAnnotations.pitchAccent &&
+        (!token.readings.length ||
+            (ss.enabledAnnotations.reading && shouldUseAnnotation('reading', token.status!, token.states, ss.dt)))
+    ) {
+        return `${s}>${tokenText}</span>`; // Colorize the pitch accent annotation only when being shown
+    }
+
+    const c = `${config.color}${config.alpha}`;
+    const t = ss.dt.dictionaryTokenStylingThickness;
+    switch (ss.dt.dictionaryTokenStyling) {
+        case TokenStyling.TEXT:
+            return `${s} style="-webkit-text-fill-color: ${c};">${tokenText}</span>`;
+        case TokenStyling.BACKGROUND:
+            return `${s} style="background-color: ${c};">${tokenText}</span>`;
+        case TokenStyling.UNDERLINE:
+        case TokenStyling.OVERLINE:
+            return `${s} style="text-decoration: ${ss.dt.dictionaryTokenStyling} ${c} ${t}px;">${tokenText}</span>`;
+        case TokenStyling.OUTLINE:
+            return `${s} style="-webkit-text-stroke: ${t}px ${c};">${tokenText}</span>`;
+        default:
+            return `${s} ${LOGIC_ERROR_STYLE}>${tokenText}</span>`;
+    }
+};
+
+const applyReadingAnnotation = (
+    tokenText: string,
+    token: Token,
+    prevPitch: PitchAccentContext,
+    ss: TokenStyleState
+) => {
+    if (ONLY_ASCII_LETTERS_REGEX.test(tokenText) && !ss.allowAsciiReading) {
+        clearPitchAccentContext(prevPitch);
+        return tokenText; // Prevent english words from getting readings
+    }
+    if (!token.readings.length) {
+        if (isKanaOnly(tokenText)) return applyPitchAccentAnnotation(tokenText, token, prevPitch, ss, tokenText);
+        clearPitchAccentContext(prevPitch);
+        return tokenText;
+    }
+
+    // Only apply skip logic for tokens generated by this class i.e. marked __internal: true
+    if ((token as InternalToken).__internal) {
+        if (!ss.enabledAnnotations.reading) {
+            clearPitchAccentContext(prevPitch);
+            return tokenText;
+        }
+        if (token.status == null || !shouldUseAnnotation('reading', token.status, token.states, ss.dt)) {
+            clearPitchAccentContext(prevPitch);
+            return tokenText;
+        }
+    }
+
+    // We want to use a single reading for the entire token if we're applying pitch accent annotations.
+    // e.g. 飛び切り readings would be `と き ` so make it contiguous as `とびきり` so connecting and reading pitch is easier
+    const tokenForDisplay = { ...token };
+    if (token.pitchAccent != null && ss.enabledAnnotations.pitchAccent) {
+        tokenForDisplay.readings = [{ pos: [0, tokenText.length], reading: '' }];
+        iterateOverStringInBlocks(
+            tokenText,
+            (_, blockIndex) => token.readings[blockIndex],
+            (left, right, reading?: TokenReading) => {
+                if (reading === undefined) tokenForDisplay.readings[0].reading += tokenText.substring(left, right);
+                else tokenForDisplay.readings[0].reading += reading.reading;
+            }
+        );
+    }
+
+    const parts: string[] = [];
+    iterateOverStringInBlocks(
+        tokenText,
+        (_, blockIndex) => tokenForDisplay.readings[blockIndex],
+        (left, right, reading?: TokenReading) => {
+            if (reading === undefined) {
+                parts.push(tokenText.substring(left, right));
+            } else {
+                const part = tokenText.substring(reading.pos[0], reading.pos[1]);
+                const readingText = applyPitchAccentAnnotation(reading.reading, tokenForDisplay, prevPitch, ss);
+                parts.push(`<ruby class="${ASB_READING_CLASS}">${part}<rt>${readingText}</rt></ruby>`);
+            }
+        }
+    );
+    return parts.join('');
+};
+
+const applyPitchAccentAnnotation = (
+    readingText: string,
+    token: Token,
+    prevPitch: PitchAccentContext,
+    ss: TokenStyleState,
+    attachedParticleCandidateText?: string
+) => {
+    if (!ss.enabledAnnotations.pitchAccent) {
+        clearPitchAccentContext(prevPitch);
+        return readingText;
+    }
+    if (!HAS_LETTER_REGEX.test(readingText)) {
+        clearPitchAccentContext(prevPitch);
+        return readingText;
+    }
+
+    const pitchAccentColor = () => {
+        if (token.status == null || !ss.enabledAnnotations.color) return 'currentColor';
+        const config = ss.dt.dictionaryTokenStatusConfig[token.status];
+        if (!config.display) return 'currentColor';
+        return `${config.color}${config.alpha}`;
+    };
+
+    if (prevPitch.prevMoras !== undefined && prevPitch.prevPitchAccent !== undefined) {
+        const pitchHigh = isAttachedParticlePitchHigh(attachedParticleCandidateText, prevPitch);
+        if (pitchHigh !== null) {
+            prevPitch.prevMoras = undefined;
+            prevPitch.prevPitchAccent = undefined;
+            const html = pitchAccentHtml(getKanaMoras(readingText), pitchAccentColor(), () => pitchHigh, prevPitch);
+            prevPitch.prevPitchHigh = undefined; // Draw vertical line for attached particles if pitched changed from previous token
+            return html;
+        }
+    }
+
+    if (token.pitchAccent == null) {
+        clearPitchAccentContext(prevPitch);
+        return readingText;
+    }
+
+    const moras = getKanaMoras(readingText);
+    prevPitch.prevMoras = moras;
+    prevPitch.prevPitchAccent = token.pitchAccent;
+    prevPitch.prevPitchHigh = undefined; // Only attached particles care about the change from the previous pitch
+    const html = pitchAccentHtml(
+        moras,
+        pitchAccentColor(),
+        (i) => isKanaMoraPitchHigh(i, token.pitchAccent!),
+        prevPitch
+    );
+    if (!attachedParticleCandidateText) prevPitch.prevPitchHigh = undefined; // For furigana we don't want the vertical line since it won't be connected to the particle
+    return html;
+};
+
+const pitchAccentHtml = (
+    moras: string[],
+    color: string,
+    pitchHigh: (index: number) => boolean,
+    prevPitch: PitchAccentContext
+) => {
+    const parts: string[] = [];
+    let prevHigh = prevPitch.prevPitchHigh;
+    for (let i = 0; i < moras.length; i++) {
+        const high = pitchHigh(i);
+        if (prevHigh !== undefined && prevHigh !== high) {
+            parts.push(`<span class="${ASB_PITCH_ACCENT_LINE_CLASS}"></span>`);
+        }
+        prevHigh = high;
+        parts.push(
+            `<span class="${ASB_PITCH_ACCENT_MORA_CLASS} ${
+                high ? ASB_PITCH_ACCENT_MORA_HIGH_CLASS : ASB_PITCH_ACCENT_MORA_LOW_CLASS
+            }">${moras[i]}</span>`
+        );
+    }
+    prevPitch.prevPitchHigh = prevHigh;
+    return `<span class="${ASB_PITCH_ACCENT_CLASS}" style="--asb-pitch-accent-color: ${color};">${parts.join('')}</span>`;
+};
+
+const applyFrequencyAnnotation = (tokenText: string, token: Token, ss: TokenStyleState) => {
+    if (!ss.enabledAnnotations.frequency) return tokenText;
+    if (token.frequency == null) return tokenText;
+    if (token.status == null || !shouldUseAnnotation('frequency', token.status, token.states, ss.dt)) return tokenText;
+    return `<ruby class="${ASB_FREQUENCY_CLASS}">${tokenText}<rt>${token.frequency}</rt></ruby>`;
+};

--- a/common/annotations/subtitle-annotations.ts
+++ b/common/annotations/subtitle-annotations.ts
@@ -1450,6 +1450,7 @@ export class SubtitleAnnotations extends SubtitleCollection<IndexedSubtitleModel
 
     private async _updatePitchAccent(token: Token, trimmedToken: string, index: number, ts: TrackState): Promise<void> {
         if (!ts.yt) throw new Error('Yomitan uninitialized - cannot update token pitch accent');
+        // TODO: Move this check to applyPitchAccentAnnotation() once pitch accent from tokenize is released
         if (token.status == null || !shouldUseAnnotation('pitchAccent', token.status, token.states, ts.dt)) return;
         if ((this.initialized && !this.generateStatisticsRequested) || ts.yt.getSupportsBulkPitchAccent()) {
             token.pitchAccent = await ts.yt.pitchAccent(trimmedToken);

--- a/common/annotations/subtitle-annotations.ts
+++ b/common/annotations/subtitle-annotations.ts
@@ -1129,6 +1129,7 @@ export class SubtitleAnnotations extends SubtitleCollection<IndexedSubtitleModel
             try {
                 if (!ts.yt) continue;
                 const tokenizeBulkRes = await ts.yt.tokenizeBulk(texts);
+                // TODO: Remove this block once pitch accent from tokenize is released
                 if (
                     (ts.dt.dictionaryTokenAnnotationConfig.onStatuses.some((l) => l.pitchAccent) ||
                         ts.dt.dictionaryTokenAnnotationConfig.onStates.some((l) => l.pitchAccent)) &&

--- a/common/annotations/subtitle-annotations.ts
+++ b/common/annotations/subtitle-annotations.ts
@@ -23,25 +23,14 @@ import {
     DictionaryTokenSource,
     DictionaryTrack,
     dictionaryTrackEnabled,
-    dictionaryTokenSourcePriority,
-    externalWordSourcePriority,
     getFullyKnownTokenStatus,
-    isExternalWordSource,
     SettingsProvider,
     TokenMatchStrategy,
-    TokenMatchStrategyPriority,
     TokenState,
     TokenStatus,
-    TokenStyling,
-    isWordSource,
-    getEnabledAnnotations,
-    getEnabledAnnotationsForHover,
-    EnabledAnnotations,
-    defaultSettings,
     shouldUseAnnotation,
-    TokenAnnotationConfigTarget,
 } from '@project/common/settings';
-import { TokenStatusInfo, DictionaryProvider, LemmaResults, TokenResults } from '@project/common/dictionary-db';
+import { DictionaryProvider, LemmaResults, TokenResults } from '@project/common/dictionary-db';
 import {
     DictionaryStatistics,
     DictionaryStatisticsAnkiDueCardsSnapshot,
@@ -55,19 +44,12 @@ import {
     HAS_LETTER_REGEX,
     inBatches,
     iterateOverStringInBlocks,
-    ONLY_ASCII_LETTERS_REGEX,
     areTokenizationsEqual,
-    getTokenStatus,
-    dedupeTokenStatusInfos,
     isKanaOnly,
-    getKanaMoras,
-    isKanaMoraPitchHigh,
     normalizeToken,
-    isAttachedParticlePitchHigh,
-    PitchAccentContext,
-    clearPitchAccentContext,
 } from '@project/common/util';
-import { Yomitan } from '@project/common/yomitan/yomitan';
+import { Yomitan } from '@project/common/yomitan';
+import { InternalToken, resolveTokenStatus, TokenCollection, TokenCollectionArray } from '@project/common/annotations';
 
 const TOKEN_CACHE_BUILD_AHEAD_INIT = 10;
 const TOKEN_CACHE_BUILD_AHEAD = 100;
@@ -80,20 +62,10 @@ const YOMITAN_RETRY_DELAY = 10000;
 const ANKI_REFRESH_INTERVAL = 10000; // We need to poll in-case the user mines to Anki outside of asbplayer (e.g directly from Yomitan), local requests so no rate concerns
 const WANIKANI_REFRESH_INTERVAL = 10000; // Only until the first successful refresh since users can't mine to it and it's an external server
 
-const ASB_TOKEN_CLASS = 'asb-token';
-const ASB_TOKEN_HIGHLIGHT_CLASS = 'asb-token-highlight';
-const ASB_READING_CLASS = 'asb-reading';
-const ASB_FREQUENCY_CLASS = 'asb-frequency';
-const ASB_PITCH_ACCENT_CLASS = 'asb-pitch-accent';
-const ASB_PITCH_ACCENT_MORA_CLASS = 'asb-pitch-accent-mora';
-const ASB_PITCH_ACCENT_MORA_HIGH_CLASS = 'asb-pitch-accent-mora-high';
-const ASB_PITCH_ACCENT_MORA_LOW_CLASS = 'asb-pitch-accent-mora-low';
-const ASB_PITCH_ACCENT_LINE_CLASS = 'asb-pitch-accent-line';
-
 /**
  * Contains all information specific to a track
  */
-class TrackState {
+export class TrackState {
     readonly track: number;
     readonly dt: DictionaryTrack;
     readonly yt: Yomitan | undefined;
@@ -109,15 +81,38 @@ class TrackState {
         this.dt = dt;
         this.yt = undefined;
         this.ytLastResetAt = 0;
-        this.tokenCollectionExact = new TokenCollection(this, TokenMatchStrategy.EXACT_FORM_COLLECTED);
-        this.tokenCollectionLemma = new TokenCollection(this, TokenMatchStrategy.LEMMA_FORM_COLLECTED);
-        this.tokenCollectionAny = new TokenCollectionArray(this, TokenMatchStrategy.ANY_FORM_COLLECTED);
         this.tokenStates = new Map();
         this.indexTokenOccurrences = new Map();
+
+        /**
+         * The logic will need to be revisited if new states are added.
+         * It also currently relies on the fact that only local tokens can have states.
+         */
+        const updateTokenStates = (normalizedToken: string, states: TokenState[]) => {
+            if (!states.length) return;
+            const existingStates = this.tokenStates.get(normalizedToken);
+            if (!existingStates) {
+                this.tokenStates.set(normalizedToken, states);
+                return;
+            }
+            for (const state of states) {
+                if (!existingStates.includes(state)) existingStates.push(state);
+            }
+        };
+        this.tokenCollectionExact = new TokenCollection(TokenMatchStrategy.EXACT_FORM_COLLECTED, dt, updateTokenStates);
+        this.tokenCollectionLemma = new TokenCollection(TokenMatchStrategy.LEMMA_FORM_COLLECTED, dt, updateTokenStates);
+        this.tokenCollectionAny = new TokenCollectionArray(
+            TokenMatchStrategy.ANY_FORM_COLLECTED,
+            dt,
+            updateTokenStates
+        );
     }
 
     updateDictionaryTrack(dt: DictionaryTrack) {
         (this.dt as DictionaryTrack) = dt;
+        this.tokenCollectionExact.updateDictionaryTrack(dt);
+        this.tokenCollectionLemma.updateDictionaryTrack(dt);
+        this.tokenCollectionAny.updateDictionaryTrack(dt);
     }
 
     updateYomitan(yt: Yomitan | undefined) {
@@ -129,22 +124,6 @@ class TrackState {
         if (!this.yt) return;
         this.yt.resetCache();
         this.updateYomitan(undefined);
-    }
-
-    /**
-     * The logic will need to be revisited if new states are added.
-     * It also currently relies on the fact that only local tokens can have states.
-     */
-    updateTokenStates(normalizedToken: string, states: TokenState[]): void {
-        if (!states.length) return;
-        const existingStates = this.tokenStates.get(normalizedToken);
-        if (!existingStates) {
-            this.tokenStates.set(normalizedToken, states);
-            return;
-        }
-        for (const state of states) {
-            if (!existingStates.includes(state)) existingStates.push(state);
-        }
     }
 
     /**
@@ -195,285 +174,6 @@ class TrackState {
 
         return { groupingKey, lemmasGroupingKey };
     }
-}
-
-/**
- * The processed data from the db.
- */
-interface TokenStatusResult {
-    status: TokenStatus;
-    source: DictionaryTokenSource;
-    normalizedToken?: string; // For ANY_FORM_COLLECTED to prefer exact, then lemma, then any form.
-    externalCandidateStatuses?: TokenStatusInfo[];
-}
-
-/**
- * The final status after applying strategies.
- */
-interface ResolvedTokenStatusResult {
-    status: TokenStatus;
-    source?: DictionaryTokenSource;
-    externalCandidateStatuses?: TokenStatusInfo[];
-}
-
-/**
- * Contains the tokens from the db depending on strategy configured.
- */
-class TokenCollectionBase<T = TokenStatusResult | TokenStatusResult[]> {
-    protected readonly collection: Map<string, T>;
-    protected readonly ts: TrackState;
-    readonly enabled: boolean;
-    readonly wordEnabled: boolean;
-    readonly sentenceEnabled: boolean;
-
-    constructor(
-        ts: TrackState,
-        classType:
-            | TokenMatchStrategy.EXACT_FORM_COLLECTED
-            | TokenMatchStrategy.LEMMA_FORM_COLLECTED
-            | TokenMatchStrategy.ANY_FORM_COLLECTED
-    ) {
-        this.collection = new Map();
-        this.ts = ts;
-        switch (classType) {
-            case TokenMatchStrategy.EXACT_FORM_COLLECTED:
-                this.wordEnabled =
-                    ts.dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.EXACT_FORM_COLLECTED ||
-                    ts.dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
-                this.sentenceEnabled =
-                    ts.dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.EXACT_FORM_COLLECTED ||
-                    ts.dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
-                break;
-            case TokenMatchStrategy.LEMMA_FORM_COLLECTED:
-                this.wordEnabled =
-                    ts.dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.LEMMA_FORM_COLLECTED ||
-                    ts.dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
-                this.sentenceEnabled =
-                    ts.dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.LEMMA_FORM_COLLECTED ||
-                    ts.dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
-                break;
-            case TokenMatchStrategy.ANY_FORM_COLLECTED:
-                this.wordEnabled = ts.dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.ANY_FORM_COLLECTED;
-                this.sentenceEnabled =
-                    ts.dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.ANY_FORM_COLLECTED;
-                break;
-            default:
-                throw new Error(`Unsupported TokenMatchStrategy: ${classType}`);
-        }
-        this.enabled = this.wordEnabled || this.sentenceEnabled;
-    }
-
-    get(normalizedKey: string): T | undefined {
-        return this.collection.get(normalizedKey);
-    }
-
-    delete(normalizedKey: string): boolean {
-        return this.collection.delete(normalizedKey);
-    }
-
-    addQuery(queryMap: Map<string, string[]>, key: string): void {
-        const normalizedKey = normalizeToken(key);
-        const queries = queryMap.get(normalizedKey);
-        if (queries) {
-            if (!queries.includes(key)) queries.push(key); // Send all original forms for backwards compatibility with older extension db lookups
-            return;
-        }
-        if (!this.collection.has(normalizedKey)) queryMap.set(normalizedKey, [key]);
-    }
-
-    getAllQueries(queryMap: Map<string, string[]>): string[] {
-        return Array.from(queryMap.values()).flat();
-    }
-
-    protected tokenStatusResult(
-        statuses: TokenStatusInfo[],
-        source: DictionaryTokenSource,
-        externalCandidateStatuses?: TokenStatusInfo[],
-        normalizedToken?: string
-    ): TokenStatusResult {
-        const candidateStatuses = externalCandidateStatuses ?? statuses;
-        return {
-            status: getTokenStatus(statuses, this.ts.dt.dictionaryAnkiTreatSuspended),
-            source,
-            normalizedToken,
-            externalCandidateStatuses: candidateStatuses.length ? candidateStatuses : undefined,
-        };
-    }
-
-    private compareTokenStatusResults(left: TokenStatusResult, right: TokenStatusResult): number {
-        const sourcePriority = dictionaryTokenSourcePriority(left.source) - dictionaryTokenSourcePriority(right.source);
-        if (sourcePriority !== 0) return sourcePriority;
-        const statusPriority = left.status - right.status;
-        if (statusPriority !== 0) return statusPriority;
-        if (isExternalWordSource(left.source) && isExternalWordSource(right.source)) {
-            return externalWordSourcePriority(left.source) - externalWordSourcePriority(right.source);
-        }
-        return 0;
-    }
-
-    protected mergeTokenStatusResults(left: TokenStatusResult, right: TokenStatusResult): TokenStatusResult {
-        return {
-            ...(this.compareTokenStatusResults(left, right) >= 0 ? left : right),
-            externalCandidateStatuses: dedupeTokenStatusInfos([
-                ...(left.externalCandidateStatuses ?? []),
-                ...(right.externalCandidateStatuses ?? []),
-            ]),
-        };
-    }
-
-    static resolveTokenStatusResults(
-        tokenStatusResults: TokenStatusResult[],
-        cmp: (tokenStatuses: TokenStatus[]) => TokenStatus = (tokenStatuses) => Math.max(...tokenStatuses)
-    ): ResolvedTokenStatusResult {
-        const status = cmp(tokenStatusResults.map((result) => result.status));
-        const selectedResult = tokenStatusResults.find((result) => result.status === status)!;
-        return {
-            status: selectedResult.status,
-            source: selectedResult.source,
-            externalCandidateStatuses: dedupeTokenStatusInfos(
-                tokenStatusResults.flatMap((result) => result.externalCandidateStatuses ?? [])
-            ),
-        };
-    }
-}
-
-class TokenCollection extends TokenCollectionBase<TokenStatusResult> {
-    add(
-        statuses: TokenStatusInfo[],
-        source: DictionaryTokenSource,
-        externalCandidateStatuses: TokenStatusInfo[] | undefined,
-        key: string,
-        states: TokenState[]
-    ): void {
-        const normalizedKey = normalizeToken(key);
-        this.ts.updateTokenStates(normalizedKey, states);
-        const statusResult = this.tokenStatusResult(statuses, source, externalCandidateStatuses);
-        const existing = this.collection.get(normalizedKey);
-        this.collection.set(
-            normalizedKey,
-            existing ? super.mergeTokenStatusResults(existing, statusResult) : statusResult
-        );
-    }
-
-    private resolve(
-        normalizedTokens: string[],
-        sourceMatches: (source: DictionaryTokenSource) => boolean
-    ): TokenStatusResult[] {
-        const statusResults: TokenStatusResult[] = [];
-        for (const normalizedToken of normalizedTokens) {
-            const statusResult = this.collection.get(normalizedToken);
-            if (statusResult && sourceMatches(statusResult.source)) statusResults.push(statusResult);
-        }
-        return statusResults;
-    }
-
-    resolveForWord(normalizedTokens: string[]): TokenStatusResult[] {
-        if (!this.wordEnabled) return [];
-        return this.resolve(normalizedTokens, (source) => isWordSource(source));
-    }
-
-    resolveForSentence(normalizedTokens: string[]): TokenStatusResult[] {
-        if (!this.sentenceEnabled) return [];
-        return this.resolve(normalizedTokens, (source) => !isWordSource(source));
-    }
-}
-
-class TokenCollectionArray extends TokenCollectionBase<TokenStatusResult[]> {
-    add(
-        statuses: TokenStatusInfo[],
-        source: DictionaryTokenSource,
-        externalCandidateStatuses: TokenStatusInfo[] | undefined,
-        normalizedKey: string,
-        states: TokenState[],
-        token: string
-    ): void {
-        const normalizedToken = normalizeToken(token);
-        this.ts.updateTokenStates(normalizedToken, states);
-        const statusResult = this.tokenStatusResult(statuses, source, externalCandidateStatuses, normalizedToken);
-        const statusResults = this.collection.get(normalizedKey);
-        if (!statusResults) {
-            this.collection.set(normalizedKey, [statusResult]);
-            return;
-        }
-        const duplicateIndex = statusResults.findIndex((r) => r.normalizedToken === statusResult.normalizedToken);
-        if (duplicateIndex === -1) {
-            statusResults.push(statusResult);
-        } else {
-            statusResults[duplicateIndex] = super.mergeTokenStatusResults(statusResults[duplicateIndex], statusResult);
-        }
-    }
-
-    /**
-     * Need to check ANY_FORM_COLLECTED results against dictionaryMatchAcrossScripts explicitly since we never checked
-     * the token, only the lemmas. EXACT_FORM_COLLECTED and LEMMA_FORM_COLLECTED looks for an exact match with either the
-     * surface form or lemma form so they don't need this extra filtering.
-     */
-    private getStatusResults(
-        normalizedToken: string,
-        normalizedLemmas: string[],
-        sourceMatches: (source: DictionaryTokenSource) => boolean
-    ): TokenStatusResult[] {
-        const tokenIsKanaOnly = isKanaOnly(normalizedToken);
-        const anyFormStatusResults: TokenStatusResult[] = [];
-        for (const normalizedLemma of normalizedLemmas) {
-            const statusResults = this.collection.get(normalizedLemma);
-            if (!statusResults) continue;
-            for (const statusResult of statusResults) {
-                if (!sourceMatches(statusResult.source)) continue;
-                const collectedTokenIsKanaOnly = isKanaOnly(statusResult.normalizedToken!);
-                if (this.ts.dt.dictionaryMatchAcrossScripts) {
-                    if (tokenIsKanaOnly || !collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
-                } else {
-                    if (tokenIsKanaOnly === collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
-                }
-            }
-        }
-        return anyFormStatusResults;
-    }
-
-    private tokenMatchesKey(normalizedToken: string, normalizedKey: string): boolean {
-        return normalizedToken === normalizedKey;
-    }
-
-    private tokenMatchesAnyKey(normalizedToken: string, normalizedKeys: string[]): boolean {
-        return normalizedKeys.some((normalizedKey) => this.tokenMatchesKey(normalizedToken, normalizedKey));
-    }
-
-    private resolve(
-        normalizedToken: string,
-        lemmas: string[],
-        sourceMatches: (source: DictionaryTokenSource) => boolean,
-        exactPriority: boolean | null
-    ): TokenStatusResult[] {
-        const statusResults = this.getStatusResults(normalizedToken, lemmas, sourceMatches);
-        if (!statusResults.length || exactPriority === null) return statusResults;
-        if (exactPriority === true) {
-            const exactMatches = statusResults.filter((r) => this.tokenMatchesKey(r.normalizedToken!, normalizedToken));
-            if (exactMatches.length) return exactMatches;
-            const lemmaMatches = statusResults.filter((r) => this.tokenMatchesAnyKey(r.normalizedToken!, lemmas));
-            if (lemmaMatches.length) return lemmaMatches;
-        } else if (exactPriority === false) {
-            const lemmaMatches = statusResults.filter((r) => this.tokenMatchesAnyKey(r.normalizedToken!, lemmas));
-            if (lemmaMatches.length) return lemmaMatches;
-            const exactMatches = statusResults.filter((r) => this.tokenMatchesKey(r.normalizedToken!, normalizedToken));
-            if (exactMatches.length) return exactMatches;
-        }
-        return statusResults;
-    }
-
-    resolveForWord(normalizedToken: string, lemmas: string[], exactPriority: boolean | null): TokenStatusResult[] {
-        if (!this.wordEnabled) return [];
-        return this.resolve(normalizedToken, lemmas, (source) => isWordSource(source), exactPriority);
-    }
-
-    resolveForSentence(normalizedToken: string, lemmas: string[], exactPriority: boolean | null): TokenStatusResult[] {
-        if (!this.sentenceEnabled) return [];
-        return this.resolve(normalizedToken, lemmas, (source) => !isWordSource(source), exactPriority);
-    }
-}
-
-export interface InternalToken extends Token {
-    __internal?: boolean;
 }
 
 interface InternalSubtitleModel extends TokenizedSubtitleModel {
@@ -1604,7 +1304,7 @@ export class SubtitleAnnotations extends SubtitleCollection<IndexedSubtitleModel
                         const tokenStatusResult =
                             states.includes(TokenState.IGNORED) || !HAS_LETTER_REGEX.test(trimmedToken)
                                 ? { status: getFullyKnownTokenStatus() }
-                                : ((await this._tokenStatus(trimmedToken, normalizedToken, ts)) ?? { status: null });
+                                : ((await resolveTokenStatus(trimmedToken, normalizedToken, ts)) ?? { status: null });
                         const status = tokenStatusResult.status;
                         const source = 'source' in tokenStatusResult ? tokenStatusResult.source : undefined;
                         const token: Token = {
@@ -1714,7 +1414,7 @@ export class SubtitleAnnotations extends SubtitleCollection<IndexedSubtitleModel
                 const tokenStatusResult =
                     token.states.includes(TokenState.IGNORED) || !HAS_LETTER_REGEX.test(trimmedToken)
                         ? { status: getFullyKnownTokenStatus() }
-                        : ((await this._tokenStatus(trimmedToken, normalizedToken, ts)) ?? { status: null });
+                        : ((await resolveTokenStatus(trimmedToken, normalizedToken, ts)) ?? { status: null });
                 const source = 'source' in tokenStatusResult ? tokenStatusResult.source : undefined;
                 token.status = tokenStatusResult.status;
                 const { groupingKey, lemmasGroupingKey } = ts.groupingKeysForToken(trimmedToken, lemmas, source);
@@ -1757,109 +1457,6 @@ export class SubtitleAnnotations extends SubtitleCollection<IndexedSubtitleModel
         }
     }
 
-    private async _tokenStatus(
-        trimmedToken: string,
-        normalizedToken: string,
-        ts: TrackState
-    ): Promise<ResolvedTokenStatusResult | null> {
-        if (!ts.yt) throw new Error('Yomitan uninitialized - cannot calculate token status');
-        const lemmas = await ts.lemmatizeForScript(trimmedToken);
-        if (this.shouldCancelBuild) return null;
-        if (!lemmas) return null;
-
-        let tokenStatusResult: ResolvedTokenStatusResult | null;
-        switch (ts.dt.dictionaryTokenMatchStrategyPriority) {
-            case TokenMatchStrategyPriority.EXACT:
-                tokenStatusResult = await this._handlePriorityExact(normalizedToken, lemmas, ts);
-                break;
-            case TokenMatchStrategyPriority.LEMMA:
-                tokenStatusResult = await this._handlePriorityLemma(normalizedToken, lemmas, ts);
-                break;
-            case TokenMatchStrategyPriority.BEST_KNOWN:
-                tokenStatusResult = await this._handlePriorityKnown(normalizedToken, lemmas, ts, (tokenStatuses) =>
-                    Math.max(...tokenStatuses)
-                );
-                break;
-            case TokenMatchStrategyPriority.LEAST_KNOWN:
-                tokenStatusResult = await this._handlePriorityKnown(normalizedToken, lemmas, ts, (tokenStatuses) =>
-                    Math.min(...tokenStatuses)
-                );
-                break;
-            default:
-                throw new Error(`Unknown strategy priority: ${ts.dt.dictionaryTokenMatchStrategyPriority}`);
-        }
-        return tokenStatusResult;
-    }
-
-    private async _handlePriorityExact(
-        normalizedToken: string,
-        lemmas: string[],
-        ts: TrackState
-    ): Promise<ResolvedTokenStatusResult | null> {
-        const statusResults: TokenStatusResult[] = [];
-
-        statusResults.push(...ts.tokenCollectionExact.resolveForWord([normalizedToken]));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-        statusResults.push(...ts.tokenCollectionLemma.resolveForWord(lemmas));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-        statusResults.push(...ts.tokenCollectionAny.resolveForWord(normalizedToken, lemmas, true));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-
-        statusResults.push(...ts.tokenCollectionExact.resolveForSentence([normalizedToken]));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-        statusResults.push(...ts.tokenCollectionLemma.resolveForSentence(lemmas));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-        statusResults.push(...ts.tokenCollectionAny.resolveForSentence(normalizedToken, lemmas, true));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-
-        return { status: TokenStatus.UNCOLLECTED };
-    }
-
-    private async _handlePriorityLemma(
-        normalizedToken: string,
-        lemmas: string[],
-        ts: TrackState
-    ): Promise<ResolvedTokenStatusResult | null> {
-        const statusResults: TokenStatusResult[] = [];
-
-        statusResults.push(...ts.tokenCollectionLemma.resolveForWord(lemmas));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-        statusResults.push(...ts.tokenCollectionExact.resolveForWord([normalizedToken]));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-        statusResults.push(...ts.tokenCollectionAny.resolveForWord(normalizedToken, lemmas, false));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-
-        statusResults.push(...ts.tokenCollectionLemma.resolveForSentence(lemmas));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-        statusResults.push(...ts.tokenCollectionExact.resolveForSentence([normalizedToken]));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-        statusResults.push(...ts.tokenCollectionAny.resolveForSentence(normalizedToken, lemmas, false));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
-
-        return { status: TokenStatus.UNCOLLECTED };
-    }
-
-    private async _handlePriorityKnown(
-        normalizedToken: string,
-        lemmas: string[],
-        ts: TrackState,
-        cmp: (tokenStatuses: TokenStatus[]) => TokenStatus
-    ): Promise<ResolvedTokenStatusResult | null> {
-        const statusResults: TokenStatusResult[] = [];
-
-        statusResults.push(...ts.tokenCollectionExact.resolveForWord([normalizedToken]));
-        statusResults.push(...ts.tokenCollectionLemma.resolveForWord(lemmas));
-        statusResults.push(...ts.tokenCollectionAny.resolveForWord(normalizedToken, lemmas, null));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults, cmp);
-
-        statusResults.push(...ts.tokenCollectionExact.resolveForSentence([normalizedToken]));
-        statusResults.push(...ts.tokenCollectionLemma.resolveForSentence(lemmas));
-        statusResults.push(...ts.tokenCollectionAny.resolveForSentence(normalizedToken, lemmas, null));
-        if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults, cmp);
-
-        return { status: TokenStatus.UNCOLLECTED };
-    }
-
     unbind() {
         this.reset();
         if (this.removeBuildAnkiCacheStateChangeCB) {
@@ -1888,435 +1485,3 @@ export class SubtitleAnnotations extends SubtitleCollection<IndexedSubtitleModel
         }
     }
 }
-
-export class HoveredToken {
-    private _hoveredElement: HTMLElement | null;
-
-    constructor() {
-        this._hoveredElement = null;
-    }
-
-    handleMouseOver(mouseEvent: MouseEvent): void {
-        if (!(mouseEvent.target instanceof HTMLElement)) return;
-        this._hoveredElement = mouseEvent.target;
-    }
-
-    handleMouseOut(mouseEvent: MouseEvent): void {
-        if (!(mouseEvent.target instanceof HTMLElement) || this._hoveredElement === mouseEvent.target) {
-            this._hoveredElement = null;
-        }
-    }
-
-    parse(): { token: string; track: number } | null {
-        const tokenEl = this._hoveredElement?.closest(`.${ASB_TOKEN_CLASS}`);
-        if (!tokenEl) return null;
-
-        const trackStr = tokenEl.closest('[data-track]')?.getAttribute('data-track');
-        if (!trackStr) return null;
-
-        let token = '';
-        for (const child of tokenEl.childNodes) token += this._extractTokenFromNode(child);
-        token = token.trim();
-        if (!token.length) return null;
-        return { token, track: parseInt(trackStr) };
-    }
-
-    private _extractTokenFromNode(node: Node): string {
-        if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? '';
-        if (node.nodeType !== Node.ELEMENT_NODE) return '';
-
-        let token = '';
-        const el = node as HTMLElement;
-        if (el.tagName === 'RUBY') {
-            for (const child of el.childNodes) {
-                if (child.nodeType === Node.ELEMENT_NODE && (child as HTMLElement).tagName === 'RT') continue;
-                token += this._extractTokenFromNode(child);
-            }
-            return token;
-        }
-
-        for (const child of el.childNodes) token += this._extractTokenFromNode(child);
-        return token;
-    }
-}
-
-export const getAnnotationsHtml = (text: string, richText: string | undefined, richTextOnHover: string | undefined) => {
-    if (!richTextOnHover) return richText ?? text;
-    return `<span class="asbplayer-subtitle-text">${richText ?? text}</span><span class="asbplayer-subtitle-rich">${richTextOnHover}</span>`;
-};
-
-export const getAnnotationsForRender = (dt: DictionaryTrack, target: TokenAnnotationConfigTarget) => {
-    const enabledAnnotations = getEnabledAnnotations(dt);
-    const enabledAnnotationsUnhover = getEnabledAnnotationsForHover(enabledAnnotations, dt, target, false);
-    const enabledAnnotationsHover = getEnabledAnnotationsForHover(enabledAnnotations, dt, target, true);
-    return {
-        dt,
-        isRichTextEnabled: Object.values(enabledAnnotationsUnhover).some((v) => v),
-        richTextEnabledAnnotations: enabledAnnotationsUnhover, // Hide annotations configured to appear only on hover
-        isRichTextOnHoverEnabled: Object.values(enabledAnnotationsHover).some((v) => v),
-        richTextOnHoverEnabledAnnotations: enabledAnnotations, // Show all enabled annotations on hover
-    };
-};
-
-export const ANNOTATIONS_VIDEO_RENDER_BEHIND_MS = 15000; // Seeking backwards is usually 5-10s
-export const ANNOTATIONS_VIDEO_RENDER_AHEAD_MS = 60000; // Seeking forward is usually 5-30s
-
-export interface RenderedRichText {
-    richText?: string;
-    richTextOnHover?: string;
-}
-
-interface CachedRenderedRichText extends RenderedRichText {
-    text: string;
-    tokenization?: Tokenization;
-    tokenAnnotationTarget: TokenAnnotationConfigTarget;
-    dictionaryTracks?: DictionaryTrack[];
-}
-
-const cachedRichTextIsCurrent = (
-    cached: CachedRenderedRichText,
-    subtitle: RichTextRenderable,
-    tokenAnnotationTarget: TokenAnnotationConfigTarget,
-    dictionaryTracks: DictionaryTrack[] | undefined
-) =>
-    cached.text === subtitle.text &&
-    areTokenizationsEqual(cached.tokenization, subtitle.tokenization) &&
-    cached.tokenAnnotationTarget === tokenAnnotationTarget &&
-    cached.dictionaryTracks?.every((dt, i) => areDictionaryTracksEqual(dt, dictionaryTracks?.[i]));
-
-interface IndexRange {
-    min: number;
-    max: number;
-}
-
-export interface RichTextWindow {
-    range?: IndexRange;
-    buffer: Map<number, CachedRenderedRichText>;
-}
-
-export const emptyRichTextWindow = (): RichTextWindow => ({ buffer: new Map() });
-
-interface RichTextRenderable {
-    index: number;
-    text: string;
-    track: number;
-    tokenization?: Tokenization;
-}
-
-export const renderRichTextOntoSubtitles = (
-    subtitles: RichTextRenderable[],
-    tokenAnnotationTarget: TokenAnnotationConfigTarget,
-    dictionaryTracks: DictionaryTrack[] | undefined
-): Map<number, RenderedRichText> => {
-    const rendered = new Map<number, RenderedRichText>();
-    if (dictionaryTracks?.length !== defaultSettings.dictionaryTracks.length) return rendered;
-
-    const trackAnnotations = dictionaryTracks.map((dt) => getAnnotationsForRender(dt, tokenAnnotationTarget));
-    const allowAsciiReading = false; // Allowing is only for preview purposes for status names to show reading
-
-    for (const subtitle of subtitles) {
-        if (!subtitle.tokenization) continue;
-        const ta = trackAnnotations[subtitle.track];
-        const hasExternalReading = subtitle.tokenization.tokens.some(
-            (token) => !(token as InternalToken).__internal && token.readings.length > 0
-        ); // Display external readings even if no annotations are enabled, unnecessary for richTextOnHover
-
-        const richText =
-            ta.isRichTextEnabled || hasExternalReading
-                ? computeRichText(subtitle.text, subtitle.tokenization, {
-                      dt: ta.dt,
-                      enabledAnnotations: ta.richTextEnabledAnnotations,
-                      allowAsciiReading,
-                  })
-                : undefined;
-        const richTextOnHover = ta.isRichTextOnHoverEnabled
-            ? computeRichText(subtitle.text, subtitle.tokenization, {
-                  dt: ta.dt,
-                  enabledAnnotations: ta.richTextOnHoverEnabledAnnotations,
-                  allowAsciiReading,
-              })
-            : undefined;
-
-        if (richText !== undefined || richTextOnHover !== undefined) {
-            rendered.set(subtitle.index, { richText, richTextOnHover });
-        }
-    }
-
-    return rendered;
-};
-
-export const renderRichTextWindow = (
-    prev: RichTextWindow,
-    windowSubtitles: RichTextRenderable[],
-    tokenAnnotationTarget: TokenAnnotationConfigTarget,
-    dictionaryTracks: DictionaryTrack[] | undefined
-): RichTextWindow => {
-    if (!windowSubtitles.length) return emptyRichTextWindow();
-    const windowSubtitleIndexes = windowSubtitles.map((s) => s.index);
-    const range: IndexRange = { min: Math.min(...windowSubtitleIndexes), max: Math.max(...windowSubtitleIndexes) };
-    const buffer = new Map<number, CachedRenderedRichText>();
-
-    const toRender: RichTextRenderable[] = [];
-    for (const subtitle of windowSubtitles) {
-        if (prev.range && subtitle.index >= prev.range.min && subtitle.index <= prev.range.max) {
-            const reused = prev.buffer.get(subtitle.index);
-            if (reused && cachedRichTextIsCurrent(reused, subtitle, tokenAnnotationTarget, dictionaryTracks)) {
-                buffer.set(subtitle.index, reused);
-                continue;
-            }
-        }
-        toRender.push(subtitle);
-    }
-    if (toRender.length) {
-        const rendered = renderRichTextOntoSubtitles(toRender, tokenAnnotationTarget, dictionaryTracks);
-        for (const subtitle of toRender) {
-            const value = rendered.get(subtitle.index);
-            buffer.set(subtitle.index, {
-                ...value,
-                text: subtitle.text,
-                tokenization: subtitle.tokenization,
-                tokenAnnotationTarget,
-                dictionaryTracks,
-            });
-        }
-    }
-
-    return { range, buffer };
-};
-
-export const renderRichTextForSubtitle = (
-    window: RichTextWindow,
-    subtitle: RichTextRenderable,
-    tokenAnnotationTarget: TokenAnnotationConfigTarget,
-    dictionaryTracks: DictionaryTrack[] | undefined
-): RenderedRichText | undefined => {
-    const cached = window.buffer.get(subtitle.index);
-    if (cached && cachedRichTextIsCurrent(cached, subtitle, tokenAnnotationTarget, dictionaryTracks)) return cached;
-
-    const rendered = renderRichTextOntoSubtitles([subtitle], tokenAnnotationTarget, dictionaryTracks).get(
-        subtitle.index
-    );
-    window.buffer.set(subtitle.index, {
-        ...rendered,
-        text: subtitle.text,
-        tokenization: subtitle.tokenization,
-        tokenAnnotationTarget,
-        dictionaryTracks,
-    });
-    return rendered;
-};
-
-interface TokenStyleState {
-    dt: DictionaryTrack;
-    enabledAnnotations: EnabledAnnotations;
-    allowAsciiReading: boolean;
-}
-
-export const computeRichText = (fullText: string, tokenization: Tokenization, ss: TokenStyleState) => {
-    if (tokenization.error) return `<span ${ERROR_STYLE}>${fullText}</span>`;
-    if (!tokenization.tokens.length) return;
-
-    const parts: string[] = [];
-    const prevPitch: PitchAccentContext = {}; // Context from the previous token to correctly determine pitch for attached particle
-    iterateOverStringInBlocks(
-        fullText,
-        (_, blockIndex) => tokenization.tokens[blockIndex],
-        (left, right, token?: Token) => {
-            if (token === undefined) {
-                clearPitchAccentContext(prevPitch);
-                parts.push(fullText.substring(left, right));
-            } else {
-                parts.push(applyTokenStyle(fullText, token, prevPitch, ss));
-            }
-        }
-    );
-    return parts.join('');
-};
-
-const ERROR_STYLE = `style="text-decoration: line-through red 3px;"`;
-const LOGIC_ERROR_STYLE = `style="text-decoration: line-through red 3px double;"`;
-
-const applyTokenStyle = (fullText: string, token: Token, prevPitch: PitchAccentContext, ss: TokenStyleState) => {
-    const rawTokenText = fullText.substring(token.pos[0], token.pos[1]);
-    if (!HAS_LETTER_REGEX.test(rawTokenText)) {
-        clearPitchAccentContext(prevPitch);
-        return rawTokenText;
-    }
-    const tokenText = applyFrequencyAnnotation(applyReadingAnnotation(rawTokenText, token, prevPitch, ss), token, ss);
-    if (token.status === null) return `<span ${ERROR_STYLE}>${tokenText}</span>`;
-    if (token.status === undefined && dictionaryTrackEnabled(ss.dt))
-        return `<span ${LOGIC_ERROR_STYLE}>${tokenText}</span>`; // External tokens may flash this on initial load
-    if (!ss.enabledAnnotations.color) return tokenText;
-
-    const s = `<span class="${ASB_TOKEN_CLASS}${ss.dt.dictionaryHighlightOnHover ? ` ${ASB_TOKEN_HIGHLIGHT_CLASS}` : ''}"`; // Only allow collection and highlighting if colors is enabled so that user has feedback
-    const config = ss.dt.dictionaryTokenStatusConfig[token.status!];
-    if (!config.display) return `${s}>${tokenText}</span>`;
-    if (
-        token.pitchAccent != null &&
-        ss.enabledAnnotations.pitchAccent &&
-        (!token.readings.length ||
-            (ss.enabledAnnotations.reading && shouldUseAnnotation('reading', token.status!, token.states, ss.dt)))
-    ) {
-        return `${s}>${tokenText}</span>`; // Colorize the pitch accent annotation only when being shown
-    }
-
-    const c = `${config.color}${config.alpha}`;
-    const t = ss.dt.dictionaryTokenStylingThickness;
-    switch (ss.dt.dictionaryTokenStyling) {
-        case TokenStyling.TEXT:
-            return `${s} style="-webkit-text-fill-color: ${c};">${tokenText}</span>`;
-        case TokenStyling.BACKGROUND:
-            return `${s} style="background-color: ${c};">${tokenText}</span>`;
-        case TokenStyling.UNDERLINE:
-        case TokenStyling.OVERLINE:
-            return `${s} style="text-decoration: ${ss.dt.dictionaryTokenStyling} ${c} ${t}px;">${tokenText}</span>`;
-        case TokenStyling.OUTLINE:
-            return `${s} style="-webkit-text-stroke: ${t}px ${c};">${tokenText}</span>`;
-        default:
-            return `${s} ${LOGIC_ERROR_STYLE}>${tokenText}</span>`;
-    }
-};
-
-const applyReadingAnnotation = (
-    tokenText: string,
-    token: Token,
-    prevPitch: PitchAccentContext,
-    ss: TokenStyleState
-) => {
-    if (ONLY_ASCII_LETTERS_REGEX.test(tokenText) && !ss.allowAsciiReading) {
-        clearPitchAccentContext(prevPitch);
-        return tokenText; // Prevent english words from getting readings
-    }
-    if (!token.readings.length) {
-        if (isKanaOnly(tokenText)) return applyPitchAccentAnnotation(tokenText, token, prevPitch, ss, tokenText);
-        clearPitchAccentContext(prevPitch);
-        return tokenText;
-    }
-
-    // Only apply skip logic for tokens generated by this class i.e. marked __internal: true
-    if ((token as InternalToken).__internal) {
-        if (!ss.enabledAnnotations.reading) {
-            clearPitchAccentContext(prevPitch);
-            return tokenText;
-        }
-        if (token.status == null || !shouldUseAnnotation('reading', token.status, token.states, ss.dt)) {
-            clearPitchAccentContext(prevPitch);
-            return tokenText;
-        }
-    }
-
-    // We want to use a single reading for the entire token if we're applying pitch accent annotations.
-    // e.g. 飛び切り readings would be `と き ` so make it contiguous as `とびきり` so connecting and reading pitch is easier
-    const tokenForDisplay = { ...token };
-    if (token.pitchAccent != null && ss.enabledAnnotations.pitchAccent) {
-        tokenForDisplay.readings = [{ pos: [0, tokenText.length], reading: '' }];
-        iterateOverStringInBlocks(
-            tokenText,
-            (_, blockIndex) => token.readings[blockIndex],
-            (left, right, reading?: TokenReading) => {
-                if (reading === undefined) tokenForDisplay.readings[0].reading += tokenText.substring(left, right);
-                else tokenForDisplay.readings[0].reading += reading.reading;
-            }
-        );
-    }
-
-    const parts: string[] = [];
-    iterateOverStringInBlocks(
-        tokenText,
-        (_, blockIndex) => tokenForDisplay.readings[blockIndex],
-        (left, right, reading?: TokenReading) => {
-            if (reading === undefined) {
-                parts.push(tokenText.substring(left, right));
-            } else {
-                const part = tokenText.substring(reading.pos[0], reading.pos[1]);
-                const readingText = applyPitchAccentAnnotation(reading.reading, tokenForDisplay, prevPitch, ss);
-                parts.push(`<ruby class="${ASB_READING_CLASS}">${part}<rt>${readingText}</rt></ruby>`);
-            }
-        }
-    );
-    return parts.join('');
-};
-
-const applyPitchAccentAnnotation = (
-    readingText: string,
-    token: Token,
-    prevPitch: PitchAccentContext,
-    ss: TokenStyleState,
-    attachedParticleCandidateText?: string
-) => {
-    if (!ss.enabledAnnotations.pitchAccent) {
-        clearPitchAccentContext(prevPitch);
-        return readingText;
-    }
-    if (!HAS_LETTER_REGEX.test(readingText)) {
-        clearPitchAccentContext(prevPitch);
-        return readingText;
-    }
-
-    const pitchAccentColor = () => {
-        if (token.status == null || !ss.enabledAnnotations.color) return 'currentColor';
-        const config = ss.dt.dictionaryTokenStatusConfig[token.status];
-        if (!config.display) return 'currentColor';
-        return `${config.color}${config.alpha}`;
-    };
-
-    if (prevPitch.prevMoras !== undefined && prevPitch.prevPitchAccent !== undefined) {
-        const pitchHigh = isAttachedParticlePitchHigh(attachedParticleCandidateText, prevPitch);
-        if (pitchHigh !== null) {
-            prevPitch.prevMoras = undefined;
-            prevPitch.prevPitchAccent = undefined;
-            const html = pitchAccentHtml(getKanaMoras(readingText), pitchAccentColor(), () => pitchHigh, prevPitch);
-            prevPitch.prevPitchHigh = undefined; // Draw vertical line for attached particles if pitched changed from previous token
-            return html;
-        }
-    }
-
-    if (token.pitchAccent == null) {
-        clearPitchAccentContext(prevPitch);
-        return readingText;
-    }
-
-    const moras = getKanaMoras(readingText);
-    prevPitch.prevMoras = moras;
-    prevPitch.prevPitchAccent = token.pitchAccent;
-    prevPitch.prevPitchHigh = undefined; // Only attached particles care about the change from the previous pitch
-    const html = pitchAccentHtml(
-        moras,
-        pitchAccentColor(),
-        (i) => isKanaMoraPitchHigh(i, token.pitchAccent!),
-        prevPitch
-    );
-    if (!attachedParticleCandidateText) prevPitch.prevPitchHigh = undefined; // For furigana we don't want the vertical line since it won't be connected to the particle
-    return html;
-};
-
-const pitchAccentHtml = (
-    moras: string[],
-    color: string,
-    pitchHigh: (index: number) => boolean,
-    prevPitch: PitchAccentContext
-) => {
-    const parts: string[] = [];
-    let prevHigh = prevPitch.prevPitchHigh;
-    for (let i = 0; i < moras.length; i++) {
-        const high = pitchHigh(i);
-        if (prevHigh !== undefined && prevHigh !== high) {
-            parts.push(`<span class="${ASB_PITCH_ACCENT_LINE_CLASS}"></span>`);
-        }
-        prevHigh = high;
-        parts.push(
-            `<span class="${ASB_PITCH_ACCENT_MORA_CLASS} ${
-                high ? ASB_PITCH_ACCENT_MORA_HIGH_CLASS : ASB_PITCH_ACCENT_MORA_LOW_CLASS
-            }">${moras[i]}</span>`
-        );
-    }
-    prevPitch.prevPitchHigh = prevHigh;
-    return `<span class="${ASB_PITCH_ACCENT_CLASS}" style="--asb-pitch-accent-color: ${color};">${parts.join('')}</span>`;
-};
-
-const applyFrequencyAnnotation = (tokenText: string, token: Token, ss: TokenStyleState) => {
-    if (!ss.enabledAnnotations.frequency) return tokenText;
-    if (token.frequency == null) return tokenText;
-    if (token.status == null || !shouldUseAnnotation('frequency', token.status, token.states, ss.dt)) return tokenText;
-    return `<ruby class="${ASB_FREQUENCY_CLASS}">${tokenText}<rt>${token.frequency}</rt></ruby>`;
-};

--- a/common/annotations/token-collection.ts
+++ b/common/annotations/token-collection.ts
@@ -1,0 +1,399 @@
+import {
+    DictionaryTokenSource,
+    dictionaryTokenSourcePriority,
+    externalWordSourcePriority,
+    isExternalWordSource,
+    TokenMatchStrategy,
+    TokenState,
+    TokenStatus,
+    isWordSource,
+    TokenMatchStrategyPriority,
+    DictionaryTrack,
+} from '@project/common/settings';
+import { TokenStatusInfo } from '@project/common/dictionary-db';
+import { getTokenStatus, dedupeTokenStatusInfos, isKanaOnly, normalizeToken } from '@project/common/util';
+import type { TrackState } from '@project/common/annotations';
+
+/**
+ * The processed data from the db.
+ */
+interface TokenStatusResult {
+    status: TokenStatus;
+    source: DictionaryTokenSource;
+    normalizedToken?: string; // For ANY_FORM_COLLECTED to prefer exact, then lemma, then any form.
+    externalCandidateStatuses?: TokenStatusInfo[];
+}
+
+/**
+ * The final status after applying strategies.
+ */
+interface ResolvedTokenStatusResult {
+    status: TokenStatus;
+    source?: DictionaryTokenSource;
+    externalCandidateStatuses?: TokenStatusInfo[];
+}
+
+/**
+ * Contains the tokens from the db depending on strategy configured.
+ */
+export class TokenCollectionBase<T = TokenStatusResult | TokenStatusResult[]> {
+    protected readonly collection: Map<string, T>;
+    protected readonly dt: DictionaryTrack;
+    protected readonly updateTokenStates: (normalizedToken: string, states: TokenState[]) => void;
+    readonly enabled: boolean;
+    readonly wordEnabled: boolean;
+    readonly sentenceEnabled: boolean;
+
+    constructor(
+        classType:
+            | TokenMatchStrategy.EXACT_FORM_COLLECTED
+            | TokenMatchStrategy.LEMMA_FORM_COLLECTED
+            | TokenMatchStrategy.ANY_FORM_COLLECTED,
+        dt: DictionaryTrack,
+        updateTokenStates: (normalizedToken: string, states: TokenState[]) => void
+    ) {
+        this.collection = new Map();
+        this.dt = dt;
+        this.updateTokenStates = updateTokenStates;
+        switch (classType) {
+            case TokenMatchStrategy.EXACT_FORM_COLLECTED:
+                this.wordEnabled =
+                    dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.EXACT_FORM_COLLECTED ||
+                    dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
+                this.sentenceEnabled =
+                    dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.EXACT_FORM_COLLECTED ||
+                    dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
+                break;
+            case TokenMatchStrategy.LEMMA_FORM_COLLECTED:
+                this.wordEnabled =
+                    dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.LEMMA_FORM_COLLECTED ||
+                    dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
+                this.sentenceEnabled =
+                    dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.LEMMA_FORM_COLLECTED ||
+                    dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED;
+                break;
+            case TokenMatchStrategy.ANY_FORM_COLLECTED:
+                this.wordEnabled = dt.dictionaryTokenMatchStrategy === TokenMatchStrategy.ANY_FORM_COLLECTED;
+                this.sentenceEnabled =
+                    dt.dictionaryAnkiSentenceTokenMatchStrategy === TokenMatchStrategy.ANY_FORM_COLLECTED;
+                break;
+            default:
+                throw new Error(`Unsupported TokenMatchStrategy: ${classType}`);
+        }
+        this.enabled = this.wordEnabled || this.sentenceEnabled;
+    }
+
+    get(normalizedKey: string): T | undefined {
+        return this.collection.get(normalizedKey);
+    }
+
+    delete(normalizedKey: string): boolean {
+        return this.collection.delete(normalizedKey);
+    }
+
+    addQuery(queryMap: Map<string, string[]>, key: string): void {
+        const normalizedKey = normalizeToken(key);
+        const queries = queryMap.get(normalizedKey);
+        if (queries) {
+            if (!queries.includes(key)) queries.push(key); // Send all original forms for backwards compatibility with older extension db lookups
+            return;
+        }
+        if (!this.collection.has(normalizedKey)) queryMap.set(normalizedKey, [key]);
+    }
+
+    getAllQueries(queryMap: Map<string, string[]>): string[] {
+        return Array.from(queryMap.values()).flat();
+    }
+
+    updateDictionaryTrack(dt: DictionaryTrack) {
+        (this.dt as DictionaryTrack) = dt;
+    }
+
+    protected tokenStatusResult(
+        statuses: TokenStatusInfo[],
+        source: DictionaryTokenSource,
+        externalCandidateStatuses?: TokenStatusInfo[],
+        normalizedToken?: string
+    ): TokenStatusResult {
+        const candidateStatuses = externalCandidateStatuses ?? statuses;
+        return {
+            status: getTokenStatus(statuses, this.dt.dictionaryAnkiTreatSuspended),
+            source,
+            normalizedToken,
+            externalCandidateStatuses: candidateStatuses.length ? candidateStatuses : undefined,
+        };
+    }
+
+    private compareTokenStatusResults(left: TokenStatusResult, right: TokenStatusResult): number {
+        const sourcePriority = dictionaryTokenSourcePriority(left.source) - dictionaryTokenSourcePriority(right.source);
+        if (sourcePriority !== 0) return sourcePriority;
+        const statusPriority = left.status - right.status;
+        if (statusPriority !== 0) return statusPriority;
+        if (isExternalWordSource(left.source) && isExternalWordSource(right.source)) {
+            return externalWordSourcePriority(left.source) - externalWordSourcePriority(right.source);
+        }
+        return 0;
+    }
+
+    protected mergeTokenStatusResults(left: TokenStatusResult, right: TokenStatusResult): TokenStatusResult {
+        return {
+            ...(this.compareTokenStatusResults(left, right) >= 0 ? left : right),
+            externalCandidateStatuses: dedupeTokenStatusInfos([
+                ...(left.externalCandidateStatuses ?? []),
+                ...(right.externalCandidateStatuses ?? []),
+            ]),
+        };
+    }
+
+    static resolveTokenStatusResults(
+        tokenStatusResults: TokenStatusResult[],
+        cmp: (tokenStatuses: TokenStatus[]) => TokenStatus = (tokenStatuses) => Math.max(...tokenStatuses)
+    ): ResolvedTokenStatusResult {
+        const status = cmp(tokenStatusResults.map((result) => result.status));
+        const selectedResult = tokenStatusResults.find((result) => result.status === status)!;
+        return {
+            status: selectedResult.status,
+            source: selectedResult.source,
+            externalCandidateStatuses: dedupeTokenStatusInfos(
+                tokenStatusResults.flatMap((result) => result.externalCandidateStatuses ?? [])
+            ),
+        };
+    }
+}
+
+export class TokenCollection extends TokenCollectionBase<TokenStatusResult> {
+    add(
+        statuses: TokenStatusInfo[],
+        source: DictionaryTokenSource,
+        externalCandidateStatuses: TokenStatusInfo[] | undefined,
+        key: string,
+        states: TokenState[]
+    ): void {
+        const normalizedKey = normalizeToken(key);
+        this.updateTokenStates(normalizedKey, states);
+        const statusResult = this.tokenStatusResult(statuses, source, externalCandidateStatuses);
+        const existing = this.collection.get(normalizedKey);
+        this.collection.set(
+            normalizedKey,
+            existing ? super.mergeTokenStatusResults(existing, statusResult) : statusResult
+        );
+    }
+
+    private resolve(
+        normalizedTokens: string[],
+        sourceMatches: (source: DictionaryTokenSource) => boolean
+    ): TokenStatusResult[] {
+        const statusResults: TokenStatusResult[] = [];
+        for (const normalizedToken of normalizedTokens) {
+            const statusResult = this.collection.get(normalizedToken);
+            if (statusResult && sourceMatches(statusResult.source)) statusResults.push(statusResult);
+        }
+        return statusResults;
+    }
+
+    resolveForWord(normalizedTokens: string[]): TokenStatusResult[] {
+        if (!this.wordEnabled) return [];
+        return this.resolve(normalizedTokens, (source) => isWordSource(source));
+    }
+
+    resolveForSentence(normalizedTokens: string[]): TokenStatusResult[] {
+        if (!this.sentenceEnabled) return [];
+        return this.resolve(normalizedTokens, (source) => !isWordSource(source));
+    }
+}
+
+export class TokenCollectionArray extends TokenCollectionBase<TokenStatusResult[]> {
+    add(
+        statuses: TokenStatusInfo[],
+        source: DictionaryTokenSource,
+        externalCandidateStatuses: TokenStatusInfo[] | undefined,
+        normalizedKey: string,
+        states: TokenState[],
+        token: string
+    ): void {
+        const normalizedToken = normalizeToken(token);
+        this.updateTokenStates(normalizedToken, states);
+        const statusResult = this.tokenStatusResult(statuses, source, externalCandidateStatuses, normalizedToken);
+        const statusResults = this.collection.get(normalizedKey);
+        if (!statusResults) {
+            this.collection.set(normalizedKey, [statusResult]);
+            return;
+        }
+        const duplicateIndex = statusResults.findIndex((r) => r.normalizedToken === statusResult.normalizedToken);
+        if (duplicateIndex === -1) {
+            statusResults.push(statusResult);
+        } else {
+            statusResults[duplicateIndex] = super.mergeTokenStatusResults(statusResults[duplicateIndex], statusResult);
+        }
+    }
+
+    /**
+     * Need to check ANY_FORM_COLLECTED results against dictionaryMatchAcrossScripts explicitly since we never checked
+     * the token, only the lemmas. EXACT_FORM_COLLECTED and LEMMA_FORM_COLLECTED looks for an exact match with either the
+     * surface form or lemma form so they don't need this extra filtering.
+     */
+    private getStatusResults(
+        normalizedToken: string,
+        normalizedLemmas: string[],
+        sourceMatches: (source: DictionaryTokenSource) => boolean
+    ): TokenStatusResult[] {
+        const tokenIsKanaOnly = isKanaOnly(normalizedToken);
+        const anyFormStatusResults: TokenStatusResult[] = [];
+        for (const normalizedLemma of normalizedLemmas) {
+            const statusResults = this.collection.get(normalizedLemma);
+            if (!statusResults) continue;
+            for (const statusResult of statusResults) {
+                if (!sourceMatches(statusResult.source)) continue;
+                const collectedTokenIsKanaOnly = isKanaOnly(statusResult.normalizedToken!);
+                if (this.dt.dictionaryMatchAcrossScripts) {
+                    if (tokenIsKanaOnly || !collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
+                } else {
+                    if (tokenIsKanaOnly === collectedTokenIsKanaOnly) anyFormStatusResults.push(statusResult);
+                }
+            }
+        }
+        return anyFormStatusResults;
+    }
+
+    private tokenMatchesKey(normalizedToken: string, normalizedKey: string): boolean {
+        return normalizedToken === normalizedKey;
+    }
+
+    private tokenMatchesAnyKey(normalizedToken: string, normalizedKeys: string[]): boolean {
+        return normalizedKeys.some((normalizedKey) => this.tokenMatchesKey(normalizedToken, normalizedKey));
+    }
+
+    private resolve(
+        normalizedToken: string,
+        lemmas: string[],
+        sourceMatches: (source: DictionaryTokenSource) => boolean,
+        exactPriority: boolean | null
+    ): TokenStatusResult[] {
+        const statusResults = this.getStatusResults(normalizedToken, lemmas, sourceMatches);
+        if (!statusResults.length || exactPriority === null) return statusResults;
+        if (exactPriority === true) {
+            const exactMatches = statusResults.filter((r) => this.tokenMatchesKey(r.normalizedToken!, normalizedToken));
+            if (exactMatches.length) return exactMatches;
+            const lemmaMatches = statusResults.filter((r) => this.tokenMatchesAnyKey(r.normalizedToken!, lemmas));
+            if (lemmaMatches.length) return lemmaMatches;
+        } else if (exactPriority === false) {
+            const lemmaMatches = statusResults.filter((r) => this.tokenMatchesAnyKey(r.normalizedToken!, lemmas));
+            if (lemmaMatches.length) return lemmaMatches;
+            const exactMatches = statusResults.filter((r) => this.tokenMatchesKey(r.normalizedToken!, normalizedToken));
+            if (exactMatches.length) return exactMatches;
+        }
+        return statusResults;
+    }
+
+    resolveForWord(normalizedToken: string, lemmas: string[], exactPriority: boolean | null): TokenStatusResult[] {
+        if (!this.wordEnabled) return [];
+        return this.resolve(normalizedToken, lemmas, (source) => isWordSource(source), exactPriority);
+    }
+
+    resolveForSentence(normalizedToken: string, lemmas: string[], exactPriority: boolean | null): TokenStatusResult[] {
+        if (!this.sentenceEnabled) return [];
+        return this.resolve(normalizedToken, lemmas, (source) => !isWordSource(source), exactPriority);
+    }
+}
+
+export async function resolveTokenStatus(
+    trimmedToken: string,
+    normalizedToken: string,
+    ts: TrackState
+): Promise<ResolvedTokenStatusResult | null> {
+    if (!ts.yt) throw new Error('Yomitan uninitialized - cannot calculate token status');
+    const lemmas = await ts.lemmatizeForScript(trimmedToken);
+    if (!lemmas) return null;
+
+    let tokenStatusResult: ResolvedTokenStatusResult | null;
+    switch (ts.dt.dictionaryTokenMatchStrategyPriority) {
+        case TokenMatchStrategyPriority.EXACT:
+            tokenStatusResult = await handlePriorityExact(normalizedToken, lemmas, ts);
+            break;
+        case TokenMatchStrategyPriority.LEMMA:
+            tokenStatusResult = await handlePriorityLemma(normalizedToken, lemmas, ts);
+            break;
+        case TokenMatchStrategyPriority.BEST_KNOWN:
+            tokenStatusResult = await handlePriorityKnown(normalizedToken, lemmas, ts, (tokenStatuses) =>
+                Math.max(...tokenStatuses)
+            );
+            break;
+        case TokenMatchStrategyPriority.LEAST_KNOWN:
+            tokenStatusResult = await handlePriorityKnown(normalizedToken, lemmas, ts, (tokenStatuses) =>
+                Math.min(...tokenStatuses)
+            );
+            break;
+        default:
+            throw new Error(`Unknown strategy priority: ${ts.dt.dictionaryTokenMatchStrategyPriority}`);
+    }
+    return tokenStatusResult;
+}
+
+async function handlePriorityExact(
+    normalizedToken: string,
+    lemmas: string[],
+    ts: TrackState
+): Promise<ResolvedTokenStatusResult | null> {
+    const statusResults: TokenStatusResult[] = [];
+
+    statusResults.push(...ts.tokenCollectionExact.resolveForWord([normalizedToken]));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+    statusResults.push(...ts.tokenCollectionLemma.resolveForWord(lemmas));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+    statusResults.push(...ts.tokenCollectionAny.resolveForWord(normalizedToken, lemmas, true));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+
+    statusResults.push(...ts.tokenCollectionExact.resolveForSentence([normalizedToken]));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+    statusResults.push(...ts.tokenCollectionLemma.resolveForSentence(lemmas));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+    statusResults.push(...ts.tokenCollectionAny.resolveForSentence(normalizedToken, lemmas, true));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+
+    return { status: TokenStatus.UNCOLLECTED };
+}
+
+async function handlePriorityLemma(
+    normalizedToken: string,
+    lemmas: string[],
+    ts: TrackState
+): Promise<ResolvedTokenStatusResult | null> {
+    const statusResults: TokenStatusResult[] = [];
+
+    statusResults.push(...ts.tokenCollectionLemma.resolveForWord(lemmas));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+    statusResults.push(...ts.tokenCollectionExact.resolveForWord([normalizedToken]));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+    statusResults.push(...ts.tokenCollectionAny.resolveForWord(normalizedToken, lemmas, false));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+
+    statusResults.push(...ts.tokenCollectionLemma.resolveForSentence(lemmas));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+    statusResults.push(...ts.tokenCollectionExact.resolveForSentence([normalizedToken]));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+    statusResults.push(...ts.tokenCollectionAny.resolveForSentence(normalizedToken, lemmas, false));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults);
+
+    return { status: TokenStatus.UNCOLLECTED };
+}
+
+async function handlePriorityKnown(
+    normalizedToken: string,
+    lemmas: string[],
+    ts: TrackState,
+    cmp: (tokenStatuses: TokenStatus[]) => TokenStatus
+): Promise<ResolvedTokenStatusResult | null> {
+    const statusResults: TokenStatusResult[] = [];
+
+    statusResults.push(...ts.tokenCollectionExact.resolveForWord([normalizedToken]));
+    statusResults.push(...ts.tokenCollectionLemma.resolveForWord(lemmas));
+    statusResults.push(...ts.tokenCollectionAny.resolveForWord(normalizedToken, lemmas, null));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults, cmp);
+
+    statusResults.push(...ts.tokenCollectionExact.resolveForSentence([normalizedToken]));
+    statusResults.push(...ts.tokenCollectionLemma.resolveForSentence(lemmas));
+    statusResults.push(...ts.tokenCollectionAny.resolveForSentence(normalizedToken, lemmas, null));
+    if (statusResults.length) return TokenCollectionBase.resolveTokenStatusResults(statusResults, cmp);
+
+    return { status: TokenStatus.UNCOLLECTED };
+}

--- a/common/app/components/Player.tsx
+++ b/common/app/components/Player.tsx
@@ -28,7 +28,7 @@ import {
 } from '@project/common/settings';
 import { DictionaryProvider } from '@project/common/dictionary-db';
 import { SubtitleCollection } from '@project/common/subtitle-collection';
-import { HoveredToken, SubtitleAnnotations } from '@project/common/subtitle-annotations';
+import { HoveredToken, SubtitleAnnotations } from '@project/common/annotations';
 import { SubtitleReader } from '@project/common/subtitle-reader';
 import { KeyBinder } from '@project/common/key-binder';
 import { surroundingSubtitles, timeDurationDisplay } from '@project/common/util';

--- a/common/app/components/SettingsDialog.tsx
+++ b/common/app/components/SettingsDialog.tsx
@@ -115,7 +115,6 @@ export default function SettingsDialog({
                     extensionSupportsDictionaryBrowser={extension.supportsDictionaryBrowser}
                     extensionSupportsDictionaryWaniKani={extension.supportsDictionaryWaniKani}
                     extensionSupportsDictionaryMatchAcrossScripts={extension.supportsDictionaryMatchAcrossScripts}
-                    extensionSupportsDictionaryTokenAnnotationConfig={extension.supportsDictionaryTokenAnnotationConfig}
                     extensionSupportsSeekableTrackSetting={extension.supportsSeekableTrackSetting}
                     extensionSupportsAutoCopyableTrackSetting={extension.supportsAutoCopyableTrackSetting}
                     extensionSupportsDictionaryTokenStatusDisplayAlpha={

--- a/common/app/components/SubtitlePlayer.tsx
+++ b/common/app/components/SubtitlePlayer.tsx
@@ -45,7 +45,7 @@ import {
     RenderedRichText,
     SubtitleAnnotations,
     renderRichTextForSubtitle,
-} from '@project/common/subtitle-annotations';
+} from '@project/common/annotations';
 import { KeyBinder } from '@project/common/key-binder';
 import SubtitleTextImage from '@project/common/components/SubtitleTextImage';
 import NoteAddIcon from '@mui/icons-material/NoteAdd';

--- a/common/app/components/VideoPlayer.tsx
+++ b/common/app/components/VideoPlayer.tsx
@@ -46,7 +46,7 @@ import {
     getAnnotationsHtml,
     ANNOTATIONS_VIDEO_RENDER_BEHIND_MS,
     ANNOTATIONS_VIDEO_RENDER_AHEAD_MS,
-} from '@project/common/subtitle-annotations';
+} from '@project/common/annotations';
 import Clock from '../services/clock';
 import Controls, { Point } from './Controls';
 import PlayerChannel from '../services/player-channel';

--- a/common/components/DictionaryImport.tsx
+++ b/common/components/DictionaryImport.tsx
@@ -21,7 +21,7 @@ import {
     ApplyStrategy,
     Profile,
 } from '@project/common/settings';
-import { Yomitan } from '../yomitan/yomitan';
+import { Yomitan } from '../yomitan';
 import SwitchLabelWithHoverEffect from './SwitchLabelWithHoverEffect';
 import SettingsTextField from './SettingsTextField';
 import { DictionaryLocalTokenInput, DictionaryProvider, DictionaryTokenRecord } from '../dictionary-db';

--- a/common/components/DictionarySettingsTab.tsx
+++ b/common/components/DictionarySettingsTab.tsx
@@ -51,7 +51,7 @@ import {
 } from '@project/common/settings';
 import { Anki } from '../anki';
 import { WaniKani, WaniKaniUser } from '../wanikani';
-import { Yomitan } from '../yomitan/yomitan';
+import { Yomitan } from '../yomitan';
 import SwitchLabelWithHoverEffect from './SwitchLabelWithHoverEffect';
 import SettingsTextField from './SettingsTextField';
 import SettingsSection from './SettingsSection';
@@ -81,7 +81,12 @@ import {
     percentToHex2,
 } from '../util';
 import DictionaryImport from './DictionaryImport';
-import { computeRichText, getAnnotationsForRender, getAnnotationsHtml, InternalToken } from '../subtitle-annotations';
+import {
+    computeRichText,
+    getAnnotationsForRender,
+    getAnnotationsHtml,
+    InternalToken,
+} from '@project/common/annotations';
 import WordBrowserDialog from './WordBrowserDialog';
 import '../app/components/subtitles.css';
 import ButtonGroup from '@mui/material/ButtonGroup';

--- a/common/components/DictionarySettingsTab.tsx
+++ b/common/components/DictionarySettingsTab.tsx
@@ -5,6 +5,7 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import FormControl from '@mui/material/FormControl';
@@ -48,6 +49,7 @@ import {
     EnabledAnnotations,
     TokenAnnotationConfigTarget,
     tokenAnnotationStyleValues,
+    dictionaryTrackEnabled,
 } from '@project/common/settings';
 import { Anki } from '../anki';
 import { WaniKani, WaniKaniUser } from '../wanikani';
@@ -89,7 +91,6 @@ import {
 } from '@project/common/annotations';
 import WordBrowserDialog from './WordBrowserDialog';
 import '../app/components/subtitles.css';
-import ButtonGroup from '@mui/material/ButtonGroup';
 import SettingsGroups from './SettingsGroups';
 
 const yomitanInstallerUrl = 'https://github.com/yomidevs/yomitan-api';
@@ -1016,6 +1017,7 @@ const DictionarySettingsTab: React.FC<Props> = ({
         [settings, selectedDictionaryTrack]
     );
     const theme = useTheme();
+    const dictionaryAnnotationsEnabled = dictionaryTrackEnabled(selectedDictionary);
     const selectedTokenAnnotationTargetIndex = tokenAnnotationTargets.findIndex(
         ({ target }) => target === tokenAnnotationTarget
     );
@@ -1190,98 +1192,127 @@ const DictionarySettingsTab: React.FC<Props> = ({
                         </MenuItem>
                     ))}
                 </SettingsTextField>
-                <SwitchLabelWithHoverEffect
-                    control={
-                        <Switch
-                            checked={selectedDictionary.dictionaryTokenAnnotationConfig.colorizeEnabled}
-                            onChange={(e) => {
-                                const colorizeEnabled = e.target.checked;
-                                const newTracks = [...dictionaryTracks];
-                                newTracks[selectedDictionaryTrack] = {
-                                    ...newTracks[selectedDictionaryTrack],
-                                    dictionaryColorizeSubtitles: colorizeEnabled,
-                                    dictionaryTokenAnnotationConfig: {
-                                        ...newTracks[selectedDictionaryTrack].dictionaryTokenAnnotationConfig,
-                                        colorizeEnabled,
-                                    },
-                                };
-                                onSettingChanged('dictionaryTracks', newTracks);
+                <Box>
+                    <Box
+                        component="fieldset"
+                        sx={{
+                            m: 0,
+                            p: 1.5,
+                            border: (theme) => `1px solid ${theme.palette.action.focus}`,
+                            borderRadius: 1,
+                        }}
+                    >
+                        <Typography
+                            component="legend"
+                            variant="caption"
+                            sx={{
+                                px: 0.5,
+                                color: dictionaryAnnotationsEnabled ? 'primary.main' : 'text.secondary',
                             }}
-                        />
-                    }
-                    label={t('settings.dictionaryColorizeSubtitles')}
-                    labelPlacement="start"
-                />
-                <SwitchLabelWithHoverEffect
-                    control={
-                        <Switch
-                            checked={selectedDictionary.dictionaryAutoGenerateStatistics}
-                            onChange={(e) => {
-                                const newTracks = [...dictionaryTracks];
-                                newTracks[selectedDictionaryTrack] = {
-                                    ...newTracks[selectedDictionaryTrack],
-                                    dictionaryAutoGenerateStatistics: e.target.checked,
-                                };
-                                onSettingChanged('dictionaryTracks', newTracks);
-                            }}
-                        />
-                    }
-                    label={t('settings.dictionaryAutoGenerateStatistics')}
-                    labelPlacement="start"
-                />
-                {supportsDictionaryTokenAnnotationConfig &&
-                    tokenAnnotationTriggerOptions.map(({ annotation, labelKey }) => {
-                        const value = tokenAnnotationSelectionOptionValues(
-                            tokenAnnotationSelection(selectedDictionary.dictionaryTokenAnnotationConfig, annotation)
-                        );
-                        return (
-                            <SettingsTextField
-                                key={annotation}
-                                select
-                                fullWidth
-                                color="primary"
-                                variant="outlined"
-                                size="small"
-                                label={t(labelKey)!}
-                                value={value}
-                                helperText={
-                                    annotation === 'pitchAccent'
-                                        ? dictionaryTokenPitchAccentUnderlineOverlineStyleWarning
-                                        : undefined
+                        >
+                            {t('settings.dictionaryEnableAnnotations')}
+                        </Typography>
+                        <Stack spacing={1}>
+                            <SwitchLabelWithHoverEffect
+                                control={
+                                    <Switch
+                                        checked={selectedDictionary.dictionaryTokenAnnotationConfig.colorizeEnabled}
+                                        onChange={(e) => {
+                                            const colorizeEnabled = e.target.checked;
+                                            const newTracks = [...dictionaryTracks];
+                                            newTracks[selectedDictionaryTrack] = {
+                                                ...newTracks[selectedDictionaryTrack],
+                                                dictionaryColorizeSubtitles: colorizeEnabled,
+                                                dictionaryTokenAnnotationConfig: {
+                                                    ...newTracks[selectedDictionaryTrack]
+                                                        .dictionaryTokenAnnotationConfig,
+                                                    colorizeEnabled,
+                                                },
+                                            };
+                                            onSettingChanged('dictionaryTracks', newTracks);
+                                        }}
+                                    />
                                 }
-                                SelectProps={{
-                                    multiple: true,
-                                    renderValue: (selected) => {
-                                        const selectedValues = tokenAnnotationOptionValues(selected);
-                                        const selection = tokenAnnotationSelectionFromOptionValues(selectedValues);
-                                        const statusLabels = tokenAnnotationStatusSelectionLabels(
-                                            selection.statuses,
-                                            tokenAnnotationStatusLabel
-                                        );
-                                        const stateLabels = selection.states.map(tokenAnnotationStateLabel);
-                                        return ([...statusLabels, ...stateLabels].join(', ') ||
-                                            t('settings.dictionaryTokenReadingAnnotationNever'))!;
-                                    },
-                                }}
-                                onChange={(e) => {
-                                    const selectedValues = tokenAnnotationOptionValues(e.target.value);
-                                    updateDictionaryTokenAnnotationStatusesAndStates(
-                                        annotation,
-                                        tokenAnnotationSelectionFromOptionValues(selectedValues)
+                                label={t('settings.dictionaryColorizeSubtitles')}
+                                labelPlacement="start"
+                            />
+                            <SwitchLabelWithHoverEffect
+                                control={
+                                    <Switch
+                                        checked={selectedDictionary.dictionaryAutoGenerateStatistics}
+                                        onChange={(e) => {
+                                            const newTracks = [...dictionaryTracks];
+                                            newTracks[selectedDictionaryTrack] = {
+                                                ...newTracks[selectedDictionaryTrack],
+                                                dictionaryAutoGenerateStatistics: e.target.checked,
+                                            };
+                                            onSettingChanged('dictionaryTracks', newTracks);
+                                        }}
+                                    />
+                                }
+                                label={t('settings.dictionaryAutoGenerateStatistics')}
+                                labelPlacement="start"
+                            />
+                            {supportsDictionaryTokenAnnotationConfig &&
+                                tokenAnnotationTriggerOptions.map(({ annotation, labelKey }) => {
+                                    const value = tokenAnnotationSelectionOptionValues(
+                                        tokenAnnotationSelection(
+                                            selectedDictionary.dictionaryTokenAnnotationConfig,
+                                            annotation
+                                        )
                                     );
-                                }}
-                            >
-                                {tokenAnnotationSelectOptions.map((option) => (
-                                    <MenuItem key={option.value} value={option.value}>
-                                        <ListItemIcon>
-                                            <Checkbox checked={value.includes(option.value)} />
-                                        </ListItemIcon>
-                                        <ListItemText primary={option.label} />
-                                    </MenuItem>
-                                ))}
-                            </SettingsTextField>
-                        );
-                    })}
+                                    return (
+                                        <SettingsTextField
+                                            key={annotation}
+                                            select
+                                            fullWidth
+                                            color="primary"
+                                            variant="outlined"
+                                            size="small"
+                                            label={t(labelKey)!}
+                                            value={value}
+                                            helperText={
+                                                annotation === 'pitchAccent'
+                                                    ? dictionaryTokenPitchAccentUnderlineOverlineStyleWarning
+                                                    : undefined
+                                            }
+                                            SelectProps={{
+                                                multiple: true,
+                                                renderValue: (selected) => {
+                                                    const selectedValues = tokenAnnotationOptionValues(selected);
+                                                    const selection =
+                                                        tokenAnnotationSelectionFromOptionValues(selectedValues);
+                                                    const statusLabels = tokenAnnotationStatusSelectionLabels(
+                                                        selection.statuses,
+                                                        tokenAnnotationStatusLabel
+                                                    );
+                                                    const stateLabels = selection.states.map(tokenAnnotationStateLabel);
+                                                    return ([...statusLabels, ...stateLabels].join(', ') ||
+                                                        t('settings.dictionaryTokenReadingAnnotationNever'))!;
+                                                },
+                                            }}
+                                            onChange={(e) => {
+                                                const selectedValues = tokenAnnotationOptionValues(e.target.value);
+                                                updateDictionaryTokenAnnotationStatusesAndStates(
+                                                    annotation,
+                                                    tokenAnnotationSelectionFromOptionValues(selectedValues)
+                                                );
+                                            }}
+                                        >
+                                            {tokenAnnotationSelectOptions.map((option) => (
+                                                <MenuItem key={option.value} value={option.value}>
+                                                    <ListItemIcon>
+                                                        <Checkbox checked={value.includes(option.value)} />
+                                                    </ListItemIcon>
+                                                    <ListItemText primary={option.label} />
+                                                </MenuItem>
+                                            ))}
+                                        </SettingsTextField>
+                                    );
+                                })}
+                        </Stack>
+                    </Box>
+                </Box>
                 {!supportsDictionaryTokenAnnotationConfig && (
                     <>
                         <FormControl>

--- a/common/components/DictionarySettingsTab.tsx
+++ b/common/components/DictionarySettingsTab.tsx
@@ -29,7 +29,6 @@ import {
     AsbplayerSettings,
     TokenMatchStrategy,
     TokenMatchStrategyPriority,
-    TokenReadingAnnotation,
     TokenStyling,
     getFullyKnownTokenStatus,
     NUM_DICTIONARY_TRACKS,
@@ -38,7 +37,6 @@ import {
     compareDTField,
     Profile,
     dictionaryStatusCollectionEnabled,
-    TokenFrequencyAnnotation,
     TokenStatusConfig,
     textSubtitleSettingsForTrack,
     TextSubtitleSettings,
@@ -160,7 +158,6 @@ const tokenAnnotationTriggerOptions: { annotation: TokenAnnotationTriggerKey; la
     { annotation: 'frequency', labelKey: 'settings.dictionaryTokenFrequencyAnnotation' },
     { annotation: 'pitchAccent', labelKey: 'settings.dictionaryTokenPitchAccentAnnotation' },
 ];
-const legacyVideoHoverAnnotationKeys: TokenAnnotationHoverKey[] = ['color', 'reading', 'frequency'];
 
 const tokenAnnotationStatusOptionValue = (status: TokenStatus) => status;
 const tokenAnnotationStateOptionValue = (state: TokenState) => NUM_TOKEN_STATUSES + state;
@@ -225,18 +222,6 @@ const withTokenAnnotationHoverEnabled = (
         },
     },
 });
-
-const withTokenAnnotationsHoverEnabled = (
-    config: DictionaryTokenAnnotationConfig,
-    target: TokenAnnotationConfigTarget,
-    annotations: TokenAnnotationHoverKey[],
-    onHoverEnabled: boolean
-): DictionaryTokenAnnotationConfig =>
-    annotations.reduce<DictionaryTokenAnnotationConfig>(
-        (updatedConfig, annotation) =>
-            withTokenAnnotationHoverEnabled(updatedConfig, target, annotation, onHoverEnabled),
-        config
-    );
 
 const withTokenAnnotationSize = (
     config: DictionaryTokenAnnotationConfig,
@@ -535,7 +520,6 @@ interface Props {
     supportsDictionaryBrowser: boolean;
     supportsDictionaryWaniKani: boolean;
     supportsDictionaryMatchAcrossScripts: boolean;
-    supportsDictionaryTokenAnnotationConfig: boolean;
     supportsDictionaryTokenStatusDisplayAlpha: boolean;
     supportsDictionaryYomitanMecab: boolean;
     onSettingChanged: <K extends keyof AsbplayerSettings>(key: K, value: AsbplayerSettings[K]) => Promise<void>;
@@ -552,7 +536,6 @@ const DictionarySettingsTab: React.FC<Props> = ({
     supportsDictionaryBrowser,
     supportsDictionaryWaniKani,
     supportsDictionaryMatchAcrossScripts,
-    supportsDictionaryTokenAnnotationConfig,
     supportsDictionaryTokenStatusDisplayAlpha,
     supportsDictionaryYomitanMecab,
     onSettingChanged,
@@ -666,7 +649,6 @@ const DictionarySettingsTab: React.FC<Props> = ({
         [selectedDictionary.dictionaryTokenAnnotationConfig]
     );
     const dictionaryTokenPitchAccentUnderlineOverlineStyleWarning =
-        supportsDictionaryTokenAnnotationConfig &&
         dictionaryTokenUnderlineOverlineStyleLabelKey !== undefined &&
         dictionaryTokenPitchAccentAnnotationEnabled &&
         !dictionaryTokenPitchAccentHoverOnlyForAllTargets
@@ -1253,278 +1235,65 @@ const DictionarySettingsTab: React.FC<Props> = ({
                                 label={t('settings.dictionaryAutoGenerateStatistics')}
                                 labelPlacement="start"
                             />
-                            {supportsDictionaryTokenAnnotationConfig &&
-                                tokenAnnotationTriggerOptions.map(({ annotation, labelKey }) => {
-                                    const value = tokenAnnotationSelectionOptionValues(
-                                        tokenAnnotationSelection(
-                                            selectedDictionary.dictionaryTokenAnnotationConfig,
-                                            annotation
-                                        )
-                                    );
-                                    return (
-                                        <SettingsTextField
-                                            key={annotation}
-                                            select
-                                            fullWidth
-                                            color="primary"
-                                            variant="outlined"
-                                            size="small"
-                                            label={t(labelKey)!}
-                                            value={value}
-                                            helperText={
-                                                annotation === 'pitchAccent'
-                                                    ? dictionaryTokenPitchAccentUnderlineOverlineStyleWarning
-                                                    : undefined
-                                            }
-                                            SelectProps={{
-                                                multiple: true,
-                                                renderValue: (selected) => {
-                                                    const selectedValues = tokenAnnotationOptionValues(selected);
-                                                    const selection =
-                                                        tokenAnnotationSelectionFromOptionValues(selectedValues);
-                                                    const statusLabels = tokenAnnotationStatusSelectionLabels(
-                                                        selection.statuses,
-                                                        tokenAnnotationStatusLabel
-                                                    );
-                                                    const stateLabels = selection.states.map(tokenAnnotationStateLabel);
-                                                    return ([...statusLabels, ...stateLabels].join(', ') ||
-                                                        t('settings.dictionaryTokenReadingAnnotationNever'))!;
-                                                },
-                                            }}
-                                            onChange={(e) => {
-                                                const selectedValues = tokenAnnotationOptionValues(e.target.value);
-                                                updateDictionaryTokenAnnotationStatusesAndStates(
-                                                    annotation,
-                                                    tokenAnnotationSelectionFromOptionValues(selectedValues)
+                            {tokenAnnotationTriggerOptions.map(({ annotation, labelKey }) => {
+                                const value = tokenAnnotationSelectionOptionValues(
+                                    tokenAnnotationSelection(
+                                        selectedDictionary.dictionaryTokenAnnotationConfig,
+                                        annotation
+                                    )
+                                );
+                                return (
+                                    <SettingsTextField
+                                        key={annotation}
+                                        select
+                                        fullWidth
+                                        color="primary"
+                                        variant="outlined"
+                                        size="small"
+                                        label={t(labelKey)!}
+                                        value={value}
+                                        helperText={
+                                            annotation === 'pitchAccent'
+                                                ? dictionaryTokenPitchAccentUnderlineOverlineStyleWarning
+                                                : undefined
+                                        }
+                                        SelectProps={{
+                                            multiple: true,
+                                            renderValue: (selected) => {
+                                                const selectedValues = tokenAnnotationOptionValues(selected);
+                                                const selection =
+                                                    tokenAnnotationSelectionFromOptionValues(selectedValues);
+                                                const statusLabels = tokenAnnotationStatusSelectionLabels(
+                                                    selection.statuses,
+                                                    tokenAnnotationStatusLabel
                                                 );
-                                            }}
-                                        >
-                                            {tokenAnnotationSelectOptions.map((option) => (
-                                                <MenuItem key={option.value} value={option.value}>
-                                                    <ListItemIcon>
-                                                        <Checkbox checked={value.includes(option.value)} />
-                                                    </ListItemIcon>
-                                                    <ListItemText primary={option.label} />
-                                                </MenuItem>
-                                            ))}
-                                        </SettingsTextField>
-                                    );
-                                })}
+                                                const stateLabels = selection.states.map(tokenAnnotationStateLabel);
+                                                return ([...statusLabels, ...stateLabels].join(', ') ||
+                                                    t('settings.dictionaryTokenReadingAnnotationNever'))!;
+                                            },
+                                        }}
+                                        onChange={(e) => {
+                                            const selectedValues = tokenAnnotationOptionValues(e.target.value);
+                                            updateDictionaryTokenAnnotationStatusesAndStates(
+                                                annotation,
+                                                tokenAnnotationSelectionFromOptionValues(selectedValues)
+                                            );
+                                        }}
+                                    >
+                                        {tokenAnnotationSelectOptions.map((option) => (
+                                            <MenuItem key={option.value} value={option.value}>
+                                                <ListItemIcon>
+                                                    <Checkbox checked={value.includes(option.value)} />
+                                                </ListItemIcon>
+                                                <ListItemText primary={option.label} />
+                                            </MenuItem>
+                                        ))}
+                                    </SettingsTextField>
+                                );
+                            })}
                         </Stack>
                     </Box>
                 </Box>
-                {!supportsDictionaryTokenAnnotationConfig && (
-                    <>
-                        <FormControl>
-                            <FormLabel component="legend">{t('settings.dictionaryTokenReadingAnnotation')}</FormLabel>
-                            <RadioGroup row={false}>
-                                <LabelWithHoverEffect
-                                    control={
-                                        <Radio
-                                            checked={
-                                                selectedDictionary.dictionaryTokenReadingAnnotation ===
-                                                TokenReadingAnnotation.ALWAYS
-                                            }
-                                            onChange={() => {
-                                                const newTracks = [...dictionaryTracks];
-                                                newTracks[selectedDictionaryTrack] = {
-                                                    ...newTracks[selectedDictionaryTrack],
-                                                    dictionaryTokenReadingAnnotation: TokenReadingAnnotation.ALWAYS,
-                                                };
-                                                onSettingChanged('dictionaryTracks', newTracks);
-                                            }}
-                                        />
-                                    }
-                                    label={t('settings.dictionaryTokenReadingAnnotationAlways')}
-                                />
-                                <LabelWithHoverEffect
-                                    control={
-                                        <Radio
-                                            checked={
-                                                selectedDictionary.dictionaryTokenReadingAnnotation ===
-                                                TokenReadingAnnotation.LEARNING_OR_BELOW
-                                            }
-                                            onChange={() => {
-                                                const newTracks = [...dictionaryTracks];
-                                                newTracks[selectedDictionaryTrack] = {
-                                                    ...newTracks[selectedDictionaryTrack],
-                                                    dictionaryTokenReadingAnnotation:
-                                                        TokenReadingAnnotation.LEARNING_OR_BELOW,
-                                                };
-                                                onSettingChanged('dictionaryTracks', newTracks);
-                                            }}
-                                        />
-                                    }
-                                    label={t('settings.dictionaryTokenReadingAnnotationLearningOrBelow')}
-                                />
-                                <LabelWithHoverEffect
-                                    control={
-                                        <Radio
-                                            checked={
-                                                selectedDictionary.dictionaryTokenReadingAnnotation ===
-                                                TokenReadingAnnotation.UNKNOWN_OR_BELOW
-                                            }
-                                            onChange={() => {
-                                                const newTracks = [...dictionaryTracks];
-                                                newTracks[selectedDictionaryTrack] = {
-                                                    ...newTracks[selectedDictionaryTrack],
-                                                    dictionaryTokenReadingAnnotation:
-                                                        TokenReadingAnnotation.UNKNOWN_OR_BELOW,
-                                                };
-                                                onSettingChanged('dictionaryTracks', newTracks);
-                                            }}
-                                        />
-                                    }
-                                    label={t('settings.dictionaryTokenReadingAnnotationUnknownOrBelow')}
-                                />
-                                <LabelWithHoverEffect
-                                    control={
-                                        <Radio
-                                            checked={
-                                                selectedDictionary.dictionaryTokenReadingAnnotation ===
-                                                TokenReadingAnnotation.NEVER
-                                            }
-                                            onChange={() => {
-                                                const newTracks = [...dictionaryTracks];
-                                                newTracks[selectedDictionaryTrack] = {
-                                                    ...newTracks[selectedDictionaryTrack],
-                                                    dictionaryTokenReadingAnnotation: TokenReadingAnnotation.NEVER,
-                                                };
-                                                onSettingChanged('dictionaryTracks', newTracks);
-                                            }}
-                                        />
-                                    }
-                                    label={t('settings.dictionaryTokenReadingAnnotationNever')}
-                                />
-                            </RadioGroup>
-                        </FormControl>
-                        <SwitchLabelWithHoverEffect
-                            control={
-                                <Switch
-                                    checked={selectedDictionary.dictionaryDisplayIgnoredTokenReadings}
-                                    onChange={(e) => {
-                                        const newTracks = [...dictionaryTracks];
-                                        newTracks[selectedDictionaryTrack] = {
-                                            ...newTracks[selectedDictionaryTrack],
-                                            dictionaryDisplayIgnoredTokenReadings: e.target.checked,
-                                        };
-                                        onSettingChanged('dictionaryTracks', newTracks);
-                                    }}
-                                />
-                            }
-                            label={t('settings.dictionaryDisplayIgnoredTokenReadings')}
-                            labelPlacement="start"
-                        />
-                        <FormControl>
-                            <FormLabel component="legend">{t('settings.dictionaryTokenFrequencyAnnotation')}</FormLabel>
-                            <RadioGroup row={false}>
-                                <LabelWithHoverEffect
-                                    control={
-                                        <Radio
-                                            checked={
-                                                selectedDictionary.dictionaryTokenFrequencyAnnotation ===
-                                                TokenFrequencyAnnotation.ALWAYS
-                                            }
-                                            onChange={() => {
-                                                const newTracks = [...dictionaryTracks];
-                                                newTracks[selectedDictionaryTrack] = {
-                                                    ...newTracks[selectedDictionaryTrack],
-                                                    dictionaryTokenFrequencyAnnotation: TokenFrequencyAnnotation.ALWAYS,
-                                                };
-                                                onSettingChanged('dictionaryTracks', newTracks);
-                                            }}
-                                        />
-                                    }
-                                    label={t('settings.dictionaryTokenFrequencyAnnotationAlways')}
-                                />
-                                <LabelWithHoverEffect
-                                    control={
-                                        <Radio
-                                            checked={
-                                                selectedDictionary.dictionaryTokenFrequencyAnnotation ===
-                                                TokenFrequencyAnnotation.UNCOLLECTED_ONLY
-                                            }
-                                            onChange={() => {
-                                                const newTracks = [...dictionaryTracks];
-                                                newTracks[selectedDictionaryTrack] = {
-                                                    ...newTracks[selectedDictionaryTrack],
-                                                    dictionaryTokenFrequencyAnnotation:
-                                                        TokenFrequencyAnnotation.UNCOLLECTED_ONLY,
-                                                };
-                                                onSettingChanged('dictionaryTracks', newTracks);
-                                            }}
-                                        />
-                                    }
-                                    label={t('settings.dictionaryTokenFrequencyAnnotationUncollectedOnly')}
-                                />
-                                <LabelWithHoverEffect
-                                    control={
-                                        <Radio
-                                            checked={
-                                                selectedDictionary.dictionaryTokenFrequencyAnnotation ===
-                                                TokenFrequencyAnnotation.NEVER
-                                            }
-                                            onChange={() => {
-                                                const newTracks = [...dictionaryTracks];
-                                                newTracks[selectedDictionaryTrack] = {
-                                                    ...newTracks[selectedDictionaryTrack],
-                                                    dictionaryTokenFrequencyAnnotation: TokenFrequencyAnnotation.NEVER,
-                                                };
-                                                onSettingChanged('dictionaryTracks', newTracks);
-                                            }}
-                                        />
-                                    }
-                                    label={t('settings.dictionaryTokenFrequencyAnnotationNever')}
-                                />
-                            </RadioGroup>
-                        </FormControl>
-                    </>
-                )}
-                {!supportsDictionaryTokenAnnotationConfig && (
-                    <>
-                        <SwitchLabelWithHoverEffect
-                            control={
-                                <Switch
-                                    checked={selectedDictionary.dictionaryColorizeOnHoverOnly}
-                                    onChange={(e) => {
-                                        const onHoverEnabled = e.target.checked;
-                                        const newTracks = [...dictionaryTracks];
-                                        newTracks[selectedDictionaryTrack] = {
-                                            ...newTracks[selectedDictionaryTrack],
-                                            dictionaryColorizeOnHoverOnly: onHoverEnabled,
-                                            dictionaryTokenAnnotationConfig: withTokenAnnotationsHoverEnabled(
-                                                newTracks[selectedDictionaryTrack].dictionaryTokenAnnotationConfig,
-                                                'video',
-                                                legacyVideoHoverAnnotationKeys,
-                                                onHoverEnabled
-                                            ),
-                                        };
-                                        onSettingChanged('dictionaryTracks', newTracks);
-                                    }}
-                                />
-                            }
-                            label={t('settings.dictionaryColorizeOnHoverOnly')}
-                            labelPlacement="start"
-                        />
-                        <SwitchLabelWithHoverEffect
-                            control={
-                                <Switch
-                                    checked={selectedDictionary.dictionaryHighlightOnHover}
-                                    onChange={(e) => {
-                                        const newTracks = [...dictionaryTracks];
-                                        newTracks[selectedDictionaryTrack] = {
-                                            ...newTracks[selectedDictionaryTrack],
-                                            dictionaryHighlightOnHover: e.target.checked,
-                                        };
-                                        onSettingChanged('dictionaryTracks', newTracks);
-                                    }}
-                                />
-                            }
-                            label={t('settings.dictionaryHighlightOnHover')}
-                            labelPlacement="start"
-                        />
-                    </>
-                )}
                 <SettingsSection>{t('settings.coloringStrategy')}</SettingsSection>
                 <FormControl>
                     <FormLabel component="legend">{t('settings.dictionaryTokenMatchStrategy')}</FormLabel>
@@ -2239,98 +2008,95 @@ const DictionarySettingsTab: React.FC<Props> = ({
                         }}
                     />
                 )}
-                {supportsDictionaryTokenAnnotationConfig && (
-                    <>
+
+                <SwitchLabelWithHoverEffect
+                    control={
+                        <Switch
+                            checked={selectedDictionary.dictionaryHighlightOnHover}
+                            onChange={(e) => {
+                                const newTracks = [...dictionaryTracks];
+                                newTracks[selectedDictionaryTrack] = {
+                                    ...newTracks[selectedDictionaryTrack],
+                                    dictionaryHighlightOnHover: e.target.checked,
+                                };
+                                onSettingChanged('dictionaryTracks', newTracks);
+                            }}
+                        />
+                    }
+                    label={t('settings.dictionaryHighlightOnHover')}
+                    labelPlacement="start"
+                />
+                <SettingsGroups
+                    groupLabels={tokenAnnotationTargets.map(({ labelKey }) => t(labelKey))}
+                    selectedGroupIndex={selectedTokenAnnotationTargetIndex}
+                    onGroupSelected={(index) => setTokenAnnotationTarget(tokenAnnotationTargets[index].target)}
+                >
+                    {tokenAnnotationHoverOptions.map(({ annotation, labelKey }) => (
                         <SwitchLabelWithHoverEffect
+                            key={annotation}
                             control={
                                 <Switch
-                                    checked={selectedDictionary.dictionaryHighlightOnHover}
-                                    onChange={(e) => {
-                                        const newTracks = [...dictionaryTracks];
-                                        newTracks[selectedDictionaryTrack] = {
-                                            ...newTracks[selectedDictionaryTrack],
-                                            dictionaryHighlightOnHover: e.target.checked,
-                                        };
-                                        onSettingChanged('dictionaryTracks', newTracks);
-                                    }}
+                                    checked={
+                                        selectedDictionary.dictionaryTokenAnnotationConfig[tokenAnnotationTarget][
+                                            annotation
+                                        ].onHoverEnabled
+                                    }
+                                    onChange={(e) =>
+                                        updateDictionaryTokenHoverAnnotation(
+                                            tokenAnnotationTarget,
+                                            annotation,
+                                            e.target.checked
+                                        )
+                                    }
                                 />
                             }
-                            label={t('settings.dictionaryHighlightOnHover')}
+                            label={t(labelKey)}
                             labelPlacement="start"
                         />
-                        <SettingsGroups
-                            groupLabels={tokenAnnotationTargets.map(({ labelKey }) => t(labelKey))}
-                            selectedGroupIndex={selectedTokenAnnotationTargetIndex}
-                            onGroupSelected={(index) => setTokenAnnotationTarget(tokenAnnotationTargets[index].target)}
+                    ))}
+                    {tokenAnnotationSizeOptions.map(({ annotation, labelKey }) => (
+                        <Stack
+                            key={annotation}
+                            direction="row"
+                            spacing={1}
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                width: '100%',
+                            }}
                         >
-                            {tokenAnnotationHoverOptions.map(({ annotation, labelKey }) => (
-                                <SwitchLabelWithHoverEffect
-                                    key={annotation}
-                                    control={
-                                        <Switch
-                                            checked={
-                                                selectedDictionary.dictionaryTokenAnnotationConfig[
-                                                    tokenAnnotationTarget
-                                                ][annotation].onHoverEnabled
-                                            }
-                                            onChange={(e) =>
-                                                updateDictionaryTokenHoverAnnotation(
-                                                    tokenAnnotationTarget,
-                                                    annotation,
-                                                    e.target.checked
-                                                )
-                                            }
-                                        />
+                            <Typography sx={{ minWidth: 'min(50%,110px)' }}>{t(labelKey)}</Typography>
+                            <div style={{ flexGrow: 1 }} />
+                            <div style={{ width: 'min(50%,110px)', flexShrink: 0 }}>
+                                <SettingsTextField
+                                    type="number"
+                                    size="small"
+                                    value={
+                                        selectedDictionary.dictionaryTokenAnnotationConfig[tokenAnnotationTarget][
+                                            annotation
+                                        ].size
                                     }
-                                    label={t(labelKey)}
-                                    labelPlacement="start"
-                                />
-                            ))}
-                            {tokenAnnotationSizeOptions.map(({ annotation, labelKey }) => (
-                                <Stack
-                                    key={annotation}
-                                    direction="row"
-                                    spacing={1}
-                                    sx={{
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        width: '100%',
+                                    onChange={(e) =>
+                                        updateDictionaryTokenAnnotationSize(
+                                            tokenAnnotationTarget,
+                                            annotation,
+                                            Number(e.target.value)
+                                        )
+                                    }
+                                    slotProps={{
+                                        htmlInput: {
+                                            min: 0.1,
+                                            step: 0.1,
+                                        },
+                                        input: {
+                                            endAdornment: <InputAdornment position="end">em</InputAdornment>,
+                                        },
                                     }}
-                                >
-                                    <Typography sx={{ minWidth: 'min(50%,110px)' }}>{t(labelKey)}</Typography>
-                                    <div style={{ flexGrow: 1 }} />
-                                    <div style={{ width: 'min(50%,110px)', flexShrink: 0 }}>
-                                        <SettingsTextField
-                                            type="number"
-                                            size="small"
-                                            value={
-                                                selectedDictionary.dictionaryTokenAnnotationConfig[
-                                                    tokenAnnotationTarget
-                                                ][annotation].size
-                                            }
-                                            onChange={(e) =>
-                                                updateDictionaryTokenAnnotationSize(
-                                                    tokenAnnotationTarget,
-                                                    annotation,
-                                                    Number(e.target.value)
-                                                )
-                                            }
-                                            slotProps={{
-                                                htmlInput: {
-                                                    min: 0.1,
-                                                    step: 0.1,
-                                                },
-                                                input: {
-                                                    endAdornment: <InputAdornment position="end">em</InputAdornment>,
-                                                },
-                                            }}
-                                        />
-                                    </div>
-                                </Stack>
-                            ))}
-                        </SettingsGroups>
-                    </>
-                )}
+                                />
+                            </div>
+                        </Stack>
+                    ))}
+                </SettingsGroups>
                 {supportsDictionaryTokenStatusDisplayAlpha ? (
                     <Stack spacing={1}>
                         {[...Array(NUM_TOKEN_STATUSES).keys()].map((i) => {

--- a/common/components/SettingsForm.tsx
+++ b/common/components/SettingsForm.tsx
@@ -182,7 +182,6 @@ interface Props {
     extensionSupportsDictionaryBrowser: boolean;
     extensionSupportsDictionaryWaniKani: boolean;
     extensionSupportsDictionaryMatchAcrossScripts: boolean;
-    extensionSupportsDictionaryTokenAnnotationConfig: boolean;
     extensionSupportsSeekableTrackSetting: boolean;
     extensionSupportsAutoCopyableTrackSetting: boolean;
     extensionSupportsDictionaryTokenStatusDisplayAlpha: boolean;
@@ -236,7 +235,6 @@ export default function SettingsForm({
     extensionSupportsDictionaryBrowser,
     extensionSupportsDictionaryWaniKani,
     extensionSupportsDictionaryMatchAcrossScripts,
-    extensionSupportsDictionaryTokenAnnotationConfig,
     extensionSupportsSeekableTrackSetting,
     extensionSupportsAutoCopyableTrackSetting,
     extensionSupportsDictionaryTokenStatusDisplayAlpha,
@@ -265,8 +263,6 @@ export default function SettingsForm({
     const supportsDictionaryMatchAcrossScripts = !extensionInstalled || extensionSupportsDictionaryMatchAcrossScripts;
     const supportsDictionaryTokenStatusDisplayAlpha =
         !extensionInstalled || extensionSupportsDictionaryTokenStatusDisplayAlpha;
-    const supportsDictionaryTokenAnnotationConfig =
-        !extensionInstalled || extensionSupportsDictionaryTokenAnnotationConfig;
     const supportsDictionaryYomitanMecab = !extensionInstalled || extensionSupportsDictionaryYomitanMecab;
     const theme = useTheme();
     const settingsTheme = useMemo(
@@ -505,7 +501,6 @@ export default function SettingsForm({
                         supportsDictionaryBrowser={supportsDictionaryBrowser}
                         supportsDictionaryWaniKani={supportsDictionaryWaniKani}
                         supportsDictionaryMatchAcrossScripts={supportsDictionaryMatchAcrossScripts}
-                        supportsDictionaryTokenAnnotationConfig={supportsDictionaryTokenAnnotationConfig}
                         supportsDictionaryTokenStatusDisplayAlpha={supportsDictionaryTokenStatusDisplayAlpha}
                         supportsDictionaryYomitanMecab={supportsDictionaryYomitanMecab}
                         onSettingChanged={handleSettingChanged}

--- a/common/components/StatisticsSentenceDetailsDialog.tsx
+++ b/common/components/StatisticsSentenceDetailsDialog.tsx
@@ -28,7 +28,7 @@ import {
     RichTextWindow,
     RenderedRichText,
     renderRichTextForSubtitle,
-} from '@project/common/subtitle-annotations';
+} from '@project/common/annotations';
 import { timeDurationDisplay } from '@project/common/util';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';

--- a/common/dictionary-db/dictionary-db-anki.ts
+++ b/common/dictionary-db/dictionary-db-anki.ts
@@ -19,7 +19,7 @@ import {
     TokenStatus,
 } from '@project/common/settings';
 import { HAS_LETTER_REGEX, inBatches, mapAsync } from '@project/common/util';
-import { Yomitan } from '@project/common/yomitan/yomitan';
+import { Yomitan } from '@project/common/yomitan';
 import { v4 as uuidv4 } from 'uuid';
 import {
     _DictionaryDatabase,

--- a/common/dictionary-db/dictionary-db-wanikani.ts
+++ b/common/dictionary-db/dictionary-db-wanikani.ts
@@ -17,7 +17,7 @@ import {
     WaniKaniSpacedRepetitionSystem,
     WaniKaniSubject,
 } from '@project/common/wanikani';
-import { Yomitan } from '@project/common/yomitan/yomitan';
+import { Yomitan } from '@project/common/yomitan';
 import { v4 as uuidv4 } from 'uuid';
 import {
     _DictionaryDatabase,

--- a/common/dictionary-db/dictionary-db.ts
+++ b/common/dictionary-db/dictionary-db.ts
@@ -14,7 +14,7 @@ import {
 } from '@project/common/settings';
 import { getTokenStatus, HAS_LETTER_REGEX, normalizeToken } from '@project/common/util';
 import { WaniKaniAssignment, WaniKaniSpacedRepetitionSystem, WaniKaniSubject } from '@project/common/wanikani';
-import { Yomitan } from '@project/common/yomitan/yomitan';
+import { Yomitan } from '@project/common/yomitan';
 import Dexie from 'dexie';
 import { buildAnkiCachePipeline } from '@project/common/dictionary-db';
 import { buildWaniKaniCachePipeline } from '@project/common/dictionary-db';

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Local word database",
         "dictionaryAnkiWordDatabase": "Anki word database",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colorize subtitles based on known words",
         "dictionaryAutoGenerateStatistics": "Generate statistics automatically",
         "dictionaryColorizeOnHoverOnly": "On Hover Only",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Local word database",
         "dictionaryAnkiWordDatabase": "Anki word database",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colorize subtitles based on known words",
         "dictionaryAutoGenerateStatistics": "Generate statistics automatically",
         "dictionaryColorizeOnHoverOnly": "Only show annotations on hover",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Local word database",
         "dictionaryAnkiWordDatabase": "Anki word database",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colorize subtitles based on known words",
         "dictionaryAutoGenerateStatistics": "Generate statistics automatically",
         "dictionaryColorizeOnHoverOnly": "On Hover Only",

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Local word database",
         "dictionaryAnkiWordDatabase": "Anki word database",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colorize subtitles based on known words",
         "dictionaryAutoGenerateStatistics": "Generate statistics automatically",
         "dictionaryColorizeOnHoverOnly": "On Hover Only",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Local word database",
         "dictionaryAnkiWordDatabase": "Anki word database",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colorize subtitles based on known words",
         "dictionaryAutoGenerateStatistics": "Generate statistics automatically",
         "dictionaryColorizeOnHoverOnly": "On Hover Only",

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Local word database",
         "dictionaryAnkiWordDatabase": "Anki word database",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colorize subtitles based on known words",
         "dictionaryAutoGenerateStatistics": "Generate statistics automatically",
         "dictionaryColorizeOnHoverOnly": "On Hover Only",

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Database parole locale",
         "dictionaryAnkiWordDatabase": "Database parole Anki",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colora i sottotitoli in base alle parole conosciute",
         "dictionaryAutoGenerateStatistics": "Genera statistiche automaticamente",
         "dictionaryColorizeOnHoverOnly": "Mostra annotazioni solo al passaggio del mouse",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "ローカルの単語データベース",
         "dictionaryAnkiWordDatabase": "Ankiの単語データベース",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "単語の成熟度をもとに字幕を色づけます",
         "dictionaryAutoGenerateStatistics": "統計を自動的に生成",
         "dictionaryColorizeOnHoverOnly": "マウスカーソルを字幕に重ねるときにのみアノテーションを表示",

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Local word database",
         "dictionaryAnkiWordDatabase": "Anki word database",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colorize subtitles based on known words",
         "dictionaryAutoGenerateStatistics": "Generate statistics automatically",
         "dictionaryColorizeOnHoverOnly": "On Hover Only",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Local word database",
         "dictionaryAnkiWordDatabase": "Anki word database",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colorize subtitles based on known words",
         "dictionaryAutoGenerateStatistics": "Generate statistics automatically",
         "dictionaryColorizeOnHoverOnly": "On Hover Only",

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Local word database",
         "dictionaryAnkiWordDatabase": "Anki word database",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colorize subtitles based on known words",
         "dictionaryAutoGenerateStatistics": "Generate statistics automatically",
         "dictionaryColorizeOnHoverOnly": "On Hover Only",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "Local word database",
         "dictionaryAnkiWordDatabase": "Anki word database",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "Colorize subtitles based on known words",
         "dictionaryAutoGenerateStatistics": "Generate statistics automatically",
         "dictionaryColorizeOnHoverOnly": "On Hover Only",

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -495,6 +495,7 @@
         "dictionaryLocalWordDatabase": "本地生词本",
         "dictionaryAnkiWordDatabase": "Anki 词汇库",
         "dictionaryWaniKaniWordDatabase": "WaniKani word database",
+        "dictionaryEnableAnnotations": "Enable Annotations",
         "dictionaryColorizeSubtitles": "根据词汇掌握度着色",
         "dictionaryAutoGenerateStatistics": "自动生成数据统计",
         "dictionaryColorizeOnHoverOnly": "仅在鼠标悬停时显示颜色",

--- a/common/settings/settings-provider.ts
+++ b/common/settings/settings-provider.ts
@@ -274,7 +274,7 @@ export const defaultSettings: AsbplayerSettings = {
 };
 
 export const NUM_DICTIONARY_TRACKS = defaultSettings.dictionaryTracks.length;
-export const NUM_TOKEN_STATUSES = defaultDictionaryTrackSettings.dictionaryTokenStatusColors.length;
+export const NUM_TOKEN_STATUSES = defaultDictionaryTrackSettings.dictionaryTokenAnnotationConfig.onStatuses.length;
 export const NUM_TOKEN_STATES = defaultDictionaryTrackSettings.dictionaryTokenAnnotationConfig.onStates.length;
 
 export interface AnkiFieldUiModel {

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -1,7 +1,7 @@
 import type { AnkiSettings, TokenState, TokenStatus } from '../settings/settings';
 import type { OnlineSubtitleSourceConfig } from '../global-state';
 import type { TokenStatusInfo } from '../dictionary-db';
-import type { PitchAccentPosition } from '../yomitan/yomitan';
+import type { PitchAccentPosition } from '../yomitan';
 
 type Profile = { name: string };
 

--- a/common/subtitle-annotations/index.ts
+++ b/common/subtitle-annotations/index.ts
@@ -1,1 +1,0 @@
-export * from './subtitle-annotations';

--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -3,7 +3,7 @@ import { Rgb, SubtitleModel, SubtitleTrack, Token, Tokenization, TokenReading } 
 import { TextSubtitleSettings, TokenStatus } from '../settings/settings';
 import { Progress } from '..';
 import { TokenStatusInfo } from '../dictionary-db';
-import { PitchAccentPosition } from '../yomitan/yomitan';
+import { PitchAccentPosition } from '../yomitan';
 
 export function arrayEquals<T>(
     a: readonly T[] | undefined,

--- a/common/yomitan/yomitan.ts
+++ b/common/yomitan/yomitan.ts
@@ -485,10 +485,14 @@ export class Yomitan {
             if (count > maxCount) {
                 maxCount = count;
                 selected = position;
-                continue;
+                continue; // Prefer the most frequent result
             }
-            if (typeof position !== 'string' || typeof selected === 'string') continue;
-            selected = position; // Prefer the first string result when tied
+            if (typeof position !== 'string') continue; // Prefer string results
+            if (typeof selected === 'string') {
+                if (position.length > selected.length) selected = position; // Prefer the longer string result when tied
+            } else {
+                selected = position; // Prefer the first string result when tied
+            }
         }
         this.pitchAccentCache.set(token, selected);
     }
@@ -766,10 +770,14 @@ export class Yomitan {
             if (count > maxCount) {
                 maxCount = count;
                 selected = position;
-                continue;
+                continue; // Prefer the most frequent result
             }
-            if (typeof position !== 'string' || typeof selected === 'string') continue;
-            selected = position; // Prefer the first string result when tied
+            if (typeof position !== 'string') continue; // Prefer string results
+            if (typeof selected === 'string') {
+                if (position.length > selected.length) selected = position; // Prefer the longer string result when tied
+            } else {
+                selected = position; // Prefer the first string result when tied
+            }
         }
         this.pitchAccentCache.set(token, selected);
         return selected;
@@ -956,6 +964,7 @@ export class Yomitan {
             }
             this.supportsTokenizeFrequency = true;
             this.supportsTermEntriesBulk = true;
+            this.supportsTokenizePronunciations = true;
             return version;
         }
         const semver = coerce(version)?.version;
@@ -974,6 +983,12 @@ export class Yomitan {
         } else {
             this.supportsTokenizeFrequency = false;
             this.supportsTermEntriesBulk = false;
+        }
+        // TODO: Use actual released version
+        if (gte(semver, '26.7.1')) {
+            this.supportsTokenizePronunciations = true;
+        } else {
+            this.supportsTokenizePronunciations = false;
         }
         return version;
     }

--- a/extension/src/controllers/subtitle-controller.ts
+++ b/extension/src/controllers/subtitle-controller.ts
@@ -32,7 +32,7 @@ import {
     SubtitleAnnotations,
     ANNOTATIONS_VIDEO_RENDER_BEHIND_MS,
     ANNOTATIONS_VIDEO_RENDER_AHEAD_MS,
-} from '@project/common/subtitle-annotations';
+} from '@project/common/annotations';
 import { arrayEquals, computeStyleString, surroundingSubtitles } from '@project/common/util';
 import i18n from 'i18next';
 import {

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -94,7 +94,7 @@ import { bufferToBase64 } from '@project/common/base64';
 import { pgsParserWorkerFactory } from './pgs-parser-worker-factory';
 import { DictionaryProvider } from '@project/common/dictionary-db/dictionary-provider';
 import { ExtensionDictionaryStorage } from './extension-dictionary-storage';
-import { HoveredToken } from '@project/common/subtitle-annotations';
+import { HoveredToken } from '@project/common/annotations';
 import { v4 as uuidv4 } from 'uuid';
 
 let netflix = false;

--- a/extension/src/ui/components/Popup.tsx
+++ b/extension/src/ui/components/Popup.tsx
@@ -232,7 +232,6 @@ const Popup = ({
                             extensionSupportsDictionaryBrowser
                             extensionSupportsDictionaryWaniKani
                             extensionSupportsDictionaryMatchAcrossScripts
-                            extensionSupportsDictionaryTokenAnnotationConfig
                             extensionSupportsSeekableTrackSetting
                             extensionSupportsAutoCopyableTrackSetting
                             extensionSupportsDictionaryTokenStatusDisplayAlpha

--- a/extension/src/ui/components/SettingsPage.tsx
+++ b/extension/src/ui/components/SettingsPage.tsx
@@ -122,7 +122,6 @@ const SettingsPage = ({
                         extensionSupportsDictionaryBrowser
                         extensionSupportsDictionaryWaniKani
                         extensionSupportsDictionaryMatchAcrossScripts
-                        extensionSupportsDictionaryTokenAnnotationConfig
                         extensionSupportsSeekableTrackSetting
                         extensionSupportsAutoCopyableTrackSetting
                         extensionSupportsDictionaryTokenStatusDisplayAlpha


### PR DESCRIPTION
The main change is a refactoring of `subtitle-annotations.ts` into multiple files under a new `annotations` folder. This clearly separates responsibilities to reduce the size of the file and makes future expansion of annotations beyond subtitles easier.

I also enabled support for pitch accent from tokenize for the `scanning-parser` since the Yomitan PR has been merged. This allows the optimization to automatically enable on Yomitan's next release.

I made a QoL UX change to clearly show what settings enable annotations for a track.
<img width="631" height="647" alt="annotations" src="https://github.com/user-attachments/assets/4c738ea1-72e2-4a2c-ab6b-a2b5160d2997" />

Finally I removed the UI guard around the extension version for the new annotation config settings. Since the initial release of the annotations feature in `v1.14`, the extension and app has rendered their own subtitles using the settings they are aware of. So while the app and extension settings for these won't be in sync, they can somewhat render independently
-  If the media is app controlled then everything in `v1.19` works
- If the media is extension controlled:
  - No pitch accent data will get sent to the synced app instance
  - Frequency annotation must be enabled in the extension settings for the App to receive them which is only populated for the statuses the settings specify
  - If the user were to change the non-synced settings in the app settings, the extension will not rebuild annotations since the annotation settings will still seem equal.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).
