### PR TITLE
Do not rewind after playback finished.

### DIFF
--- a/common/app/components/Player.tsx
+++ b/common/app/components/Player.tsx
@@ -1214,9 +1214,6 @@ const Player = React.memo(function Player({
 
             if (progress >= 1) {
                 pause(clock, mediaAdapter, true);
-
-                await seek(0, clock, true, true);
-                setLastJumpToTopTimestamp(Date.now());
             }
         }, 1000);
 


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Closes https://github.com/asbplayer/asbplayer/issues/827

The original logic dates back https://github.com/asbplayer/asbplayer/commit/b129ea8d so not sure if it's still applicable. Personally I think it's more useful to have the playback stop at the end because it makes it easier to mine sentences near the end of the stream. What do you think?