### PR TITLE
Fix missing token highlight when only-hover settings are enabled

### DIFF
--- a/common/app/hooks/use-subtitle-styles.ts
+++ b/common/app/hooks/use-subtitle-styles.ts
@@ -32,7 +32,7 @@ export const useSubtitleStyles = (
             tracks.push({
                 styles: computeStyles(s, annotationStyleValues),
                 styleString: computeStyleString(s, annotationStyleValues),
-                classes: s.subtitleBlur ? 'asbplayer-subtitles-blurred' : '',
+                classes: s.subtitleBlur ? 'asbplayer-subtitles-blurred asb-subtitles' : 'asb-subtitles',
             });
         }
         return tracks;


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Fixes the issue reported by EmielDX in Discord

> I don't have word reading and pitch accent enabled but the blue highlight only shows when 'Only display word color on hover' is disabled
> there are no issues on youtube btw, just local video

It seems that the `asb-subtitles` class is required for `.asbplayer-subtitle-text` and `.asbplayer-subtitle-rich` to toggle off and on when an "only display on hover" setting is enabled, as per `subtitles.css`:

```
.asb-subtitles:hover .asbplayer-subtitle-text {
    display: none;
}

.asb-subtitles:hover .asbplayer-subtitle-rich {
    display: inline;
}
```

These styles are slightly different from `video.css`, which uses `.asbplayer-subtitles`. I'm assuming that's intentional.

This change ensures that the `asb-subtitles` class is applied to `VideoPlayer` subtitles.