### PR TITLE
Workaround Firefox's unfair application of style-src CSP to iframes

### DIFF
--- a/extension/src/controllers/mobile-video-overlay-controller.ts
+++ b/extension/src/controllers/mobile-video-overlay-controller.ts
@@ -8,7 +8,7 @@ import {
 import Binding from '../services/binding';
 import { CachingElementOverlay, OffsetAnchor } from '../services/element-overlay';
 import { adjacentSubtitle } from '@project/common/key-binder';
-import { frameColorScheme } from '@/services/frame-color-scheme';
+import { frameColorSchemeClass } from '@/services/frame-color-scheme';
 
 const smallScreenVideoHeightThreshold = 300;
 
@@ -224,12 +224,12 @@ export class MobileVideoOverlayController {
             this._overlay.uncacheHtml();
         }
 
-        const colorScheme = frameColorScheme();
+        const colorSchemeClass = frameColorSchemeClass();
         this._overlay.setHtml([
             {
                 key: 'ui',
                 html: () =>
-                    `<iframe style="border: 0; color-scheme: ${colorScheme}; width: ${width}px; height: ${height}px" src="${browser.runtime.getURL(
+                    `<iframe class="${colorSchemeClass}" style="border: 0; width: ${width}px; height: ${height}px" src="${browser.runtime.getURL(
                         '/mobile-video-overlay-ui.html'
                     )}?src=${src}&anchor=${anchor}&tooltips=${tooltips}"/>`,
             },

--- a/extension/src/controllers/statistics-overlay-controller.ts
+++ b/extension/src/controllers/statistics-overlay-controller.ts
@@ -1,5 +1,5 @@
 import { CachingElementOverlay, OffsetAnchor } from '@/services/element-overlay';
-import { frameColorScheme } from '@/services/frame-color-scheme';
+import { frameColorSchemeClass } from '@/services/frame-color-scheme';
 import UiFrame, { uiFrameForSrc } from '@/services/ui-frame';
 import { type OpenStatisticsOverlayOneUncollectedDialogMessage } from '@/ui/components/StatisticsOverlayUi';
 import { type UiState } from '@/ui/components/StatisticsOverlayOneUncollectedUi';
@@ -200,22 +200,12 @@ export class StatisticsOverlayController {
 
     private _setHeight(height: string) {
         this._height = height;
-        if (this._overlay !== undefined) {
-            for (const elm of this._overlay.displayingElements()) {
-                (elm as HTMLIFrameElement).style.setProperty('height', height, 'important');
-            }
-            this._overlay.refresh();
-        }
+        this._overlay?.refresh();
     }
 
     private _setWidth(width: string) {
         this._width = width;
-        if (this._overlay !== undefined) {
-            for (const elm of this._overlay.displayingElements()) {
-                (elm as HTMLIFrameElement).style.setProperty('width', width, 'important');
-            }
-            this._overlay.refresh();
-        }
+        this._overlay?.refresh();
     }
 
     private _ensureOverlay() {
@@ -225,9 +215,9 @@ export class StatisticsOverlayController {
         this._overlay = new CachingElementOverlay({
             targetElement: document.body,
             nonFullscreenContainerClassName: 'asbplayer-statistics-overlay-container',
-            nonFullscreenContentClassName: '',
+            nonFullscreenContentClassName: 'asbplayer-statistics-overlay-content',
             fullscreenContainerClassName: 'asbplayer-statistics-overlay-container',
-            fullscreenContentClassName: '',
+            fullscreenContentClassName: 'asbplayer-statistics-overlay-content',
             offsetAnchor: OffsetAnchor.bottom,
             contentWidthPercentage: -1,
             onMouseOut: () => {},
@@ -236,12 +226,12 @@ export class StatisticsOverlayController {
                 this._applyOverlayContainerStyles(container);
             },
         });
-        const colorScheme = frameColorScheme();
+        const colorSchemeClass = frameColorSchemeClass();
         this._overlay.setHtml([
             {
                 key: 'ui',
                 html: () =>
-                    `<iframe style="display: block !important; border: 0 !important; color-scheme: ${colorScheme} !important; width: 100% !important; height: 0px !important" src="${browser.runtime.getURL(
+                    `<iframe class="${colorSchemeClass} asbplayer-statistics-overlay-frame " src="${browser.runtime.getURL(
                         '/statistics-overlay-ui.html'
                     )}"/>`,
             },

--- a/extension/src/entrypoints/video.content/video.css
+++ b/extension/src/entrypoints/video.content/video.css
@@ -295,3 +295,32 @@
     z-index: 2147483647 !important;
     pointer-events: auto !important;
 }
+
+/* Contains the iframe with class "asbplayer-statistics-overlay-frame " */
+.asbplayer-statistics-overlay-content {
+    width: 100% !important;
+    height: 100% !important;
+}
+
+.asbplayer-statistics-overlay-frame {
+    display: block !important;
+    border: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+}
+
+.asbplayer-color-scheme-normal {
+    color-scheme: normal !important;
+}
+
+.asbplayer-color-scheme-light {
+    color-scheme: light !important;
+}
+
+.asbplayer-color-scheme-dark {
+    color-scheme: dark !important;
+}
+
+.asbplayer-color-scheme-light-dark {
+    color-scheme: light dark !important;
+}

--- a/extension/src/services/frame-color-scheme.ts
+++ b/extension/src/services/frame-color-scheme.ts
@@ -1,11 +1,11 @@
-export const frameColorScheme = () => {
+export const frameColorSchemeClass = () => {
     // Prevent iframe from showing up with solid background by selecting suitable color scheme according to document's color scheme
     // https://fvsch.com/transparent-iframes
 
     const documentColorSchemeMetaTag = document.querySelector('meta[name="color-scheme"]');
 
     if (documentColorSchemeMetaTag === null) {
-        return 'normal';
+        return 'asbplayer-color-scheme-normal';
     }
 
     const documentColorScheme = (documentColorSchemeMetaTag as HTMLMetaElement).content;
@@ -13,16 +13,16 @@ export const frameColorScheme = () => {
     const dark = documentColorScheme.includes('dark');
 
     if (light && dark) {
-        return 'none';
+        return 'asbplayer-color-scheme-light-dark';
     }
 
     if (light) {
-        return 'light';
+        return 'asbplayer-color-scheme-light';
     }
 
     if (dark) {
-        return 'dark';
+        return 'asbplayer-color-scheme-dark';
     }
 
-    return 'normal';
+    return 'asbplayer-color-scheme-normal';
 };

--- a/extension/src/services/ui-frame.ts
+++ b/extension/src/services/ui-frame.ts
@@ -1,6 +1,6 @@
 import { isFirefoxBuild } from './build-flags';
 import FrameBridgeClient, { FetchOptions } from './frame-bridge-client';
-import { frameColorScheme } from './frame-color-scheme';
+import { frameColorSchemeClass } from './frame-color-scheme';
 
 export const uiFrameForHtml = (html: (lang: string) => Promise<string>) => {
     return new UiFrame(async (frame: HTMLIFrameElement, lang: string) => {
@@ -90,9 +90,8 @@ export default class UiFrame {
         this._frame?.remove();
 
         this._frame = document.createElement('iframe');
-        this._frame.className = 'asbplayer-ui-frame';
-
-        this._frame.style.colorScheme = frameColorScheme();
+        this._frame.classList.add('asbplayer-ui-frame');
+        this._frame.classList.add(frameColorSchemeClass());
         this._frame.setAttribute('allowtransparency', 'true');
 
         this._client = new FrameBridgeClient(this._frame, this._fetchOptions);


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Fixes https://github.com/asbplayer/asbplayer/issues/1024

For some reason Firefox applies the host site's CSP more strictly to iframes, even if they are extension-injected. Other types of extension-injected DOM are ignored. This change moves iframe styles into classes instead. 
