### PR TITLE
Fix seekable track filtering not working when seeking backwards

### DIFF
--- a/common/key-binder/key-binder.ts
+++ b/common/key-binder/key-binder.ts
@@ -12,25 +12,43 @@ export function adjacentSubtitle(
     let adjacentSubtitleIndex = -1;
     let minDiff = Number.MAX_SAFE_INTEGER;
 
-    for (let i = 0; i < subtitles.length; ++i) {
-        const s = subtitles[i];
+    if (forward) {
+        for (let i = 0; i < subtitles.length; ++i) {
+            const s = subtitles[i];
 
-        if (!isTrackSeekable(seekableTracks, s.track)) {
-            continue;
+            if (!isTrackSeekable(seekableTracks, s.track)) {
+                continue;
+            }
+
+            const diff = s.start - now;
+
+            if (minDiff <= diff) {
+                continue;
+            }
+
+            if (now < s.start) {
+                minDiff = diff;
+                adjacentSubtitleIndex = i;
+            }
         }
+    } else {
+        for (let i = subtitles.length - 1; i >= 0; --i) {
+            const s = subtitles[i];
 
-        const diff = forward ? s.start - now : now - s.start;
+            if (!isTrackSeekable(seekableTracks, s.track)) {
+                continue;
+            }
 
-        if (minDiff <= diff) {
-            continue;
-        }
+            const diff = now - s.end;
 
-        if (forward && now < s.start) {
-            minDiff = diff;
-            adjacentSubtitleIndex = i;
-        } else if (!forward && now > s.start) {
-            minDiff = diff;
-            adjacentSubtitleIndex = now < s.end ? Math.max(0, i - 1) : i;
+            if (minDiff <= diff) {
+                continue;
+            }
+
+            if (now > s.end) {
+                minDiff = diff;
+                adjacentSubtitleIndex = i;
+            }
         }
     }
 


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Fixes seekable track filtering when going backwards. The previous index was being taken, allowing the filtering to be bypassed.

Fixes https://github.com/asbplayer/asbplayer/issues/1049
