### PR TITLE
add tests for annotations

### DIFF
--- a/client/src/local-settings-storage.test.ts
+++ b/client/src/local-settings-storage.test.ts
@@ -1,5 +1,6 @@
 import { AsbplayerSettings, defaultSettings } from '@project/common/settings';
 import { LocalSettingsStorage } from './local-settings-storage';
+import { expect, it, beforeEach } from '@jest/globals';
 
 const settingsStorage = new LocalSettingsStorage();
 

--- a/common/anki/anki.test.ts
+++ b/common/anki/anki.test.ts
@@ -9,8 +9,7 @@ import {
     NoteInfo,
 } from '@project/common/anki';
 import { AnkiSettings } from '@project/common/settings';
-import { CardModel, Fetcher, MediaFragment } from '@project/common';
-import { AudioClip } from '@project/common/audio-clip';
+import { CardModel, Fetcher } from '@project/common';
 import { extractText, sourceString } from '@project/common/util';
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
@@ -117,21 +116,34 @@ const makeSubtitle = (text: string, track = 0) => ({
     track,
 });
 
-const makeAudioClip = (overrides: Record<string, unknown> = {}) =>
-    ({
+const makeAudioClip = (overrides: Record<string, unknown> & { base64Result?: string; base64Error?: Error } = {}) => {
+    const media = {
         name: 'clip:name?.mp3',
         error: undefined,
-        base64: jest.fn<() => Promise<string>>().mockResolvedValue('audio-base64'),
+        base64Reads: 0,
+        base64: async () => {
+            media.base64Reads++;
+            if (overrides.base64Error) throw overrides.base64Error;
+            return overrides.base64Result ?? 'audio-base64';
+        },
         ...overrides,
-    }) as any;
+    };
+    return media as any;
+};
 
-const makeImage = (overrides: Record<string, unknown> = {}) =>
-    ({
+const makeImage = (overrides: Record<string, unknown> & { base64Result?: string } = {}) => {
+    const media = {
         name: 'image:name?.jpeg',
         error: undefined,
-        base64: jest.fn<() => Promise<string>>().mockResolvedValue('image-base64'),
+        base64Reads: 0,
+        base64: async () => {
+            media.base64Reads++;
+            return overrides.base64Result ?? 'image-base64';
+        },
         ...overrides,
-    }) as any;
+    };
+    return media as any;
+};
 
 const makeExportArguments = (overrides: Partial<ExportArguments> = {}): ExportArguments => ({
     text: 'line 1\nline 2',
@@ -229,11 +241,8 @@ it('preserves target markup instead of replacing it with shallower source markup
 });
 
 it('maps CardModel data into export params in exportCard', async () => {
-    const exportSpy = jest.spyOn(Anki.prototype, 'export').mockResolvedValue('stored-word');
-    const audioClip = { kind: 'audio' } as any;
-    const image = { kind: 'image' } as any;
-    const audioFromBase64Spy = jest.spyOn(AudioClip, 'fromBase64').mockReturnValue(audioClip);
-    const imageFromBase64Spy = jest.spyOn(MediaFragment, 'fromBase64').mockReturnValue(image);
+    const fetcher = new MockFetcher();
+    fetcher.fetch.mockResolvedValue(ankiConnectResponse('stored-word'));
     const card = makeCardModel({
         text: undefined,
         mediaTimestamp: 0,
@@ -246,45 +255,62 @@ it('maps CardModel data into export params in exportCard', async () => {
         },
     });
 
-    const result = await exportCard(card, testAnkiSettings, 'gui');
+    const result = await exportCard(card, testAnkiSettings, 'default', fetcher);
 
     expect(result).toEqual('stored-word');
-    expect(audioFromBase64Spy).toHaveBeenCalledWith('episode.ass', 1000, 2000, 1, 'audio-base64', 'mp3', undefined);
-    expect(imageFromBase64Spy).toHaveBeenCalledWith('episode.ass', 1000, 'image-base64', 'jpeg', undefined);
-    expect(exportSpy).toHaveBeenCalledWith({
-        text: extractText(card.subtitle, card.surroundingSubtitles),
-        track1: extractText(card.subtitle, card.surroundingSubtitles, 0),
-        track2: extractText(card.subtitle, card.surroundingSubtitles, 1),
-        track3: extractText(card.subtitle, card.surroundingSubtitles, 2),
-        definition: card.definition,
-        audioClip,
-        image,
-        word: card.word,
-        source: sourceString(card.subtitleFileName, 0),
-        url: card.url,
-        customFieldValues: {},
-        tags: testAnkiSettings.tags,
-        mode: 'gui',
+    expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+        action: 'addNote',
+        version: 6,
+        params: {
+            note: {
+                deckName: 'Sentences',
+                modelName: 'Sentence',
+                tags: [],
+                options: {
+                    allowDuplicate: true,
+                    duplicateScope: 'deck',
+                    duplicateScopeOptions: { deckName: 'Sentences', checkChildren: false },
+                },
+                audio: { filename: 'asbp_episode_1000.mp3', data: 'audio-base64', fields: ['Audio'] },
+                picture: { filename: 'asbp_episode_1000.jpeg', data: 'image-base64', fields: ['Image'] },
+                fields: {
+                    Sentence: extractText(card.subtitle, card.surroundingSubtitles).replaceAll('\n', '<br>'),
+                    Track1: extractText(card.subtitle, card.surroundingSubtitles, 0),
+                    Track2: extractText(card.subtitle, card.surroundingSubtitles, 1),
+                    Track3: extractText(card.subtitle, card.surroundingSubtitles, 2),
+                    Definition: card.definition,
+                    Word: card.word,
+                    Source: sourceString(card.subtitleFileName, 0),
+                    Url: card.url,
+                },
+            },
+        },
     });
 });
 
+it('forwards GUI export mode in exportCard', async () => {
+    const fetcher = new MockFetcher();
+    fetcher.fetch.mockResolvedValue(ankiConnectResponse('stored-word'));
+    const card = makeCardModel({ audio: undefined, image: undefined });
+
+    await expect(exportCard(card, testAnkiSettings, 'gui', fetcher)).resolves.toBe('stored-word');
+    expect(fetcher.fetch).toHaveBeenCalledWith(
+        testAnkiSettings.ankiConnectUrl,
+        expect.objectContaining({ action: 'guiAddCards' })
+    );
+});
+
 it('passes through missing media in exportCard without constructing clips', async () => {
-    const exportSpy = jest.spyOn(Anki.prototype, 'export').mockResolvedValue('stored-word');
-    const audioFromBase64Spy = jest.spyOn(AudioClip, 'fromBase64');
-    const imageFromBase64Spy = jest.spyOn(MediaFragment, 'fromBase64');
+    const fetcher = new MockFetcher();
+    fetcher.fetch.mockResolvedValue(ankiConnectResponse('stored-word'));
     const card = makeCardModel({ audio: undefined, image: undefined, mediaTimestamp: 12345 });
 
-    await exportCard(card, testAnkiSettings);
+    await exportCard(card, testAnkiSettings, 'default', fetcher);
 
-    expect(audioFromBase64Spy).not.toHaveBeenCalled();
-    expect(imageFromBase64Spy).not.toHaveBeenCalled();
-    expect(exportSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-            audioClip: undefined,
-            image: undefined,
-            source: sourceString(card.subtitleFileName, card.mediaTimestamp),
-        })
-    );
+    const request = fetcher.fetch.mock.calls[0][1];
+    expect(request.params.note.audio).toBeUndefined();
+    expect(request.params.note.picture).toBeUndefined();
+    expect(request.params.note.fields.Source).toBe(sourceString(card.subtitleFileName, card.mediaTimestamp));
 });
 
 describe('Anki', () => {
@@ -872,8 +898,8 @@ describe('Anki', () => {
         );
 
         expect(result).toEqual(321);
-        expect(audioClip.base64).toHaveBeenCalled();
-        expect(image.base64).toHaveBeenCalled();
+        expect(audioClip.base64Reads).toBe(1);
+        expect(image.base64Reads).toBe(1);
         expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
             action: 'addNote',
             version: 6,
@@ -918,13 +944,13 @@ describe('Anki', () => {
         const fetcher = new MockFetcher();
         fetcher.fetch.mockResolvedValue(ankiConnectResponse(321));
         const audioClip = makeAudioClip({ error: new Error('audio failed') });
-        const image = makeImage({ base64: jest.fn<() => Promise<string>>().mockResolvedValue('') });
+        const image = makeImage({ base64Result: '' });
         const anki = new Anki(testAnkiSettings, fetcher);
 
         await expect(anki.export(makeExportArguments({ audioClip, image }))).resolves.toEqual(321);
 
-        expect(audioClip.base64).not.toHaveBeenCalled();
-        expect(image.base64).toHaveBeenCalledTimes(1);
+        expect(audioClip.base64Reads).toBe(0);
+        expect(image.base64Reads).toBe(1);
         const body = fetcher.fetch.mock.calls[0][1];
         expect(body.action).toBe('addNote');
         expect(body.params.note.audio).toBeUndefined();
@@ -936,7 +962,7 @@ describe('Anki', () => {
     it('rejects media encoding failures before creating an Anki note', async () => {
         const fetcher = new MockFetcher();
         const audioClip = makeAudioClip({
-            base64: jest.fn<() => Promise<string>>().mockRejectedValue(new Error('encode failed')),
+            base64Error: new Error('encode failed'),
         });
         const anki = new Anki(testAnkiSettings, fetcher);
 
@@ -959,7 +985,7 @@ describe('Anki', () => {
         );
 
         expect(result).toEqual(322);
-        expect(image.base64).toHaveBeenCalled();
+        expect(image.base64Reads).toBe(1);
         expect(fetcher.fetch.mock.calls).toEqual([
             [
                 testAnkiSettings.ankiConnectUrl,

--- a/common/anki/anki.test.ts
+++ b/common/anki/anki.test.ts
@@ -1,4 +1,5 @@
 import { inheritHtmlMarkup } from './anki';
+import { expect, it } from '@jest/globals';
 
 it('inherits marked up html', () => {
     expect(inheritHtmlMarkup('a foo bar', '<c>foo</c> <b>bar</b> is')).toEqual('a <c>foo</c> <b>bar</b>');

--- a/common/anki/anki.test.ts
+++ b/common/anki/anki.test.ts
@@ -1,34 +1,1495 @@
-import { inheritHtmlMarkup } from './anki';
-import { expect, it } from '@jest/globals';
+import {
+    Anki,
+    CardInfo,
+    DuplicateNoteError,
+    escapeAnkiDeckQuery,
+    escapeAnkiQuery,
+    exportCard,
+    inheritHtmlMarkup,
+    NoteInfo,
+} from '@project/common/anki';
+import { AnkiSettings } from '@project/common/settings';
+import { CardModel, Fetcher, MediaFragment } from '@project/common';
+import { AudioClip } from '@project/common/audio-clip';
+import { extractText, sourceString } from '@project/common/util';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
-it('inherits marked up html', () => {
+const testAnkiSettings: AnkiSettings = {
+    ankiConnectUrl: 'http://127.0.0.1:8765',
+    ankiConnectApiKey: '',
+    deck: 'Sentences',
+    noteType: 'Sentence',
+    sentenceField: 'Sentence',
+    definitionField: 'Definition',
+    audioField: 'Audio',
+    imageField: 'Image',
+    wordField: 'Word',
+    sourceField: 'Source',
+    urlField: 'Url',
+    track1Field: 'Track1',
+    track2Field: 'Track2',
+    track3Field: 'Track3',
+    customAnkiFields: {},
+    tags: [],
+    recordWithAudioPlayback: false,
+    preferMp3: false,
+    audioPaddingStart: 0,
+    audioPaddingEnd: 0,
+    maxImageWidth: 0,
+    maxImageHeight: 0,
+    mediaFragmentFormat: 'jpeg',
+    mediaFragmentTrimStart: 200,
+    mediaFragmentTrimEnd: 200,
+    mediaFragmentMaxClipLength: 10000,
+    surroundingSubtitlesCountRadius: 0,
+    surroundingSubtitlesTimeRadius: 0,
+    ankiFieldSettings: {
+        sentence: { order: 0, display: true },
+        definition: { order: 1, display: true },
+        audio: { order: 2, display: true },
+        image: { order: 3, display: true },
+        word: { order: 4, display: true },
+        source: { order: 5, display: true },
+        url: { order: 6, display: true },
+        track1: { order: 7, display: true },
+        track2: { order: 8, display: true },
+        track3: { order: 9, display: true },
+    },
+    customAnkiFieldSettings: {},
+};
+
+const makeCardInfo = (overrides: Partial<CardInfo> = {}): CardInfo => ({
+    answer: '<div>answer</div>',
+    question: '<div>question</div>',
+    deckName: 'test_deck',
+    modelName: 'test_model',
+    fieldOrder: 0,
+    fields: {
+        Sentence: { value: 'sentence', order: 0 },
+        Word: { value: 'word', order: 1 },
+    },
+    css: '.card {}',
+    cardId: 1,
+    interval: 5,
+    factor: 2500,
+    note: 11,
+    ord: 0,
+    type: 2,
+    queue: 2,
+    due: 0,
+    reps: 3,
+    lapses: 0,
+    left: 0,
+    mod: 123456,
+    nextReviews: ['1d', '3d', '5d', '10d'],
+    flags: 0,
+    ...overrides,
+});
+
+const makeNoteInfo = (overrides: Partial<NoteInfo> = {}): NoteInfo => ({
+    noteId: 11,
+    profile: 'User 1',
+    modelName: 'test_model',
+    tags: ['tag1'],
+    fields: {
+        Sentence: { value: 'sentence', order: 0 },
+        Word: { value: 'word', order: 1 },
+    },
+    mod: 123456,
+    cards: [1, 2],
+    ...overrides,
+});
+
+const ankiConnectResponse = <T>(result: T) => ({ result, error: null });
+
+type ExportArguments = Parameters<Anki['export']>[0];
+
+class MockFetcher implements Fetcher {
+    readonly fetch = jest.fn<Fetcher['fetch']>();
+}
+
+const makeSubtitle = (text: string, track = 0) => ({
+    text,
+    start: 1000,
+    end: 2000,
+    originalStart: 1000,
+    originalEnd: 2000,
+    track,
+});
+
+const makeAudioClip = (overrides: Record<string, unknown> = {}) =>
+    ({
+        name: 'clip:name?.mp3',
+        error: undefined,
+        base64: jest.fn<() => Promise<string>>().mockResolvedValue('audio-base64'),
+        ...overrides,
+    }) as any;
+
+const makeImage = (overrides: Record<string, unknown> = {}) =>
+    ({
+        name: 'image:name?.jpeg',
+        error: undefined,
+        base64: jest.fn<() => Promise<string>>().mockResolvedValue('image-base64'),
+        ...overrides,
+    }) as any;
+
+const makeExportArguments = (overrides: Partial<ExportArguments> = {}): ExportArguments => ({
+    text: 'line 1\nline 2',
+    track1: 'track 1',
+    track2: '<span>track 2</span>',
+    track3: undefined,
+    definition: 'definition line 1\ndefinition line 2',
+    audioClip: undefined,
+    image: undefined,
+    word: 'term',
+    source: 'Episode 1',
+    url: 'https://example.com',
+    customFieldValues: {},
+    tags: ['tag-a', 'tag-b'],
+    mode: 'default',
+    ...overrides,
+});
+
+const makeCardModel = (overrides: Partial<CardModel> = {}): CardModel => ({
+    subtitle: makeSubtitle('main subtitle'),
+    surroundingSubtitles: [
+        makeSubtitle('track 0 line', 0),
+        makeSubtitle('track 1 line', 1),
+        makeSubtitle('track 2 line', 2),
+    ],
+    subtitleFileName: 'episode.ass',
+    mediaTimestamp: 12345,
+    text: 'manual text',
+    word: 'term',
+    definition: 'definition',
+    customFieldValues: { Hint: 'hint' },
+    url: 'https://example.com',
+    audio: {
+        base64: 'audio-base64',
+        extension: 'mp3',
+        paddingStart: 0,
+        paddingEnd: 0,
+        playbackRate: 1,
+    },
+    image: {
+        base64: 'image-base64',
+        extension: 'jpeg',
+    },
+    ...overrides,
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+it('escapes Anki query special characters', () => {
+    expect(escapeAnkiQuery('a"b*c_d\\e:f')).toEqual('a\\"b\\*c\\_d\\\\e\\:f');
+});
+
+it('escapes deck query characters without escaping colons', () => {
+    expect(escapeAnkiDeckQuery('deck:name*with_"slash\\')).toEqual('deck:name\\*with\\_\\"slash\\\\');
+});
+
+it('applies source markup to matching plain words', () => {
     expect(inheritHtmlMarkup('a foo bar', '<c>foo</c> <b>bar</b> is')).toEqual('a <c>foo</c> <b>bar</b>');
 });
 
-it('inherits marked up html for nested tags', () => {
+it('adds missing outer markup around an already-marked target word', () => {
     expect(inheritHtmlMarkup('a <c class="term">foo</c> bar', '<b><c class="term">foo</c></b> <b>bar</b> is')).toEqual(
         'a <b><c class="term">foo</c></b> <b>bar</b>'
     );
 });
 
-it('inherits marked up html for nested tags 2', () => {
+it('applies nested source markup to a plain target word', () => {
     expect(inheritHtmlMarkup('a foo bar', '<b><c class="term">foo</c></b> <b>bar</b> is')).toEqual(
         'a <b><c class="term">foo</c></b> <b>bar</b>'
     );
 });
 
-it('inherits marked up html for nested tags 3', () => {
+it('inherits marked up html with multi-character tag names', () => {
+    expect(inheritHtmlMarkup('a foo bar', '<strong><span class="term">foo</span></strong> <em>bar</em> is')).toEqual(
+        'a <strong><span class="term">foo</span></strong> <em>bar</em>'
+    );
+});
+
+it('applies multiple missing outer tags around an already-marked target word', () => {
     expect(
         inheritHtmlMarkup('a <c class="term">foo</c> bar', '<d><b><c class="term">foo</c></b></d> <b>bar</b> is')
     ).toEqual('a <d><b><c class="term">foo</c></b></d> <b>bar</b>');
 });
 
-it('inherits marked up html with break lines', () => {
+it('does not copy source line-break tags into the target', () => {
     expect(inheritHtmlMarkup('a foo bar', '<d>foo</d><br> <b>bar</b> is')).toEqual('a <d>foo</d> <b>bar</b>');
 });
 
-it('does not inherit marked up html if already marked up', () => {
+it('preserves target markup instead of replacing it with shallower source markup', () => {
     expect(
         inheritHtmlMarkup('a <d><b><c class="term">foo</c></b></d> bar', '<b><c class="term">foo</c></b> <b>bar</b> is')
     ).toEqual('a <d><b><c class="term">foo</c></b></d> <b>bar</b>');
+});
+
+it('maps CardModel data into export params in exportCard', async () => {
+    const exportSpy = jest.spyOn(Anki.prototype, 'export').mockResolvedValue('stored-word');
+    const audioClip = { kind: 'audio' } as any;
+    const image = { kind: 'image' } as any;
+    const audioFromBase64Spy = jest.spyOn(AudioClip, 'fromBase64').mockReturnValue(audioClip);
+    const imageFromBase64Spy = jest.spyOn(MediaFragment, 'fromBase64').mockReturnValue(image);
+    const card = makeCardModel({
+        text: undefined,
+        mediaTimestamp: 0,
+        customFieldValues: undefined,
+        audio: {
+            base64: 'audio-base64',
+            extension: 'mp3',
+            paddingStart: 0,
+            paddingEnd: 0,
+        },
+    });
+
+    const result = await exportCard(card, testAnkiSettings, 'gui');
+
+    expect(result).toEqual('stored-word');
+    expect(audioFromBase64Spy).toHaveBeenCalledWith('episode.ass', 1000, 2000, 1, 'audio-base64', 'mp3', undefined);
+    expect(imageFromBase64Spy).toHaveBeenCalledWith('episode.ass', 1000, 'image-base64', 'jpeg', undefined);
+    expect(exportSpy).toHaveBeenCalledWith({
+        text: extractText(card.subtitle, card.surroundingSubtitles),
+        track1: extractText(card.subtitle, card.surroundingSubtitles, 0),
+        track2: extractText(card.subtitle, card.surroundingSubtitles, 1),
+        track3: extractText(card.subtitle, card.surroundingSubtitles, 2),
+        definition: card.definition,
+        audioClip,
+        image,
+        word: card.word,
+        source: sourceString(card.subtitleFileName, 0),
+        url: card.url,
+        customFieldValues: {},
+        tags: testAnkiSettings.tags,
+        mode: 'gui',
+    });
+});
+
+it('passes through missing media in exportCard without constructing clips', async () => {
+    const exportSpy = jest.spyOn(Anki.prototype, 'export').mockResolvedValue('stored-word');
+    const audioFromBase64Spy = jest.spyOn(AudioClip, 'fromBase64');
+    const imageFromBase64Spy = jest.spyOn(MediaFragment, 'fromBase64');
+    const card = makeCardModel({ audio: undefined, image: undefined, mediaTimestamp: 12345 });
+
+    await exportCard(card, testAnkiSettings);
+
+    expect(audioFromBase64Spy).not.toHaveBeenCalled();
+    expect(imageFromBase64Spy).not.toHaveBeenCalled();
+    expect(exportSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+            audioClip: undefined,
+            image: undefined,
+            source: sourceString(card.subtitleFileName, card.mediaTimestamp),
+        })
+    );
+});
+
+describe('Anki', () => {
+    it('exposes connection settings and includes a configured API key in requests', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse(['Default']));
+        const settings = { ...testAnkiSettings, ankiConnectApiKey: 'secret-key' };
+        const anki = new Anki(settings, fetcher);
+
+        expect(anki.ankiConnectUrl).toBe(testAnkiSettings.ankiConnectUrl);
+        expect(anki.ankiConnectApiKey).toBe('secret-key');
+        await expect(anki.deckNames()).resolves.toEqual(['Default']);
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'deckNames',
+            version: 6,
+            key: 'secret-key',
+        });
+    });
+
+    it.each([
+        {
+            name: 'findCardsWithWord',
+            invoke: (anki: Anki) => anki.findCardsWithWord('term', []),
+        },
+        {
+            name: 'findCardsContainingWord',
+            invoke: (anki: Anki) => anki.findCardsContainingWord('term', []),
+        },
+        {
+            name: 'findNotesWithFieldsContainingWord',
+            invoke: (anki: Anki) => anki.findNotesWithFieldsContainingWord('term', []),
+        },
+        {
+            name: 'findRecentlyEditedOrReviewedCards',
+            invoke: (anki: Anki) => anki.findRecentlyEditedOrReviewedCards(1, []),
+        },
+        {
+            name: 'findCardsDueBy',
+            invoke: (anki: Anki) => anki.findCardsDueBy(1, []),
+        },
+        {
+            name: 'cardsInfo',
+            invoke: (anki: Anki) => anki.cardsInfo([]),
+        },
+        {
+            name: 'cardsModTime',
+            invoke: (anki: Anki) => anki.cardsModTime([]),
+        },
+        {
+            name: 'areSuspended',
+            invoke: (anki: Anki) => anki.areSuspended([]),
+        },
+        {
+            name: 'notesInfo',
+            invoke: (anki: Anki) => anki.notesInfo([]),
+        },
+        {
+            name: 'notesModTime',
+            invoke: (anki: Anki) => anki.notesModTime([]),
+        },
+    ])('returns an empty array without calling AnkiConnect for empty inputs in $name', async ({ invoke }) => {
+        const fetcher = new MockFetcher();
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(invoke(anki)).resolves.toEqual([]);
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        {
+            name: 'deckNames',
+            invoke: (anki: Anki) => anki.deckNames('http://override:8765'),
+            action: 'deckNames',
+            params: undefined,
+            result: ['Default', 'Mining'],
+            url: 'http://override:8765',
+        },
+        {
+            name: 'modelNames',
+            invoke: (anki: Anki) => anki.modelNames(),
+            action: 'modelNames',
+            params: undefined,
+            result: ['Basic', 'Sentence'],
+            url: testAnkiSettings.ankiConnectUrl,
+        },
+        {
+            name: 'modelFieldNames',
+            invoke: (anki: Anki) => anki.modelFieldNames('Sentence'),
+            action: 'modelFieldNames',
+            params: { modelName: 'Sentence' },
+            result: ['Sentence', 'Word'],
+            url: testAnkiSettings.ankiConnectUrl,
+        },
+        {
+            name: 'createDeck',
+            invoke: (anki: Anki) => anki.createDeck('Mining'),
+            action: 'createDeck',
+            params: { deck: 'Mining' },
+            result: 1,
+            url: testAnkiSettings.ankiConnectUrl,
+        },
+        {
+            name: 'createModel',
+            invoke: (anki: Anki) =>
+                anki.createModel({
+                    modelName: 'Sentence',
+                    inOrderFields: ['Sentence', 'Word'],
+                    css: '.card {}',
+                    cardTemplates: [{ Front: '{{Sentence}}', Back: '{{Word}}' }],
+                }),
+            action: 'createModel',
+            params: {
+                modelName: 'Sentence',
+                inOrderFields: ['Sentence', 'Word'],
+                css: '.card {}',
+                cardTemplates: [{ Front: '{{Sentence}}', Back: '{{Word}}' }],
+            },
+            result: { created: true },
+            url: testAnkiSettings.ankiConnectUrl,
+        },
+        {
+            name: 'requestPermission',
+            invoke: (anki: Anki) => anki.requestPermission(),
+            action: 'requestPermission',
+            params: undefined,
+            result: { permission: 'granted' },
+            url: testAnkiSettings.ankiConnectUrl,
+        },
+        {
+            name: 'version',
+            invoke: (anki: Anki) => anki.version(),
+            action: 'version',
+            params: undefined,
+            result: 6,
+            url: testAnkiSettings.ankiConnectUrl,
+        },
+    ])('returns AnkiConnect results for $name', async ({ invoke, action, params, result, url }) => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse(result));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(invoke(anki)).resolves.toEqual(result);
+        expect(fetcher.fetch).toHaveBeenCalledWith(
+            url,
+            params === undefined
+                ? {
+                      action,
+                      version: 6,
+                  }
+                : {
+                      action,
+                      version: 6,
+                      params,
+                  }
+        );
+    });
+
+    it('passes arbitrary queries directly to findCards and findNotes', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([1, 2]));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([11, 12]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.findCards('is:new', 'http://override:8765')).resolves.toEqual([1, 2]);
+        await expect(anki.findNotes('deck:Mining')).resolves.toEqual([11, 12]);
+        expect(fetcher.fetch.mock.calls).toEqual([
+            [
+                'http://override:8765',
+                {
+                    action: 'findCards',
+                    version: 6,
+                    params: { query: 'is:new' },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'findNotes',
+                    version: 6,
+                    params: { query: 'deck:Mining' },
+                },
+            ],
+        ]);
+    });
+
+    it('builds the exact field query for findCardsWithWord', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse([1, 2]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const result = await anki.findCardsWithWord('foo:bar', ['Sentence', 'Word']);
+
+        expect(result).toEqual([1, 2]);
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'findCards',
+            version: 6,
+            params: { query: '"Sentence:foo\\:bar" OR "Word:foo\\:bar"' },
+        });
+    });
+
+    it('builds the exact field query for a single field in findCardsWithWord', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse([1]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const result = await anki.findCardsWithWord('foo:bar', ['Sentence']);
+
+        expect(result).toEqual([1]);
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'findCards',
+            version: 6,
+            params: { query: '"Sentence:foo\\:bar"' },
+        });
+    });
+
+    it('builds the wildcard field query for findCardsContainingWord', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse([1, 2]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const result = await anki.findCardsContainingWord('foo:bar', ['Sentence', 'Word']);
+
+        expect(result).toEqual([1, 2]);
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'findCards',
+            version: 6,
+            params: { query: '"Sentence:*foo\\:bar*" OR "Word:*foo\\:bar*"' },
+        });
+    });
+
+    it('builds the wildcard query for a single field in findCardsContainingWord', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse([2]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const result = await anki.findCardsContainingWord('foo:bar', ['Sentence']);
+
+        expect(result).toEqual([2]);
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'findCards',
+            version: 6,
+            params: { query: '"Sentence:*foo\\:bar*"' },
+        });
+    });
+
+    it('uses the configured word field for note lookups and GUI browsing', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([11]));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([11]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.findNotesWithWord('foo:bar')).resolves.toEqual([11]);
+        await expect(anki.findNotesWithWordGui('foo:bar')).resolves.toEqual([11]);
+        expect(fetcher.fetch.mock.calls).toEqual([
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'findNotes',
+                    version: 6,
+                    params: { query: '"Word:foo\\:bar"' },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'guiBrowse',
+                    version: 6,
+                    params: { query: '"Word:foo\\:bar"' },
+                },
+            ],
+        ]);
+    });
+
+    it('builds wildcard note queries across configured fields', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse([11, 12]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.findNotesWithFieldsContainingWord('foo:bar', ['Sentence', 'Word'])).resolves.toEqual([
+            11, 12,
+        ]);
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'findNotes',
+            version: 6,
+            params: { query: '"Sentence:*foo\\:bar*" OR "Word:*foo\\:bar*"' },
+        });
+    });
+
+    it('detects AnkiConnect responses that require an API key', () => {
+        expect(Anki.requiresApiKey(null)).toBe(false);
+        expect(Anki.requiresApiKey('valid api key must be provided')).toBe(true);
+        expect(Anki.requiresApiKey(new Error('Valid API key must be provided'))).toBe(true);
+        expect(Anki.requiresApiKey({ requireApikey: true })).toBe(true);
+        expect(Anki.requiresApiKey({ requireApiKey: true })).toBe(true);
+        expect(Anki.requiresApiKey({ error: 'valid api key must be provided' })).toBe(true);
+        expect(Anki.requiresApiKey({ error: 'other error' })).toBe(false);
+    });
+
+    it('builds the recency and due queries with escaped fields and decks', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([1]));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([2]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.findRecentlyEditedOrReviewedCards(0, ['Sentence:Field'], ['Mining*Deck'])).resolves.toEqual([
+            1,
+        ]);
+        await expect(anki.findCardsDueBy(-3, ['Sentence:Field'], ['Mining*Deck'])).resolves.toEqual([2]);
+
+        expect(fetcher.fetch.mock.calls).toEqual([
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'findCards',
+                    version: 6,
+                    params: {
+                        query: '(edited:1 OR rated:1) (("deck:Mining\\*Deck") ("Sentence\\:Field:_*"))',
+                    },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'findCards',
+                    version: 6,
+                    params: {
+                        query: 'prop:due<=0 (("deck:Mining\\*Deck") ("Sentence\\:Field:_*"))',
+                    },
+                },
+            ],
+        ]);
+    });
+
+    it('builds recency and due queries for multiple fields and decks', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([1, 2]));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([3, 4]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(
+            anki.findRecentlyEditedOrReviewedCards(2, ['Sentence:Field', 'Word'], ['Mining*Deck', 'Secondary'])
+        ).resolves.toEqual([1, 2]);
+        await expect(anki.findCardsDueBy(5, ['Sentence:Field', 'Word'], ['Mining*Deck', 'Secondary'])).resolves.toEqual(
+            [3, 4]
+        );
+
+        expect(fetcher.fetch.mock.calls).toEqual([
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'findCards',
+                    version: 6,
+                    params: {
+                        query: '(edited:2 OR rated:2) (("deck:Mining\\*Deck" OR "deck:Secondary") ("Sentence\\:Field:_*" OR "Word:_*"))',
+                    },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'findCards',
+                    version: 6,
+                    params: {
+                        query: 'prop:due<=5 (("deck:Mining\\*Deck" OR "deck:Secondary") ("Sentence\\:Field:_*" OR "Word:_*"))',
+                    },
+                },
+            ],
+        ]);
+    });
+
+    it('omits deck filters when no decks are supplied for recency and due queries', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([5]));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([6]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.findRecentlyEditedOrReviewedCards(3, ['Sentence:Field', 'Word'])).resolves.toEqual([5]);
+        await expect(anki.findCardsDueBy(7, ['Sentence:Field', 'Word'])).resolves.toEqual([6]);
+
+        expect(fetcher.fetch.mock.calls).toEqual([
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'findCards',
+                    version: 6,
+                    params: {
+                        query: '(edited:3 OR rated:3) ("Sentence\\:Field:_*" OR "Word:_*")',
+                    },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'findCards',
+                    version: 6,
+                    params: {
+                        query: 'prop:due<=7 ("Sentence\\:Field:_*" OR "Word:_*")',
+                    },
+                },
+            ],
+        ]);
+    });
+
+    it('returns empty card lookups without querying Anki when no fields are supplied', async () => {
+        const fetcher = new MockFetcher();
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.findCardsWithWord('term', [])).resolves.toEqual([]);
+        await expect(anki.findCardsContainingWord('term', [])).resolves.toEqual([]);
+        await expect(anki.findNotesWithFieldsContainingWord('term', [])).resolves.toEqual([]);
+        await expect(anki.findRecentlyEditedOrReviewedCards(1, [])).resolves.toEqual([]);
+        await expect(anki.findCardsDueBy(1, [])).resolves.toEqual([]);
+
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('cardsInfo strips answer, question, and css from the AnkiConnect response', async () => {
+        const fetcher = new MockFetcher();
+        const responseCard = makeCardInfo();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse([responseCard]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const result = await anki.cardsInfo([responseCard.cardId]);
+
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'cardsInfo',
+            version: 6,
+            params: { cards: [responseCard.cardId] },
+        });
+        expect(result).toEqual([
+            {
+                ...responseCard,
+                answer: undefined,
+                question: undefined,
+                css: undefined,
+            },
+        ]);
+        expect(result[0]).not.toHaveProperty('answer');
+        expect(result[0]).not.toHaveProperty('question');
+        expect(result[0]).not.toHaveProperty('css');
+    });
+
+    it('returns card mod times for a single card', async () => {
+        const fetcher = new MockFetcher();
+        const modTimes = [{ cardId: 7, mod: 123456 }];
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse(modTimes));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.cardsModTime([7])).resolves.toEqual(modTimes);
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'cardsModTime',
+            version: 6,
+            params: { cards: [7] },
+        });
+    });
+
+    it('batches cardsModTime and notesModTime requests at 10000 ids', async () => {
+        const fetcher = new MockFetcher();
+        const requestedCards: number[][] = [];
+        const requestedNotes: number[][] = [];
+
+        fetcher.fetch.mockImplementation(async (_url, body) => {
+            if (body.action === 'cardsModTime') {
+                const cards = body.params.cards as number[];
+                requestedCards.push(cards);
+                return ankiConnectResponse(cards.map((cardId) => ({ cardId, mod: cardId + 100 })));
+            }
+
+            if (body.action === 'notesModTime') {
+                const notes = body.params.notes as number[];
+                requestedNotes.push(notes);
+                return ankiConnectResponse(notes.map((noteId) => ({ noteId, mod: noteId + 200 })));
+            }
+
+            throw new Error(`Unexpected action ${body.action}`);
+        });
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const cardIds = Array.from({ length: 10001 }, (_, index) => index + 1);
+        const noteIds = Array.from({ length: 10001 }, (_, index) => index + 1);
+
+        const cardsModTime = await anki.cardsModTime(cardIds);
+        const notesModTime = await anki.notesModTime(noteIds);
+
+        expect(requestedCards).toEqual([cardIds.slice(0, 10000), cardIds.slice(10000)]);
+        expect(requestedNotes).toEqual([noteIds.slice(0, 10000), noteIds.slice(10000)]);
+        expect(cardsModTime[0]).toEqual({ cardId: 1, mod: 101 });
+        expect(cardsModTime[cardsModTime.length - 1]).toEqual({ cardId: 10001, mod: 10101 });
+        expect(notesModTime[0]).toEqual({ noteId: 1, mod: 201 });
+        expect(notesModTime[notesModTime.length - 1]).toEqual({ noteId: 10001, mod: 10201 });
+    });
+
+    it('returns note mod times for a single note', async () => {
+        const fetcher = new MockFetcher();
+        const modTimes = [{ noteId: 7, mod: 654321 }];
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse(modTimes));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.notesModTime([7])).resolves.toEqual(modTimes);
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'notesModTime',
+            version: 6,
+            params: { notes: [7] },
+        });
+    });
+
+    it.each([
+        { cards: [7], result: [true] },
+        { cards: [7, 8], result: [true, null] },
+    ])('passes through areSuspended results for $cards', async ({ cards, result }) => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse(result));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.areSuspended(cards)).resolves.toEqual(result);
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'areSuspended',
+            version: 6,
+            params: { cards },
+        });
+    });
+
+    it('batches cardsInfo and notesInfo requests using the AnkiConnect contract', async () => {
+        const fetcher = new MockFetcher();
+        const requestedCards: number[][] = [];
+        const requestedNotes: number[][] = [];
+
+        fetcher.fetch.mockImplementation(async (_url, body) => {
+            if (body.action === 'cardsInfo') {
+                const cards = body.params.cards as number[];
+                requestedCards.push(cards);
+                return ankiConnectResponse(cards.map((cardId) => makeCardInfo({ cardId, note: cardId + 1000 })));
+            }
+
+            if (body.action === 'notesInfo') {
+                const notes = body.params.notes as number[];
+                requestedNotes.push(notes);
+                return ankiConnectResponse(notes.map((noteId) => makeNoteInfo({ noteId, cards: [noteId * 10] })));
+            }
+
+            throw new Error(`Unexpected action ${body.action}`);
+        });
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const cardIds = Array.from({ length: 12 }, (_, index) => index + 1);
+        const noteIds = Array.from({ length: 101 }, (_, index) => index + 1);
+
+        const cardsInfo = await anki.cardsInfo(cardIds);
+        const notesInfo = await anki.notesInfo(noteIds);
+
+        expect(requestedCards).toEqual([cardIds.slice(0, 10), cardIds.slice(10)]);
+        expect(requestedNotes).toEqual([noteIds.slice(0, 100), noteIds.slice(100)]);
+        expect(cardsInfo.map((card) => card.cardId)).toEqual(cardIds);
+        expect(cardsInfo.every((card) => !('answer' in card) && !('question' in card) && !('css' in card))).toBe(true);
+        expect(notesInfo.map((note) => note.noteId)).toEqual(noteIds);
+    });
+
+    it('exports a default note with multiline fields and inline media payloads', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse(321));
+        const audioClip = makeAudioClip();
+        const image = makeImage();
+        const settings = {
+            ...testAnkiSettings,
+            customAnkiFields: { ExtraDefinition: 'Definition' },
+        };
+        const anki = new Anki(settings, fetcher);
+
+        const result = await anki.export(
+            makeExportArguments({
+                audioClip,
+                image,
+                customFieldValues: { ExtraDefinition: 'custom note' },
+            })
+        );
+
+        expect(result).toEqual(321);
+        expect(audioClip.base64).toHaveBeenCalled();
+        expect(image.base64).toHaveBeenCalled();
+        expect(fetcher.fetch).toHaveBeenCalledWith(testAnkiSettings.ankiConnectUrl, {
+            action: 'addNote',
+            version: 6,
+            params: {
+                note: {
+                    deckName: settings.deck,
+                    modelName: settings.noteType,
+                    tags: ['tag-a', 'tag-b'],
+                    options: {
+                        allowDuplicate: true,
+                        duplicateScope: 'deck',
+                        duplicateScopeOptions: {
+                            deckName: settings.deck,
+                            checkChildren: false,
+                        },
+                    },
+                    audio: {
+                        filename: 'asbp_clip_name_.mp3',
+                        data: 'audio-base64',
+                        fields: ['Audio'],
+                    },
+                    picture: {
+                        filename: 'asbp_image_name_.jpeg',
+                        data: 'image-base64',
+                        fields: ['Image'],
+                    },
+                    fields: {
+                        Sentence: 'line 1<br>line 2',
+                        Track1: 'track 1',
+                        Track2: '<span>track 2</span>',
+                        Definition: 'definition line 1<br>definition line 2<br>custom note',
+                        Word: 'term',
+                        Source: 'Episode 1',
+                        Url: 'https://example.com',
+                    },
+                },
+            },
+        });
+    });
+
+    it('skips errored media and media that encodes to an empty payload', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse(321));
+        const audioClip = makeAudioClip({ error: new Error('audio failed') });
+        const image = makeImage({ base64: jest.fn<() => Promise<string>>().mockResolvedValue('') });
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.export(makeExportArguments({ audioClip, image }))).resolves.toEqual(321);
+
+        expect(audioClip.base64).not.toHaveBeenCalled();
+        expect(image.base64).toHaveBeenCalledTimes(1);
+        const body = fetcher.fetch.mock.calls[0][1];
+        expect(body.action).toBe('addNote');
+        expect(body.params.note.audio).toBeUndefined();
+        expect(body.params.note.picture).toBeUndefined();
+        expect(body.params.note.fields.Audio).toBeUndefined();
+        expect(body.params.note.fields.Image).toBeUndefined();
+    });
+
+    it('rejects media encoding failures before creating an Anki note', async () => {
+        const fetcher = new MockFetcher();
+        const audioClip = makeAudioClip({
+            base64: jest.fn<() => Promise<string>>().mockRejectedValue(new Error('encode failed')),
+        });
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.export(makeExportArguments({ audioClip }))).rejects.toThrow('encode failed');
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('exports a default note with a webm media fragment by storing it and appending video html', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse('stored-clip.webm'));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse(322));
+        const image = makeImage({ name: 'clip:name?.webm', extension: 'webm' });
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        const result = await anki.export(
+            makeExportArguments({
+                audioClip: undefined,
+                image,
+            })
+        );
+
+        expect(result).toEqual(322);
+        expect(image.base64).toHaveBeenCalled();
+        expect(fetcher.fetch.mock.calls).toEqual([
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'storeMediaFile',
+                    version: 6,
+                    params: {
+                        filename: expect.stringMatching(/^asbp_clip_name__[A-Za-z0-9]{8}\.webm$/),
+                        data: 'image-base64',
+                        deleteExisting: false,
+                    },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'addNote',
+                    version: 6,
+                    params: {
+                        note: {
+                            deckName: testAnkiSettings.deck,
+                            modelName: testAnkiSettings.noteType,
+                            tags: ['tag-a', 'tag-b'],
+                            options: {
+                                allowDuplicate: true,
+                                duplicateScope: 'deck',
+                                duplicateScopeOptions: {
+                                    deckName: testAnkiSettings.deck,
+                                    checkChildren: false,
+                                },
+                            },
+                            fields: {
+                                Sentence: 'line 1<br>line 2',
+                                Track1: 'track 1',
+                                Track2: '<span>track 2</span>',
+                                Definition: 'definition line 1<br>definition line 2',
+                                Word: 'term',
+                                Source: 'Episode 1',
+                                Url: 'https://example.com',
+                                Image: '<video autoplay loop muted playsinline src="stored-clip.webm"></video>',
+                            },
+                        },
+                    },
+                },
+            ],
+        ]);
+    });
+
+    it('uses the per-export AnkiConnect URL override for default exports', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse(321));
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await anki.export(makeExportArguments({ ankiConnectUrl: 'http://override:8765' }));
+
+        expect(fetcher.fetch).toHaveBeenCalledWith(
+            'http://override:8765',
+            expect.objectContaining({ action: 'addNote' })
+        );
+    });
+
+    it('exports GUI notes by storing media files and referencing the stored filenames', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse('stored-audio.mp3'));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse('stored-image.jpeg'));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse(654));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const result = await anki.export(
+            makeExportArguments({
+                audioClip: makeAudioClip(),
+                image: makeImage(),
+                mode: 'gui',
+            })
+        );
+
+        expect(result).toEqual(654);
+        expect(fetcher.fetch.mock.calls[0]).toEqual([
+            testAnkiSettings.ankiConnectUrl,
+            {
+                action: 'storeMediaFile',
+                version: 6,
+                params: {
+                    filename: expect.stringMatching(/^asbp_clip_name__[A-Za-z0-9]{8}\.mp3$/),
+                    data: 'audio-base64',
+                    deleteExisting: false,
+                },
+            },
+        ]);
+        expect(fetcher.fetch.mock.calls[1]).toEqual([
+            testAnkiSettings.ankiConnectUrl,
+            {
+                action: 'storeMediaFile',
+                version: 6,
+                params: {
+                    filename: expect.stringMatching(/^asbp_image_name__[A-Za-z0-9]{8}\.jpeg$/),
+                    data: 'image-base64',
+                    deleteExisting: false,
+                },
+            },
+        ]);
+        expect(fetcher.fetch.mock.calls[2]).toEqual([
+            testAnkiSettings.ankiConnectUrl,
+            {
+                action: 'guiAddCards',
+                version: 6,
+                params: {
+                    note: {
+                        deckName: testAnkiSettings.deck,
+                        modelName: testAnkiSettings.noteType,
+                        tags: ['tag-a', 'tag-b'],
+                        options: {
+                            allowDuplicate: true,
+                            duplicateScope: 'deck',
+                            duplicateScopeOptions: {
+                                deckName: testAnkiSettings.deck,
+                                checkChildren: false,
+                            },
+                        },
+                        fields: {
+                            Sentence: 'line 1<br>line 2',
+                            Track1: 'track 1',
+                            Track2: '<span>track 2</span>',
+                            Definition: 'definition line 1<br>definition line 2',
+                            Word: 'term',
+                            Source: 'Episode 1',
+                            Url: 'https://example.com',
+                            Audio: '[sound:stored-audio.mp3]',
+                            Image: '<img src="stored-image.jpeg">',
+                        },
+                    },
+                },
+            },
+        ]);
+    });
+
+    it('exports GUI notes with webm media fragments using video html', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse('stored-audio.mp3'));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse('stored-clip.webm'));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse(655));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const result = await anki.export(
+            makeExportArguments({
+                audioClip: makeAudioClip(),
+                image: makeImage({ name: 'clip:name?.webm', extension: 'webm' }),
+                mode: 'gui',
+            })
+        );
+
+        expect(result).toEqual(655);
+        expect(fetcher.fetch.mock.calls[2]).toEqual([
+            testAnkiSettings.ankiConnectUrl,
+            {
+                action: 'guiAddCards',
+                version: 6,
+                params: {
+                    note: {
+                        deckName: testAnkiSettings.deck,
+                        modelName: testAnkiSettings.noteType,
+                        tags: ['tag-a', 'tag-b'],
+                        options: {
+                            allowDuplicate: true,
+                            duplicateScope: 'deck',
+                            duplicateScopeOptions: {
+                                deckName: testAnkiSettings.deck,
+                                checkChildren: false,
+                            },
+                        },
+                        fields: {
+                            Sentence: 'line 1<br>line 2',
+                            Track1: 'track 1',
+                            Track2: '<span>track 2</span>',
+                            Definition: 'definition line 1<br>definition line 2',
+                            Word: 'term',
+                            Source: 'Episode 1',
+                            Url: 'https://example.com',
+                            Audio: '[sound:stored-audio.mp3]',
+                            Image: '<video autoplay loop muted playsinline src="stored-clip.webm"></video>',
+                        },
+                    },
+                },
+            },
+        ]);
+    });
+
+    it('updates the latest note, inherits markup, adds tags, and returns the stored word in updateLast mode', async () => {
+        const fetcher = new MockFetcher();
+        // Note ids include values whose lexicographic order differs from numeric order
+        // ('11' < '4' as strings) and arrive newest-first to guard the numeric comparator.
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([11, 4]));
+        fetcher.fetch.mockResolvedValueOnce(
+            ankiConnectResponse([
+                makeNoteInfo({
+                    noteId: 11,
+                    fields: {
+                        Sentence: { value: '<b>foo</b> <i>bar</i>', order: 0 },
+                        Track1: { value: '<u>track one</u>', order: 1 },
+                        Track2: { value: '<span>track two</span>', order: 2 },
+                        Track3: { value: '<a>track three</a>', order: 3 },
+                        Word: { value: 'stored word', order: 4 },
+                    },
+                }),
+            ])
+        );
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse(null));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse(null));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const result = await anki.export(
+            makeExportArguments({
+                text: 'foo bar',
+                track1: 'track one',
+                track2: 'track two',
+                track3: 'track three',
+                tags: ['tagged'],
+                mode: 'updateLast',
+            })
+        );
+
+        expect(result).toEqual('stored word');
+        expect(fetcher.fetch.mock.calls).toEqual([
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'findNotes',
+                    version: 6,
+                    params: { query: 'added:1' },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'notesInfo',
+                    version: 6,
+                    params: { notes: [11] },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'updateNoteFields',
+                    version: 6,
+                    params: {
+                        note: {
+                            deckName: testAnkiSettings.deck,
+                            modelName: testAnkiSettings.noteType,
+                            tags: ['tagged'],
+                            options: {
+                                allowDuplicate: true,
+                                duplicateScope: 'deck',
+                                duplicateScopeOptions: {
+                                    deckName: testAnkiSettings.deck,
+                                    checkChildren: false,
+                                },
+                            },
+                            id: 11,
+                            fields: {
+                                Sentence: '<b>foo</b> <i>bar</i>',
+                                Track1: '<u>track one</u>',
+                                Track2: '<span>track two</span>',
+                                Track3: '<a>track three</a>',
+                                Definition: 'definition line 1<br>definition line 2',
+                                Word: 'term',
+                                Source: 'Episode 1',
+                                Url: 'https://example.com',
+                            },
+                        },
+                    },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'addTags',
+                    version: 6,
+                    params: { notes: [11], tags: 'tagged' },
+                },
+            ],
+        ]);
+    });
+
+    it('uses the per-export AnkiConnect URL override throughout updateLast exports', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([8]));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([makeNoteInfo({ noteId: 8 })]));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse(null));
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await anki.export(
+            makeExportArguments({
+                ankiConnectUrl: 'http://override:8765',
+                tags: [],
+                mode: 'updateLast',
+            })
+        );
+
+        expect(fetcher.fetch.mock.calls.map((call) => call[0])).toEqual([
+            'http://override:8765',
+            'http://override:8765',
+            'http://override:8765',
+        ]);
+    });
+
+    it('stores media in updateLast mode and returns the note id when the word field is unavailable', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([8]));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse('stored-audio.mp3'));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse('stored-image.jpeg'));
+        fetcher.fetch.mockResolvedValueOnce(
+            ankiConnectResponse([
+                makeNoteInfo({
+                    noteId: 8,
+                    fields: {
+                        Sentence: { value: '<b>foo</b>', order: 0 },
+                        Track1: { value: '<u>track one</u>', order: 1 },
+                        Track2: { value: '<span>track two</span>', order: 2 },
+                        Track3: { value: '<a>track three</a>', order: 3 },
+                    },
+                }),
+            ])
+        );
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse(null));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        const result = await anki.export(
+            makeExportArguments({
+                text: 'foo',
+                track1: 'track one',
+                track2: 'track two',
+                track3: 'track three',
+                audioClip: makeAudioClip(),
+                image: makeImage(),
+                tags: [],
+                mode: 'updateLast',
+            })
+        );
+
+        expect(result).toEqual(8);
+        expect(fetcher.fetch.mock.calls).toEqual([
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'findNotes',
+                    version: 6,
+                    params: { query: 'added:1' },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'storeMediaFile',
+                    version: 6,
+                    params: {
+                        filename: expect.stringMatching(/^asbp_clip_name__[A-Za-z0-9]{8}\.mp3$/),
+                        data: 'audio-base64',
+                        deleteExisting: false,
+                    },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'storeMediaFile',
+                    version: 6,
+                    params: {
+                        filename: expect.stringMatching(/^asbp_image_name__[A-Za-z0-9]{8}\.jpeg$/),
+                        data: 'image-base64',
+                        deleteExisting: false,
+                    },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'notesInfo',
+                    version: 6,
+                    params: { notes: [8] },
+                },
+            ],
+            [
+                testAnkiSettings.ankiConnectUrl,
+                {
+                    action: 'updateNoteFields',
+                    version: 6,
+                    params: {
+                        note: {
+                            deckName: testAnkiSettings.deck,
+                            modelName: testAnkiSettings.noteType,
+                            tags: [],
+                            options: {
+                                allowDuplicate: true,
+                                duplicateScope: 'deck',
+                                duplicateScopeOptions: {
+                                    deckName: testAnkiSettings.deck,
+                                    checkChildren: false,
+                                },
+                            },
+                            id: 8,
+                            fields: {
+                                Sentence: '<b>foo</b>',
+                                Track1: '<u>track one</u>',
+                                Track2: '<span>track two</span>',
+                                Track3: '<a>track three</a>',
+                                Definition: 'definition line 1<br>definition line 2',
+                                Word: 'term',
+                                Source: 'Episode 1',
+                                Url: 'https://example.com',
+                                Audio: '[sound:stored-audio.mp3]',
+                                Image: '<img src="stored-image.jpeg">',
+                            },
+                        },
+                    },
+                },
+            ],
+        ]);
+    });
+
+    it('returns the note id in updateLast mode when the stored word is empty', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([9]));
+        fetcher.fetch.mockResolvedValueOnce(
+            ankiConnectResponse([
+                makeNoteInfo({
+                    noteId: 9,
+                    fields: {
+                        Sentence: { value: 'sentence', order: 0 },
+                        Word: { value: '', order: 1 },
+                    },
+                }),
+            ])
+        );
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse(null));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.export(makeExportArguments({ tags: [], mode: 'updateLast' }))).resolves.toEqual(9);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('updates a specific note without querying recently added notes', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([makeNoteInfo({ noteId: 42 })]));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse(null));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(
+            anki.export(makeExportArguments({ mode: 'updateSpecific', noteId: 42, tags: [] }))
+        ).resolves.toEqual('word');
+        expect(fetcher.fetch.mock.calls.map((call) => call[1].action)).toEqual(['notesInfo', 'updateNoteFields']);
+        expect(fetcher.fetch.mock.calls[1][1].params.note.id).toBe(42);
+    });
+
+    it('requires a note id for updateSpecific exports', async () => {
+        const fetcher = new MockFetcher();
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.export(makeExportArguments({ mode: 'updateSpecific' }))).rejects.toThrow(
+            'noteId is required for updateSpecific mode'
+        );
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('keeps extensionless stored media names unchanged before upload', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse('stored-audio'));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse(10));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+        await anki.export(
+            makeExportArguments({
+                audioClip: makeAudioClip({ name: 'clip' }),
+                image: undefined,
+                mode: 'gui',
+            })
+        );
+
+        expect(fetcher.fetch.mock.calls[0]).toEqual([
+            testAnkiSettings.ankiConnectUrl,
+            {
+                action: 'storeMediaFile',
+                version: 6,
+                params: {
+                    filename: 'asbp_clip',
+                    data: 'audio-base64',
+                    deleteExisting: false,
+                },
+            },
+        ]);
+    });
+
+    it('throws if updateLast cannot find a recent note', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue(ankiConnectResponse([]));
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.export(makeExportArguments({ mode: 'updateLast' }))).rejects.toThrow(
+            'Could not find note to update'
+        );
+    });
+
+    it('throws if updateLast cannot fetch info for the selected recent note', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([7]));
+        fetcher.fetch.mockResolvedValueOnce(ankiConnectResponse([makeNoteInfo({ noteId: 8 })]));
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.export(makeExportArguments({ mode: 'updateLast' }))).rejects.toThrow(
+            'Could not update card because the card info could not be fetched'
+        );
+    });
+
+    it('throws DuplicateNoteError for duplicate AnkiConnect responses', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ result: null, error: 'cannot create note because it is a duplicate' });
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.export(makeExportArguments())).rejects.toBeInstanceOf(DuplicateNoteError);
+    });
+
+    it('throws a regular error for non-duplicate AnkiConnect failures', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ result: null, error: 'boom' });
+
+        const anki = new Anki(testAnkiSettings, fetcher);
+
+        await expect(anki.version()).rejects.toThrow('boom');
+    });
 });

--- a/common/anki/anki.ts
+++ b/common/anki/anki.ts
@@ -177,9 +177,10 @@ interface Base64Exportable {
 export async function exportCard(
     card: CardModel,
     ankiSettings: AnkiSettings,
-    exportMode: AnkiExportMode = 'default'
+    exportMode: AnkiExportMode = 'default',
+    fetcher?: Fetcher
 ): Promise<string> {
-    const anki = new Anki(ankiSettings);
+    const anki = new Anki(ankiSettings, fetcher);
     const source = sourceString(card.subtitleFileName, card.mediaTimestamp);
     const audioClip =
         card.audio === undefined

--- a/common/anki/anki.ts
+++ b/common/anki/anki.ts
@@ -88,7 +88,7 @@ const makeUniqueFileName = (fileName: string) => {
     return `${baseName}_${randomString()}.${exension}`;
 };
 
-const htmlTagRegexString = '<([^/ >])*[^>]*>(.*?)</\\1>';
+const htmlTagRegexString = '<([^/ >]+)[^>]*>(.*?)</\\1>';
 const anyHtmlTagRegex = /<[^>]+>/;
 
 // Given <a><b>content</b></a> return ['<a><b>content</b></a>', '<b>content</b>', 'content']
@@ -572,7 +572,7 @@ export class Anki {
             case 'gui':
                 return (await this._executeAction('guiAddCards', params, ankiConnectUrl)).result;
             case 'updateLast': {
-                const lastNoteId = [...recentNotes].sort()[recentNotes.length - 1];
+                const lastNoteId = [...recentNotes].sort((a, b) => a - b)[recentNotes.length - 1];
 
                 if (recentNotes.length === 0) {
                     throw new Error('Could not find note to update');

--- a/common/annotations/annotations-test-utils.ts
+++ b/common/annotations/annotations-test-utils.ts
@@ -5,11 +5,13 @@ import {
     type AsbplayerSettings,
     defaultSettings,
     type DictionaryTrack,
+    SettingsProvider,
     TokenFrequencyAnnotation,
     TokenReadingAnnotation,
     TokenState,
     TokenStatus,
 } from '@project/common/settings';
+import { MockSettingsStorage } from '@project/common/settings/mock-settings-storage';
 import { SubtitleAnnotations } from './subtitle-annotations';
 
 export const cloneAnnotationConfig = (track: DictionaryTrack) => ({
@@ -130,17 +132,12 @@ export const makeStorage = () => ({
     _removeCallback: jest.fn(),
 });
 
-export const makeSettingsProvider = (settings: AsbplayerSettings) =>
-    ({
-        getAll: jest.fn(async () => settings),
-        getSingle: jest.fn(async (key: keyof AsbplayerSettings) => settings[key]),
-        activeProfile: jest.fn(async () => ({ name: 'Profile' })),
-    }) as any;
-
 export const makeSubtitleAnnotations = (settings = makeSettings()) => {
     const storage = makeStorage();
     const provider = new DictionaryProvider(storage as any);
-    const settingsProvider = makeSettingsProvider(settings);
+    const settingsStorage = new MockSettingsStorage();
+    settingsStorage.setData(settings);
+    const settingsProvider = new SettingsProvider(settingsStorage);
     const subtitleAnnotationsUpdated = jest.fn();
     const subtitleAnnotations = new SubtitleAnnotations(
         provider,

--- a/common/annotations/annotations-test-utils.ts
+++ b/common/annotations/annotations-test-utils.ts
@@ -1,0 +1,154 @@
+import { type IndexedSubtitleModel, type Token } from '@project/common';
+import { jest } from '@jest/globals';
+import { DictionaryProvider } from '@project/common/dictionary-db';
+import {
+    type AsbplayerSettings,
+    defaultSettings,
+    type DictionaryTrack,
+    TokenFrequencyAnnotation,
+    TokenReadingAnnotation,
+    TokenState,
+    TokenStatus,
+} from '@project/common/settings';
+import { SubtitleAnnotations } from './subtitle-annotations';
+
+export const cloneAnnotationConfig = (track: DictionaryTrack) => ({
+    ...track.dictionaryTokenAnnotationConfig,
+    video: {
+        color: { ...track.dictionaryTokenAnnotationConfig.video.color },
+        reading: { ...track.dictionaryTokenAnnotationConfig.video.reading },
+        frequency: { ...track.dictionaryTokenAnnotationConfig.video.frequency },
+        pitchAccent: { ...track.dictionaryTokenAnnotationConfig.video.pitchAccent },
+    },
+    subtitlePlayer: {
+        color: { ...track.dictionaryTokenAnnotationConfig.subtitlePlayer.color },
+        reading: { ...track.dictionaryTokenAnnotationConfig.subtitlePlayer.reading },
+        frequency: { ...track.dictionaryTokenAnnotationConfig.subtitlePlayer.frequency },
+        pitchAccent: { ...track.dictionaryTokenAnnotationConfig.subtitlePlayer.pitchAccent },
+    },
+    onStatuses: track.dictionaryTokenAnnotationConfig.onStatuses.map((config) => ({ ...config })),
+    onStates: track.dictionaryTokenAnnotationConfig.onStates.map((config) => ({ ...config })),
+});
+
+export const makeDictionaryTrack = (overrides: Partial<DictionaryTrack> = {}): DictionaryTrack => {
+    const track = {
+        ...defaultSettings.dictionaryTracks[0],
+        dictionaryAnkiDecks: [...defaultSettings.dictionaryTracks[0].dictionaryAnkiDecks],
+        dictionaryAnkiWordFields: [...defaultSettings.dictionaryTracks[0].dictionaryAnkiWordFields],
+        dictionaryAnkiSentenceFields: [...defaultSettings.dictionaryTracks[0].dictionaryAnkiSentenceFields],
+        dictionaryTokenStatusColors: [...defaultSettings.dictionaryTracks[0].dictionaryTokenStatusColors],
+        dictionaryTokenStatusConfig: defaultSettings.dictionaryTracks[0].dictionaryTokenStatusConfig.map((config) => ({
+            ...config,
+        })),
+        ...overrides,
+    };
+    const dictionaryTokenAnnotationConfig = cloneAnnotationConfig(track);
+    dictionaryTokenAnnotationConfig.colorizeEnabled = track.dictionaryColorizeSubtitles;
+
+    for (const target of [dictionaryTokenAnnotationConfig.video, dictionaryTokenAnnotationConfig.subtitlePlayer]) {
+        target.color.onHoverEnabled = track.dictionaryColorizeOnHoverOnly;
+        target.reading.onHoverEnabled = track.dictionaryColorizeOnHoverOnly;
+        target.frequency.onHoverEnabled = track.dictionaryColorizeOnHoverOnly;
+    }
+
+    for (const [status, config] of dictionaryTokenAnnotationConfig.onStatuses.entries()) {
+        config.reading =
+            track.dictionaryTokenReadingAnnotation === TokenReadingAnnotation.ALWAYS ||
+            (track.dictionaryTokenReadingAnnotation === TokenReadingAnnotation.LEARNING_OR_BELOW &&
+                status <= TokenStatus.LEARNING) ||
+            (track.dictionaryTokenReadingAnnotation === TokenReadingAnnotation.UNKNOWN_OR_BELOW &&
+                status <= TokenStatus.UNKNOWN);
+        config.frequency =
+            track.dictionaryTokenFrequencyAnnotation === TokenFrequencyAnnotation.ALWAYS ||
+            (track.dictionaryTokenFrequencyAnnotation === TokenFrequencyAnnotation.UNCOLLECTED_ONLY &&
+                status === TokenStatus.UNCOLLECTED);
+    }
+    dictionaryTokenAnnotationConfig.onStates[TokenState.IGNORED].reading =
+        track.dictionaryDisplayIgnoredTokenReadings &&
+        track.dictionaryTokenReadingAnnotation !== TokenReadingAnnotation.NEVER;
+
+    return { ...track, dictionaryTokenAnnotationConfig };
+};
+
+export const makeDictionaryTracks = (track = makeDictionaryTrack()) =>
+    defaultSettings.dictionaryTracks.map((_, index) => (index === 0 ? track : makeDictionaryTrack()));
+
+export const makeSettings = (dictionaryTracks = makeDictionaryTracks()): AsbplayerSettings => ({
+    ...defaultSettings,
+    dictionaryTracks,
+});
+
+export const makeSubtitle = (overrides: Record<string, unknown> = {}): IndexedSubtitleModel =>
+    ({
+        text: 'word',
+        originalText: 'word',
+        start: 0,
+        originalStart: 0,
+        end: 1000,
+        originalEnd: 1000,
+        track: 0,
+        index: 0,
+        ...overrides,
+    }) as IndexedSubtitleModel;
+
+export const makeToken = (overrides: Partial<Token> = {}): Token => ({
+    pos: [0, 4],
+    readings: [],
+    states: [],
+    status: TokenStatus.UNKNOWN,
+    ...overrides,
+});
+
+export const makeStorage = () => ({
+    getBulk: jest.fn(async () => ({})),
+    getAllTokens: jest.fn(async () => ({})),
+    getByLemmaBulk: jest.fn(async () => ({})),
+    saveRecordLocalBulk: jest.fn(async () => ({ savedTokens: [] })),
+    deleteRecordLocalBulk: jest.fn(async () => ({ deletedTokens: [] })),
+    deleteProfile: jest.fn(async () => ({})),
+    exportRecordLocalBulk: jest.fn(async () => ({ exportedRecords: [] })),
+    importRecordLocalBulk: jest.fn(async () => ({ importedTokens: [] })),
+    getRecords: jest.fn(async () => ({ tokenRecords: [], ankiCardRecords: {}, waniKaniSubjectRecords: {} })),
+    updateRecords: jest.fn(async () => ({ savedTokens: [], deletedTokens: [] })),
+    deleteRecords: jest.fn(async () => ({ deletedTokens: [] })),
+    buildAnkiCache: jest.fn(async () => undefined),
+    buildWaniKaniCache: jest.fn(async () => undefined),
+    ankiCardWasModified: jest.fn(),
+    onAnkiCardModified: jest.fn().mockReturnValue(jest.fn()),
+    onBuildAnkiCacheStateChange: jest.fn().mockReturnValue(jest.fn()),
+    onBuildWaniKaniCacheStateChange: jest.fn().mockReturnValue(jest.fn()),
+    publishStatisticsSnapshot: jest.fn(),
+    onStatisticsSnapshot: jest.fn().mockReturnValue(jest.fn()),
+    requestStatisticsSnapshot: jest.fn(),
+    onRequestStatisticsSnapshot: jest.fn().mockReturnValue(jest.fn()),
+    requestStatisticsGeneration: jest.fn(),
+    onRequestStatisticsGeneration: jest.fn().mockReturnValue(jest.fn()),
+    requestStatisticsSeek: jest.fn(),
+    onRequestStatisticsSeek: jest.fn().mockReturnValue(jest.fn()),
+    requestStatisticsMineSentences: jest.fn(),
+    onRequestStatisticsMineSentences: jest.fn().mockReturnValue(jest.fn()),
+    _removeCallback: jest.fn(),
+});
+
+export const makeSettingsProvider = (settings: AsbplayerSettings) =>
+    ({
+        getAll: jest.fn(async () => settings),
+        getSingle: jest.fn(async (key: keyof AsbplayerSettings) => settings[key]),
+        activeProfile: jest.fn(async () => ({ name: 'Profile' })),
+    }) as any;
+
+export const makeSubtitleAnnotations = (settings = makeSettings()) => {
+    const storage = makeStorage();
+    const provider = new DictionaryProvider(storage as any);
+    const settingsProvider = makeSettingsProvider(settings);
+    const subtitleAnnotationsUpdated = jest.fn();
+    const subtitleAnnotations = new SubtitleAnnotations(
+        provider,
+        settingsProvider,
+        { showingCheckRadiusMs: 150 },
+        'media-id',
+        subtitleAnnotationsUpdated
+    );
+
+    return { subtitleAnnotations, storage, settingsProvider, subtitleAnnotationsUpdated };
+};

--- a/common/annotations/dom-annotations.test.ts
+++ b/common/annotations/dom-annotations.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from '@jest/globals';
+import { HoveredToken } from './dom-annotations';
+
+describe('HoveredToken', () => {
+    it('extracts visible token text and track while ignoring ruby text', () => {
+        const hoveredToken = new HoveredToken();
+        const wrapper = document.createElement('div');
+        wrapper.dataset.track = '3';
+        wrapper.innerHTML = '<span class="asb-token"> 語<ruby><rb>学</rb><rt>がく</rt></ruby> </span>';
+        const inner = wrapper.querySelector('ruby') as HTMLElement;
+
+        hoveredToken.handleMouseOver({ target: inner } as unknown as MouseEvent);
+
+        expect(hoveredToken.parse()).toEqual({ token: '語学', track: 3 });
+    });
+
+    it('clears when the hovered token receives mouseout', () => {
+        const hoveredToken = new HoveredToken();
+        const wrapper = document.createElement('div');
+        wrapper.dataset.track = '1';
+        wrapper.innerHTML = '<span class="asb-token">word</span>';
+        const token = wrapper.querySelector('.asb-token') as HTMLElement;
+
+        hoveredToken.handleMouseOver({ target: token } as unknown as MouseEvent);
+        expect(hoveredToken.parse()).toEqual({ token: 'word', track: 1 });
+
+        hoveredToken.handleMouseOut({ target: token } as unknown as MouseEvent);
+        expect(hoveredToken.parse()).toBeNull();
+    });
+
+    it('preserves the hovered token when mouseout comes from a different element', () => {
+        const hoveredToken = new HoveredToken();
+        const wrapper = document.createElement('div');
+        wrapper.dataset.track = '1';
+        wrapper.innerHTML = '<span class="asb-token">word</span><span class="other">other</span>';
+        const token = wrapper.querySelector('.asb-token') as HTMLElement;
+        const other = wrapper.querySelector('.other') as HTMLElement;
+
+        hoveredToken.handleMouseOver({ target: token } as unknown as MouseEvent);
+        hoveredToken.handleMouseOut({ target: other } as unknown as MouseEvent);
+
+        expect(hoveredToken.parse()).toEqual({ token: 'word', track: 1 });
+    });
+});

--- a/common/annotations/render-annotations.test.ts
+++ b/common/annotations/render-annotations.test.ts
@@ -1,0 +1,451 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+    type DictionaryTrack,
+    TokenFrequencyAnnotation,
+    TokenReadingAnnotation,
+    TokenStatus,
+    TokenStyling,
+    tokenAnnotationStyleValues,
+} from '@project/common/settings';
+import {
+    computeRichText,
+    emptyRichTextWindow,
+    getAnnotationsHtml,
+    getAnnotationsForRender,
+    renderRichTextForSubtitle,
+    renderRichTextOntoSubtitles,
+    renderRichTextWindow,
+} from './render-annotations';
+import { makeDictionaryTrack, makeDictionaryTracks, makeSubtitle, makeToken } from './annotations-test-utils';
+
+type AnnotationToggles = {
+    color?: boolean;
+    reading?: boolean;
+    frequency?: boolean;
+    pitchAccent?: boolean;
+};
+type HoverAnnotation = keyof Required<AnnotationToggles>;
+type HoverCase = [HoverAnnotation, string, AnnotationToggles, ReturnType<typeof makeToken>, string];
+
+const renderToken = (
+    fullText: string,
+    token: ReturnType<typeof makeToken>,
+    dt = makeDictionaryTrack(),
+    allowAsciiReading = false
+) => {
+    const annotations = getAnnotationsForRender(dt, 'video');
+    return computeRichText(
+        fullText,
+        { tokens: [token] },
+        {
+            dt,
+            enabledAnnotations: annotations.richTextEnabledAnnotations,
+            allowAsciiReading,
+        }
+    );
+};
+
+const makeInternalToken = (overrides: Parameters<typeof makeToken>[0] = {}) =>
+    ({ ...makeToken(overrides), __internal: true }) as ReturnType<typeof makeToken> & { __internal: true };
+
+const makeAnnotationTrack = (toggles: AnnotationToggles, overrides: Partial<DictionaryTrack> = {}) => {
+    const dt = makeDictionaryTrack(overrides);
+    dt.dictionaryTokenAnnotationConfig.colorizeEnabled = toggles.color ?? false;
+    for (const config of dt.dictionaryTokenAnnotationConfig.onStatuses) {
+        config.reading = toggles.reading ?? false;
+        config.frequency = toggles.frequency ?? false;
+        config.pitchAccent = toggles.pitchAccent ?? false;
+    }
+    for (const config of dt.dictionaryTokenAnnotationConfig.onStates) {
+        config.reading = false;
+        config.frequency = false;
+        config.pitchAccent = false;
+    }
+    for (const target of [
+        dt.dictionaryTokenAnnotationConfig.video,
+        dt.dictionaryTokenAnnotationConfig.subtitlePlayer,
+    ]) {
+        target.color.onHoverEnabled = false;
+        target.reading.onHoverEnabled = false;
+        target.frequency.onHoverEnabled = false;
+        target.pitchAccent.onHoverEnabled = false;
+    }
+    return dt;
+};
+
+const setUnknownTokenColor = (dt: DictionaryTrack, color: string, alpha: string) => {
+    dt.dictionaryTokenStatusConfig[TokenStatus.UNKNOWN] = { display: true, color, alpha };
+};
+
+const pitchAccentHtml = (moras: string[], color: string, highMoraCount = 1) => {
+    const parts: string[] = [];
+    for (const [index, mora] of moras.entries()) {
+        if (index === highMoraCount) parts.push('<span class="asb-pitch-accent-line"></span>');
+        parts.push(
+            `<span class="asb-pitch-accent-mora asb-pitch-accent-mora-${
+                index < highMoraCount ? 'high' : 'low'
+            }">${mora}</span>`
+        );
+    }
+    return `<span class="asb-pitch-accent" style="--asb-pitch-accent-color: ${color};">${parts.join('')}</span>`;
+};
+
+const expectedAnnotationCombinationHtml = ({
+    color = false,
+    reading = false,
+    frequency = false,
+    pitchAccent = false,
+}: AnnotationToggles) => {
+    const colorValue = '#11223344';
+    let tokenText = '語学';
+
+    if (reading) {
+        tokenText = `<ruby class="asb-reading">語学<rt>${
+            pitchAccent ? pitchAccentHtml(['ご', 'が', 'く'], color ? colorValue : 'currentColor') : 'ごがく'
+        }</rt></ruby>`;
+    }
+    if (frequency) {
+        tokenText = `<ruby class="asb-frequency">${tokenText}<rt>7</rt></ruby>`;
+    }
+    if (!color) return tokenText;
+    if (pitchAccent && reading) return `<span class="asb-token asb-token-highlight">${tokenText}</span>`;
+    return `<span class="asb-token asb-token-highlight" style="text-decoration: UNDERLINE ${colorValue} 3px;">${tokenText}</span>`;
+};
+
+const annotationCombinations: Required<AnnotationToggles>[] = [];
+for (const color of [false, true]) {
+    for (const reading of [false, true]) {
+        for (const frequency of [false, true]) {
+            for (const pitchAccent of [false, true]) {
+                annotationCombinations.push({ color, reading, frequency, pitchAccent });
+            }
+        }
+    }
+}
+
+describe('rich text rendering', () => {
+    it('selects plain, rich, and hover-rich subtitle HTML without dropping fallback text', () => {
+        expect(getAnnotationsHtml('plain', undefined, undefined)).toBe('plain');
+        expect(getAnnotationsHtml('plain', '<b>rich</b>', undefined)).toBe('<b>rich</b>');
+        expect(getAnnotationsHtml('plain', undefined, '<i>hover</i>')).toBe(
+            '<span class="asbplayer-subtitle-text">plain</span><span class="asbplayer-subtitle-rich"><i>hover</i></span>'
+        );
+    });
+
+    it('skips subtitles that cannot be rendered and rejects incomplete track configuration', () => {
+        const tracks = makeDictionaryTracks(makeDictionaryTrack({ dictionaryColorizeSubtitles: true }));
+        const withoutTokenization = makeSubtitle({ tokenization: undefined });
+
+        expect(renderRichTextOntoSubtitles([withoutTokenization], 'video', tracks)).toEqual(new Map());
+        expect(renderRichTextOntoSubtitles([makeSubtitle()], 'video', tracks.slice(0, 1))).toEqual(new Map());
+        expect(computeRichText('plain', { tokens: [] }, {} as any)).toBeUndefined();
+    });
+
+    it('renders colored tokens and tokenization errors into the returned map', () => {
+        const subtitles = [
+            makeSubtitle({
+                text: '語学',
+                tokenization: { tokens: [makeToken({ pos: [0, 2], status: TokenStatus.UNKNOWN })] },
+            }),
+            makeSubtitle({ index: 1, text: 'broken', tokenization: { tokens: [], error: true } }),
+        ];
+        const rendered = renderRichTextOntoSubtitles(
+            subtitles,
+            'video',
+            makeDictionaryTracks(makeDictionaryTrack({ dictionaryColorizeSubtitles: true }))
+        );
+
+        expect(rendered.get(0)?.richText).toContain('class="asb-token asb-token-highlight"');
+        expect(rendered.get(1)?.richText).toBe('<span style="text-decoration: line-through red 3px;">broken</span>');
+    });
+
+    it('renders null token statuses with error styling', () => {
+        expect(renderToken('語学', makeToken({ pos: [0, 2], status: null }))).toBe(
+            '<span style="text-decoration: line-through red 3px;">語学</span>'
+        );
+    });
+
+    it('separates hover-only annotations into richTextOnHover', () => {
+        const rendered = renderRichTextOntoSubtitles(
+            [
+                makeSubtitle({
+                    text: '語学',
+                    tokenization: { tokens: [makeToken({ pos: [0, 2], status: TokenStatus.UNKNOWN })] },
+                }),
+            ],
+            'video',
+            makeDictionaryTracks(
+                makeDictionaryTrack({ dictionaryColorizeSubtitles: true, dictionaryColorizeOnHoverOnly: true })
+            )
+        );
+
+        expect(rendered.get(0)?.richText).toBeUndefined();
+        expect(rendered.get(0)?.richTextOnHover).toContain('asb-token');
+    });
+
+    it('renders reading and frequency annotations through computeRichText', () => {
+        const rendered = renderToken(
+            '語学',
+            makeToken({
+                pos: [0, 2],
+                status: TokenStatus.UNCOLLECTED,
+                readings: [{ pos: [0, 2], reading: 'ごがく' }],
+                frequency: 12,
+            }),
+            makeDictionaryTrack({
+                dictionaryColorizeSubtitles: true,
+                dictionaryTokenReadingAnnotation: TokenReadingAnnotation.ALWAYS,
+                dictionaryTokenFrequencyAnnotation: TokenFrequencyAnnotation.ALWAYS,
+                dictionaryTokenStyling: TokenStyling.UNDERLINE,
+            })
+        );
+
+        expect(rendered).toContain('<ruby class="asb-reading">語学<rt>ごがく</rt></ruby>');
+        expect(rendered).toContain('<ruby class="asb-frequency">');
+        expect(rendered).toContain('text-decoration: UNDERLINE #FF0000FF 3px;');
+    });
+
+    it.each(annotationCombinations)('renders annotation combination %# from DictionaryTrack settings', (toggles) => {
+        const dt = makeAnnotationTrack(toggles, { dictionaryTokenStyling: TokenStyling.UNDERLINE });
+        setUnknownTokenColor(dt, '#112233', '44');
+
+        const rendered = renderToken(
+            '語学',
+            makeInternalToken({
+                pos: [0, 2],
+                status: TokenStatus.UNKNOWN,
+                readings: [{ pos: [0, 2], reading: 'ごがく' }],
+                frequency: 7,
+                pitchAccent: 1,
+            }),
+            dt
+        );
+
+        expect(rendered).toBe(expectedAnnotationCombinationHtml(toggles));
+    });
+
+    it.each([
+        [TokenStyling.TEXT, '-webkit-text-fill-color: #12345680;'],
+        [TokenStyling.BACKGROUND, 'background-color: #12345680;'],
+        [TokenStyling.UNDERLINE, 'text-decoration: UNDERLINE #12345680 5px;'],
+        [TokenStyling.OVERLINE, 'text-decoration: OVERLINE #12345680 5px;'],
+        [TokenStyling.OUTLINE, '-webkit-text-stroke: 5px #12345680;'],
+    ])('renders %s color styling with configured color and alpha', (style, expectedStyle) => {
+        const dt = makeAnnotationTrack(
+            { color: true },
+            {
+                dictionaryHighlightOnHover: false,
+                dictionaryTokenStyling: style,
+                dictionaryTokenStylingThickness: 5,
+            }
+        );
+        setUnknownTokenColor(dt, '#123456', '80');
+
+        expect(renderToken('語学', makeInternalToken({ pos: [0, 2], status: TokenStatus.UNKNOWN }), dt)).toBe(
+            `<span class="asb-token" style="${expectedStyle}">語学</span>`
+        );
+    });
+
+    it('adds the highlight class only when configured', () => {
+        expect(
+            renderToken(
+                '語学',
+                makeInternalToken({ pos: [0, 2], status: TokenStatus.UNKNOWN }),
+                makeAnnotationTrack({ color: true }, { dictionaryHighlightOnHover: true })
+            )
+        ).toContain('class="asb-token asb-token-highlight"');
+
+        expect(
+            renderToken(
+                '語学',
+                makeInternalToken({ pos: [0, 2], status: TokenStatus.UNKNOWN }),
+                makeAnnotationTrack({ color: true }, { dictionaryHighlightOnHover: false })
+            )
+        ).toContain('class="asb-token"');
+    });
+
+    it('renders pitch accent directly on kana tokens when no reading annotation is needed', () => {
+        const dt = makeAnnotationTrack({ color: true, pitchAccent: true });
+        setUnknownTokenColor(dt, '#334455', '66');
+
+        expect(
+            renderToken('かな', makeInternalToken({ pos: [0, 2], status: TokenStatus.UNKNOWN, pitchAccent: 1 }), dt)
+        ).toBe(`<span class="asb-token asb-token-highlight">${pitchAccentHtml(['か', 'な'], '#33445566')}</span>`);
+    });
+
+    it('carries pitch accent context onto an attached particle', () => {
+        const rendered = computeRichText(
+            '日本は',
+            {
+                tokens: [
+                    makeInternalToken({
+                        pos: [0, 2],
+                        status: TokenStatus.UNKNOWN,
+                        readings: [{ pos: [0, 2], reading: 'にほん' }],
+                        pitchAccent: 0,
+                    }),
+                    makeInternalToken({ pos: [2, 3], status: TokenStatus.UNKNOWN }),
+                ],
+            },
+            {
+                dt: makeAnnotationTrack({ reading: true, pitchAccent: true }),
+                enabledAnnotations: { color: false, reading: true, frequency: false, pitchAccent: true },
+                allowAsciiReading: false,
+            }
+        );
+
+        expect(rendered).toContain('<span class="asb-pitch-accent-mora asb-pitch-accent-mora-high">は</span>');
+    });
+
+    it.each<HoverCase>([
+        [
+            'color',
+            '語学',
+            { color: true },
+            makeInternalToken({ pos: [0, 2], status: TokenStatus.UNKNOWN }),
+            '<span class="asb-token asb-token-highlight" style="text-decoration: UNDERLINE #FFA500FF 3px;">語学</span>',
+        ],
+        [
+            'reading',
+            '語学',
+            { reading: true },
+            makeInternalToken({
+                pos: [0, 2],
+                status: TokenStatus.UNKNOWN,
+                readings: [{ pos: [0, 2], reading: 'ごがく' }],
+            }),
+            '<ruby class="asb-reading">語学<rt>ごがく</rt></ruby>',
+        ],
+        [
+            'frequency',
+            '語学',
+            { frequency: true },
+            makeInternalToken({ pos: [0, 2], status: TokenStatus.UNKNOWN, frequency: 7 }),
+            '<ruby class="asb-frequency">語学<rt>7</rt></ruby>',
+        ],
+        [
+            'pitchAccent',
+            'かな',
+            { pitchAccent: true },
+            makeInternalToken({ pos: [0, 2], status: TokenStatus.UNKNOWN, pitchAccent: 1 }),
+            pitchAccentHtml(['か', 'な'], 'currentColor'),
+        ],
+    ])(
+        'renders %s only in richTextOnHover when its hover setting is enabled',
+        (annotation, text, toggles, token, html) => {
+            const dt = makeAnnotationTrack(toggles);
+            dt.dictionaryTokenAnnotationConfig.video[annotation].onHoverEnabled = true;
+            const rendered = renderRichTextOntoSubtitles(
+                [makeSubtitle({ text, tokenization: { tokens: [token] } })],
+                'video',
+                makeDictionaryTracks(dt)
+            ).get(0);
+
+            expect(rendered?.richText).toBeUndefined();
+            expect(rendered?.richTextOnHover).toBe(html);
+        }
+    );
+
+    it('uses the selected annotation target when splitting hover and non-hover rich text', () => {
+        const dt = makeAnnotationTrack({ reading: true });
+        dt.dictionaryTokenAnnotationConfig.video.reading.onHoverEnabled = true;
+        dt.dictionaryTokenAnnotationConfig.subtitlePlayer.reading.onHoverEnabled = false;
+        const subtitle = makeSubtitle({
+            text: '語学',
+            tokenization: {
+                tokens: [
+                    makeInternalToken({
+                        pos: [0, 2],
+                        status: TokenStatus.UNKNOWN,
+                        readings: [{ pos: [0, 2], reading: 'ごがく' }],
+                    }),
+                ],
+            },
+        });
+
+        const videoRendered = renderRichTextOntoSubtitles([subtitle], 'video', makeDictionaryTracks(dt)).get(0);
+        const subtitlePlayerRendered = renderRichTextOntoSubtitles(
+            [subtitle],
+            'subtitlePlayer',
+            makeDictionaryTracks(dt)
+        ).get(0);
+
+        expect(videoRendered?.richText).toBeUndefined();
+        expect(videoRendered?.richTextOnHover).toBe('<ruby class="asb-reading">語学<rt>ごがく</rt></ruby>');
+        expect(subtitlePlayerRendered?.richText).toBe('<ruby class="asb-reading">語学<rt>ごがく</rt></ruby>');
+        expect(subtitlePlayerRendered?.richTextOnHover).toBeUndefined();
+    });
+
+    it('exposes target-specific annotation sizes as CSS custom properties', () => {
+        const dt = makeDictionaryTrack();
+        dt.dictionaryTokenAnnotationConfig.video.reading.size = 0.75;
+        dt.dictionaryTokenAnnotationConfig.video.frequency.size = 0.25;
+        dt.dictionaryTokenAnnotationConfig.video.pitchAccent.size = 0.125;
+        dt.dictionaryTokenAnnotationConfig.subtitlePlayer.reading.size = 0.9;
+        dt.dictionaryTokenAnnotationConfig.subtitlePlayer.frequency.size = 0.4;
+        dt.dictionaryTokenAnnotationConfig.subtitlePlayer.pitchAccent.size = 0.2;
+
+        expect(tokenAnnotationStyleValues(dt.dictionaryTokenAnnotationConfig.video)).toEqual({
+            '--asb-reading-size': '0.75em',
+            '--asb-frequency-size': '0.25em',
+            '--asb-pitch-accent-size': '0.125em',
+        });
+        expect(tokenAnnotationStyleValues(dt.dictionaryTokenAnnotationConfig.subtitlePlayer)).toEqual({
+            '--asb-reading-size': '0.9em',
+            '--asb-frequency-size': '0.4em',
+            '--asb-pitch-accent-size': '0.2em',
+        });
+    });
+
+    it('leaves non-letter token text unstyled', () => {
+        expect(
+            renderToken(
+                '。',
+                makeToken({ pos: [0, 1], status: TokenStatus.UNKNOWN }),
+                makeDictionaryTrack({ dictionaryColorizeSubtitles: true })
+            )
+        ).toBe('。');
+    });
+
+    it('reuses cached entries at both rich text window boundaries', () => {
+        const dictionaryTracks = makeDictionaryTracks(makeDictionaryTrack({ dictionaryColorizeSubtitles: true }));
+        const first = makeSubtitle({
+            index: 0,
+            text: '語',
+            tokenization: { tokens: [makeToken({ pos: [0, 1], status: TokenStatus.UNKNOWN })] },
+        });
+        const second = makeSubtitle({
+            index: 1,
+            text: '学',
+            tokenization: { tokens: [makeToken({ pos: [0, 1], status: TokenStatus.UNKNOWN })] },
+        });
+        const previous = renderRichTextWindow(emptyRichTextWindow(), [first, second], 'video', dictionaryTracks);
+
+        const reused = renderRichTextWindow(previous, [first, second], 'video', dictionaryTracks);
+
+        expect(reused.buffer.get(first.index)).toBe(previous.buffer.get(first.index));
+        expect(reused.buffer.get(second.index)).toBe(previous.buffer.get(second.index));
+    });
+
+    it('reuses per-subtitle cache entries while refreshing stale entries', () => {
+        const dictionaryTracks = makeDictionaryTracks(makeDictionaryTrack({ dictionaryColorizeSubtitles: true }));
+        const subtitle = makeSubtitle({
+            text: '語学',
+            tokenization: { tokens: [makeToken({ pos: [0, 2], status: TokenStatus.UNKNOWN })] },
+        });
+        const window = renderRichTextWindow(emptyRichTextWindow(), [subtitle], 'video', dictionaryTracks);
+
+        const cached = renderRichTextForSubtitle(window, subtitle, 'video', dictionaryTracks);
+        expect(cached?.richText).toContain('語学');
+        expect(renderRichTextForSubtitle(window, subtitle, 'video', dictionaryTracks)).toBe(cached);
+
+        const changedSubtitle = makeSubtitle({
+            text: '語',
+            tokenization: { tokens: [makeToken({ pos: [0, 1], status: TokenStatus.UNKNOWN })] },
+        });
+        const refreshed = renderRichTextForSubtitle(window, changedSubtitle, 'video', dictionaryTracks);
+
+        expect(refreshed).not.toBe(cached);
+        expect(refreshed?.richText).toContain('語</span>');
+    });
+});

--- a/common/annotations/subtitle-annotations.test.ts
+++ b/common/annotations/subtitle-annotations.test.ts
@@ -1,0 +1,767 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import {
+    DictionaryBuildAnkiCacheStateErrorCode,
+    DictionaryBuildAnkiCacheStateType,
+    DictionaryBuildWaniKaniCacheStateErrorCode,
+    DictionaryBuildWaniKaniCacheStateType,
+} from '@project/common';
+import {
+    ApplyStrategy,
+    DictionaryTokenSource,
+    TokenMatchStrategy,
+    TokenState,
+    TokenStatus,
+} from '@project/common/settings';
+import { Anki } from '@project/common/anki';
+import { REVIEW_DUES } from '@project/common/dictionary-statistics';
+import { SubtitleAnnotations, TrackState } from './subtitle-annotations';
+import {
+    makeDictionaryTrack,
+    makeDictionaryTracks,
+    makeSettings,
+    makeSubtitle,
+    makeSubtitleAnnotations,
+    makeToken,
+} from './annotations-test-utils';
+
+const privateAnnotations = (subtitleAnnotations: SubtitleAnnotations) => subtitleAnnotations as any;
+
+const makeYomitan = (overrides: Record<string, unknown> = {}) => ({
+    resetCache: jest.fn(),
+    tokenizeBulk: jest.fn(async (texts: string[]) => texts.map((text) => [{ text }])),
+    tokenize: jest.fn(async (text: string) => [[{ text }]]),
+    verifyTokenizeResult: jest.fn(),
+    lemmatize: jest.fn(async (text: string) => [text]),
+    frequency: jest.fn(async () => 42),
+    pitchAccent: jest.fn(async () => undefined),
+    getSupportsBulkFrequency: jest.fn(() => true),
+    getSupportsBulkPitchAccent: jest.fn(() => true),
+    getSupportsTermEntriesBulk: jest.fn(() => false),
+    inferFrequencyModesFromTokenOccurrences: jest.fn(),
+    ...overrides,
+});
+
+beforeEach(() => {
+    jest.restoreAllMocks();
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
+describe('TrackState', () => {
+    it('filters lemmas by script according to dictionaryMatchAcrossScripts', async () => {
+        const crossScript = new TrackState(0, makeDictionaryTrack({ dictionaryMatchAcrossScripts: true }));
+        crossScript.updateYomitan({ lemmatize: jest.fn(async () => ['見る', 'みる']) } as any);
+
+        await expect(crossScript.lemmatizeForScript('みる')).resolves.toEqual(['見る', 'みる']);
+
+        const sameScript = new TrackState(0, makeDictionaryTrack({ dictionaryMatchAcrossScripts: false }));
+        sameScript.updateYomitan({ lemmatize: jest.fn(async () => ['見る', 'みる']) } as any);
+
+        await expect(sameScript.lemmatizeForScript('見る', false)).resolves.toEqual(['見る']);
+    });
+
+    it('builds stable lemma grouping keys only for strategies that use lemmas', () => {
+        const track = makeDictionaryTrack({
+            dictionaryMatchAcrossScripts: true,
+            dictionaryTokenMatchStrategy: TokenMatchStrategy.ANY_FORM_COLLECTED,
+            dictionaryAnkiSentenceTokenMatchStrategy: TokenMatchStrategy.EXACT_FORM_COLLECTED,
+        });
+        const trackState = new TrackState(0, track);
+
+        expect(trackState.groupingKeysForToken('みる', ['見る', 'みる', '見る'], undefined)).toEqual({
+            groupingKey: 'みる',
+            lemmasGroupingKey: JSON.stringify(['みる', '見る']),
+        });
+        expect(trackState.groupingKeysForToken('みる', ['見る', 'みる'], DictionaryTokenSource.ANKI_SENTENCE)).toEqual({
+            groupingKey: 'みる',
+        });
+    });
+
+    it('resets the active Yomitan cache and detaches the instance', () => {
+        jest.spyOn(Date, 'now').mockReturnValue(1234);
+        const resetCache = jest.fn();
+        const trackState = new TrackState(0, makeDictionaryTrack());
+        trackState.updateYomitan({ resetCache } as any);
+
+        trackState.resetYomitan();
+
+        expect(resetCache).toHaveBeenCalledTimes(1);
+        expect(trackState.yt).toBeUndefined();
+        expect(trackState.ytLastResetAt).toBe(1234);
+    });
+});
+
+describe('SubtitleAnnotations', () => {
+    it('defaults originalText, clones subtitles, preserves cached tokenization, and stores external readings', () => {
+        const { subtitleAnnotations } = makeSubtitleAnnotations();
+        const buildAnnotations = jest.spyOn(subtitleAnnotations as any, '_buildAnnotations').mockResolvedValue(true);
+        const tokenization = {
+            tokens: [makeToken({ pos: [0, 2], readings: [{ pos: [0, 2], reading: 'ごがく' }] })],
+        };
+        const subtitle = makeSubtitle({ text: '語学', originalText: undefined, tokenization });
+
+        subtitleAnnotations.setSubtitles([subtitle]);
+        (subtitleAnnotations.subtitles[0] as any).__tokenized = true;
+        subtitleAnnotations.subtitles[0].text = 'annotated';
+        buildAnnotations.mockClear();
+
+        subtitleAnnotations.setSubtitles([makeSubtitle({ text: '語学', originalText: '語学', tokenization })]);
+
+        expect((subtitle as any).originalText).toBe('語学');
+        expect(subtitleAnnotations.subtitles[0]).not.toBe(subtitle);
+        expect(subtitleAnnotations.subtitles[0].text).toBe('annotated');
+        expect((subtitleAnnotations.subtitles[0] as any).__tokenized).toBe(true);
+        expect((subtitleAnnotations as any).externalTokenReadings.get('語学')).toEqual(
+            new Map([[0, [{ pos: [0, 2], reading: 'ごがく' }]]])
+        );
+        expect(buildAnnotations).not.toHaveBeenCalled();
+    });
+
+    it('restores raw text and clears transient token state when an enabled track is disabled', () => {
+        const enabledTrack = makeDictionaryTrack({ dictionaryColorizeSubtitles: true });
+        const disabledTrack = makeDictionaryTrack({ dictionaryColorizeSubtitles: false });
+        const settings = makeSettings(makeDictionaryTracks(enabledTrack));
+        const { subtitleAnnotations, subtitleAnnotationsUpdated } = makeSubtitleAnnotations(settings);
+        jest.spyOn(subtitleAnnotations as any, '_buildAnnotations').mockResolvedValue(true);
+
+        subtitleAnnotations.setSubtitles([
+            makeSubtitle({
+                text: 'annotated',
+                originalText: 'raw',
+                tokenization: { tokens: [makeToken({ pos: [0, 4], states: [TokenState.IGNORED] })] },
+            }),
+        ]);
+        (subtitleAnnotations as any).trackStates = [new TrackState(0, enabledTrack)];
+        subtitleAnnotationsUpdated.mockClear();
+
+        subtitleAnnotations.settingsUpdated(makeSettings(makeDictionaryTracks(disabledTrack)));
+
+        expect(subtitleAnnotations.subtitles[0].text).toBe('raw');
+        expect(subtitleAnnotations.subtitles[0].tokenization).toEqual({
+            tokens: [{ pos: [0, 4], readings: [], states: [] }],
+        });
+        expect(subtitleAnnotationsUpdated).toHaveBeenCalledWith(
+            [expect.objectContaining({ text: 'raw', track: 0 })],
+            expect.any(Array)
+        );
+    });
+
+    it('saves local token state through the dictionary provider when profile, track, and Yomitan are available', async () => {
+        const enabledTrack = makeDictionaryTrack({ dictionaryColorizeSubtitles: true });
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const trackState = new TrackState(0, enabledTrack);
+        trackState.updateYomitan({ lemmatize: jest.fn(async () => ['lemma-a', 'lemma-b']) } as any);
+        (subtitleAnnotations as any).profile = 'Profile';
+        (subtitleAnnotations as any).trackStates = [trackState];
+
+        await subtitleAnnotations.saveTokenLocal(
+            0,
+            'word',
+            TokenStatus.UNKNOWN,
+            [TokenState.IGNORED],
+            ApplyStrategy.ADD
+        );
+
+        expect(storage.saveRecordLocalBulk).toHaveBeenCalledWith(
+            'Profile',
+            [
+                {
+                    token: 'word',
+                    status: TokenStatus.UNKNOWN,
+                    lemmas: ['lemma-a', 'lemma-b'],
+                    states: [TokenState.IGNORED],
+                },
+            ],
+            ApplyStrategy.ADD
+        );
+        expect((subtitleAnnotations as any).tokensForRefresh).toEqual(new Set(['word', 'lemma-a', 'lemma-b']));
+    });
+
+    it('updates refresh state from Anki cache events and card modifications', () => {
+        const { subtitleAnnotations } = makeSubtitleAnnotations();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        (subtitleAnnotations as any).ankiState.recentlyModifiedCardIds = new Set([1]);
+        (subtitleAnnotations as any).ankiState.recentlyModifiedFirstCheck = true;
+
+        subtitleAnnotations.buildAnkiCacheStateChange({
+            type: DictionaryBuildAnkiCacheStateType.error,
+            body: {
+                code: DictionaryBuildAnkiCacheStateErrorCode.failedToBuild,
+                msg: 'failed',
+                modifiedTokens: ['alpha'],
+            },
+        } as any);
+        subtitleAnnotations.ankiCardWasModified();
+
+        expect((subtitleAnnotations as any).tokensForRefresh).toEqual(new Set(['alpha']));
+        expect((subtitleAnnotations as any).ankiState.recentlyModifiedCardIds).toEqual(new Set());
+        expect((subtitleAnnotations as any).ankiState.recentlyModifiedFirstCheck).toBe(false);
+        expect((subtitleAnnotations as any).ankiState.triggerRefresh).toBe(true);
+        expect(consoleError).toHaveBeenCalled();
+    });
+
+    it('preserves the Anki polling baseline for concurrent builds but clears it for terminal build errors', () => {
+        const { subtitleAnnotations } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        runtime.ankiState.recentlyModifiedCardIds = new Set([7]);
+        runtime.ankiState.recentlyModifiedFirstCheck = true;
+
+        subtitleAnnotations.buildAnkiCacheStateChange({
+            type: DictionaryBuildAnkiCacheStateType.error,
+            body: {
+                code: DictionaryBuildAnkiCacheStateErrorCode.concurrentBuild,
+                msg: 'already building',
+                modifiedTokens: [],
+            },
+        } as any);
+
+        expect(runtime.ankiState.recentlyModifiedCardIds).toEqual(new Set([7]));
+        expect(runtime.ankiState.recentlyModifiedFirstCheck).toBe(true);
+
+        subtitleAnnotations.buildAnkiCacheStateChange({
+            type: DictionaryBuildAnkiCacheStateType.error,
+            body: {
+                code: DictionaryBuildAnkiCacheStateErrorCode.failedToBuild,
+                msg: 'failed',
+                modifiedTokens: [],
+            },
+        } as any);
+
+        expect(runtime.ankiState.recentlyModifiedCardIds).toEqual(new Set());
+        expect(runtime.ankiState.recentlyModifiedFirstCheck).toBe(false);
+    });
+
+    it('updates refresh state from WaniKani cache events', () => {
+        const { subtitleAnnotations } = makeSubtitleAnnotations();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        (subtitleAnnotations as any).waniKaniState.statisticsRefreshed = true;
+
+        subtitleAnnotations.buildWaniKaniCacheStateChange({
+            type: DictionaryBuildWaniKaniCacheStateType.error,
+            body: {
+                code: DictionaryBuildWaniKaniCacheStateErrorCode.invalidWaniKaniToken,
+                msg: 'bad token',
+                modifiedTokens: ['単語'],
+            },
+        } as any);
+
+        expect((subtitleAnnotations as any).tokensForRefresh).toEqual(new Set(['単語']));
+        expect((subtitleAnnotations as any).waniKaniState.statisticsRefreshed).toBe(false);
+        expect(consoleError).toHaveBeenCalled();
+
+        (subtitleAnnotations as any).waniKaniState.statisticsRefreshed = true;
+        subtitleAnnotations.buildWaniKaniCacheStateChange({
+            type: DictionaryBuildWaniKaniCacheStateType.stats,
+            body: {
+                modifiedTokens: ['語彙'],
+            },
+        } as any);
+
+        expect((subtitleAnnotations as any).tokensForRefresh).toEqual(new Set(['単語', '語彙']));
+        expect((subtitleAnnotations as any).waniKaniState.statisticsRefreshed).toBe(false);
+    });
+
+    it('binds and unbinds dictionary provider callbacks including WaniKani cache events', () => {
+        jest.useFakeTimers();
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const removeAnkiBuild = jest.fn();
+        const removeWaniKaniBuild = jest.fn();
+        const removeAnkiCard = jest.fn();
+        const removeSnapshot = jest.fn();
+        const removeGeneration = jest.fn();
+        storage.onBuildAnkiCacheStateChange.mockReturnValue(removeAnkiBuild);
+        storage.onBuildWaniKaniCacheStateChange.mockReturnValue(removeWaniKaniBuild);
+        storage.onAnkiCardModified.mockReturnValue(removeAnkiCard);
+        storage.onRequestStatisticsSnapshot.mockReturnValue(removeSnapshot);
+        storage.onRequestStatisticsGeneration.mockReturnValue(removeGeneration);
+
+        subtitleAnnotations.bind();
+        subtitleAnnotations.unbind();
+
+        expect(storage.onBuildAnkiCacheStateChange).toHaveBeenCalledTimes(1);
+        expect(storage.onBuildWaniKaniCacheStateChange).toHaveBeenCalledTimes(1);
+        expect(removeAnkiBuild).toHaveBeenCalledTimes(1);
+        expect(removeWaniKaniBuild).toHaveBeenCalledTimes(1);
+        expect(removeAnkiCard).toHaveBeenCalledTimes(1);
+        expect(removeSnapshot).toHaveBeenCalledTimes(1);
+        expect(removeGeneration).toHaveBeenCalledTimes(1);
+    });
+
+    it('computes annotation windows from the whole collection or visible subtitles', () => {
+        const { subtitleAnnotations } = makeSubtitleAnnotations();
+
+        subtitleAnnotations.setSubtitles([
+            makeSubtitle({ index: 0 }),
+            makeSubtitle({ index: 1, text: 'two', originalText: 'two' }),
+        ]);
+
+        expect((subtitleAnnotations as any)._getAnnotationsIndexes()).toEqual({
+            annotationsStartIndex: 0,
+            annotationsEndIndex: 2,
+        });
+
+        jest.spyOn(subtitleAnnotations, 'subtitlesAt').mockReturnValue({
+            showing: [makeSubtitle({ index: 4 })],
+            nextToShow: [],
+        });
+        (subtitleAnnotations as any).getMediaTimeMs = () => 0;
+
+        expect((subtitleAnnotations as any)._getAnnotationsIndexes(false)).toEqual({
+            annotationsStartIndex: 4,
+            annotationsEndIndex: 105,
+        });
+    });
+
+    it('polls Anki changes without rebuilding on the baseline or unchanged card IDs', async () => {
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const findRecentlyModified = jest
+            .fn<() => Promise<number[]>>()
+            .mockResolvedValueOnce([1, 2])
+            .mockResolvedValueOnce([2, 1])
+            .mockResolvedValueOnce([2, 3]);
+        runtime.anki = { findRecentlyEditedOrReviewedCards: findRecentlyModified };
+
+        await runtime._checkAnkiRecentlyModifiedCards('Profile', ['Word'], ['Mining']);
+        expect(runtime.ankiState.recentlyModifiedCardIds).toEqual(new Set([1, 2]));
+        expect(runtime.ankiState.recentlyModifiedFirstCheck).toBe(false);
+        expect(storage.buildAnkiCache).not.toHaveBeenCalled();
+
+        await runtime._checkAnkiRecentlyModifiedCards('Profile', ['Word'], ['Mining']);
+        expect(storage.buildAnkiCache).not.toHaveBeenCalled();
+
+        await runtime._checkAnkiRecentlyModifiedCards('Profile', ['Word'], ['Mining']);
+        expect(storage.buildAnkiCache).toHaveBeenCalledWith('Profile', expect.any(Object));
+        expect(runtime.ankiState.recentlyModifiedCardIds).toEqual(new Set([2, 3]));
+        expect(runtime.ankiState.triggerRefresh).toBe(true);
+        expect(runtime.ankiState.statisticsRefreshed).toBe(false);
+        expect(findRecentlyModified).toHaveBeenNthCalledWith(1, 1, ['Word'], ['Mining']);
+    });
+
+    it('clears the Anki polling client and baseline after a polling failure', async () => {
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        runtime.anki = {
+            findRecentlyEditedOrReviewedCards: jest.fn(async () => {
+                throw new Error('offline');
+            }),
+        };
+        runtime.ankiState.recentlyModifiedCardIds = new Set([9]);
+
+        await runtime._checkAnkiRecentlyModifiedCards('Profile', ['Word'], []);
+
+        expect(runtime.anki).toBeUndefined();
+        expect(runtime.ankiState.recentlyModifiedCardIds).toEqual(new Set());
+        expect(runtime.ankiState.recentlyModifiedFirstCheck).toBe(false);
+        expect(storage.buildAnkiCache).not.toHaveBeenCalled();
+        expect(consoleError).toHaveBeenCalledWith('Error checking Anki recently modified cards:', expect.any(Error));
+    });
+
+    it('refreshes Anki once, merges configured fields, and treats an empty deck list as all decks', async () => {
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const track0 = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryAnkiWordFields: ['Word', 'Shared'],
+            dictionaryAnkiSentenceFields: ['Sentence'],
+            dictionaryAnkiDecks: ['Mining'],
+        });
+        const track1 = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryAnkiWordFields: ['Shared', 'Expression'],
+            dictionaryAnkiSentenceFields: [],
+            dictionaryAnkiDecks: [],
+        });
+        const findRecentlyModified = jest.fn(async () => [7]);
+        runtime.profile = 'Profile';
+        runtime.trackStates = [new TrackState(0, track0), new TrackState(1, track1)];
+        runtime.anki = { findRecentlyEditedOrReviewedCards: findRecentlyModified };
+        const refreshStatistics = jest.spyOn(runtime, '_refreshAnkiStatistics').mockResolvedValue(undefined);
+
+        await runtime._refreshAnki();
+        await runtime._refreshAnki();
+
+        expect(storage.buildAnkiCache).toHaveBeenCalledTimes(1);
+        expect(storage.buildAnkiCache).toHaveBeenCalledWith('Profile', expect.any(Object));
+        expect(findRecentlyModified).toHaveBeenCalledTimes(2);
+        expect(findRecentlyModified).toHaveBeenCalledWith(1, ['Word', 'Shared', 'Sentence', 'Expression'], []);
+        expect(refreshStatistics).toHaveBeenCalledWith('Profile', ['Word', 'Shared', 'Sentence', 'Expression'], []);
+        expect(runtime.ankiState.refreshed).toBe(true);
+        expect(runtime.ankiState.refreshing).toBe(false);
+
+        runtime.ankiState.refreshing = true;
+        await runtime._refreshAnki();
+        expect(findRecentlyModified).toHaveBeenCalledTimes(2);
+    });
+
+    it('handles denied Anki permission without starting a cache build', async () => {
+        const track = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const permission = jest.spyOn(Anki.prototype, 'requestPermission').mockResolvedValue({ permission: 'denied' });
+        runtime.profile = 'Profile';
+        runtime.trackStates = [new TrackState(0, track)];
+        const checkRecentlyModified = jest
+            .spyOn(runtime, '_checkAnkiRecentlyModifiedCards')
+            .mockResolvedValue(undefined);
+        jest.spyOn(runtime, '_refreshAnkiStatistics').mockResolvedValue(undefined);
+
+        await runtime._refreshAnki();
+
+        expect(permission).toHaveBeenCalledTimes(1);
+        expect(runtime.anki).toBeUndefined();
+        expect(storage.buildAnkiCache).not.toHaveBeenCalled();
+        expect(checkRecentlyModified).toHaveBeenCalledWith('Profile', ['Word'], []);
+        expect(runtime.ankiState.refreshing).toBe(false);
+        expect(consoleWarn).toHaveBeenCalledWith('Anki permission request failed:', expect.any(Error));
+    });
+
+    it('resets Anki refresh state when the cache build rejects', async () => {
+        const track = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        storage.buildAnkiCache.mockRejectedValue(new Error('build failed'));
+        runtime.profile = 'Profile';
+        runtime.trackStates = [new TrackState(0, track)];
+        runtime.anki = { findRecentlyEditedOrReviewedCards: jest.fn(async () => []) };
+
+        await runtime._refreshAnki();
+
+        expect(runtime.ankiState.refreshed).toBe(false);
+        expect(runtime.ankiState.refreshing).toBe(false);
+        expect(consoleWarn).toHaveBeenCalledWith('Anki refresh failed:', expect.any(Error));
+    });
+
+    it('builds and caches the Anki statistics snapshot, including due-card requests', async () => {
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const cardRecord = {
+            cardId: 7,
+            status: TokenStatus.LEARNING,
+            data: { deckName: 'Mining', modelName: 'Sentence', due: 3 },
+        };
+        storage.getRecords.mockResolvedValue({
+            tokenRecords: [],
+            ankiCardRecords: { 0: { 7: cardRecord } },
+            waniKaniSubjectRecords: {},
+        });
+        const findCardsDueBy = jest.fn(async (due: number) => [due + 100]);
+        runtime.anki = { findCardsDueBy };
+        runtime.generateStatistics = true;
+        const replaceSnapshot = jest.spyOn(runtime.dictionaryStatistics, 'replaceAnkiSnapshot');
+
+        await runtime._refreshAnkiStatistics('Profile', ['Word'], ['Mining']);
+        await runtime._refreshAnkiStatistics('Profile', ['Word'], ['Mining']);
+
+        expect(findCardsDueBy.mock.calls).toEqual(REVIEW_DUES.map((due) => [due, ['Word'], ['Mining']]));
+        expect(replaceSnapshot).toHaveBeenCalledTimes(1);
+        expect(replaceSnapshot).toHaveBeenCalledWith({
+            available: true,
+            progress: { current: 1, total: 1, startedAt: expect.any(Number) },
+            cardsInfo: { 7: cardRecord.data },
+            cardsStatus: { 7: TokenStatus.LEARNING },
+            dueCards: { 0: [100], 1: [101], 7: [107] },
+        });
+        expect(runtime.ankiState.statisticsRefreshed).toBe(true);
+    });
+
+    it('requests missing Anki card details when cache records do not contain statistics metadata', async () => {
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        storage.getRecords.mockResolvedValue({
+            tokenRecords: [],
+            ankiCardRecords: {
+                0: {
+                    7: { cardId: 7, status: TokenStatus.GRADUATED, data: undefined },
+                },
+            },
+            waniKaniSubjectRecords: {},
+        });
+        const cardsInfo = jest.fn(async () => [{ cardId: 7, deckName: 'Mining', modelName: 'Sentence', due: 5 }]);
+        runtime.anki = { cardsInfo, findCardsDueBy: jest.fn(async () => []) };
+        runtime.generateStatistics = true;
+        const replaceSnapshot = jest.spyOn(runtime.dictionaryStatistics, 'replaceAnkiSnapshot');
+
+        await runtime._refreshAnkiStatistics('Profile', ['Word'], []);
+
+        expect(cardsInfo).toHaveBeenCalledWith([7]);
+        expect(replaceSnapshot).toHaveBeenCalledWith(
+            expect.objectContaining({
+                cardsInfo: { 7: { deckName: 'Mining', modelName: 'Sentence', due: 5 } },
+                cardsStatus: { 7: TokenStatus.GRADUATED },
+            })
+        );
+    });
+
+    it('publishes unavailable Anki statistics and drops the client after a request failure', async () => {
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        storage.getRecords.mockResolvedValue({
+            tokenRecords: [],
+            ankiCardRecords: {},
+            waniKaniSubjectRecords: {},
+        });
+        runtime.anki = {
+            findCardsDueBy: jest.fn(async () => {
+                throw new Error('offline');
+            }),
+        };
+        runtime.generateStatistics = true;
+        const replaceSnapshot = jest.spyOn(runtime.dictionaryStatistics, 'replaceAnkiSnapshot');
+
+        await runtime._refreshAnkiStatistics('Profile', ['Word'], []);
+
+        expect(runtime.anki).toBeUndefined();
+        expect(runtime.ankiState.statisticsRefreshed).toBe(false);
+        expect(replaceSnapshot).toHaveBeenCalledWith({
+            available: false,
+            cardsInfo: {},
+            cardsStatus: {},
+            dueCards: {},
+        });
+        expect(consoleError).toHaveBeenCalledWith('Error refreshing Anki for statistics:', expect.any(Error));
+    });
+
+    it('builds the WaniKani cache once and always releases its refresh lock', async () => {
+        const track = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryWaniKaniApiToken: ' wk-token ',
+        });
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        runtime.profile = 'Profile';
+        runtime.trackStates = [new TrackState(0, track)];
+        const refreshStatistics = jest.spyOn(runtime, '_refreshWaniKaniStatistics').mockResolvedValue(undefined);
+
+        await runtime._refreshWaniKani();
+        await runtime._refreshWaniKani();
+
+        expect(storage.buildWaniKaniCache).toHaveBeenCalledTimes(1);
+        expect(storage.buildWaniKaniCache).toHaveBeenCalledWith('Profile');
+        expect(refreshStatistics).toHaveBeenCalledTimes(2);
+        expect(runtime.waniKaniState.refreshed).toBe(true);
+        expect(runtime.waniKaniState.refreshing).toBe(false);
+
+        runtime.waniKaniState.refreshing = true;
+        await runtime._refreshWaniKani();
+        expect(refreshStatistics).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips WaniKani requests without a token and recovers its state from build failures', async () => {
+        const noTokenTrack = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryWaniKaniApiToken: '   ',
+        });
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        runtime.profile = 'Profile';
+        runtime.trackStates = [new TrackState(0, noTokenTrack)];
+
+        await runtime._refreshWaniKani();
+        expect(storage.buildWaniKaniCache).not.toHaveBeenCalled();
+        expect(runtime.waniKaniState.refreshing).toBe(false);
+
+        runtime.trackStates = [
+            new TrackState(
+                0,
+                makeDictionaryTrack({ dictionaryColorizeSubtitles: true, dictionaryWaniKaniApiToken: 'token' })
+            ),
+        ];
+        storage.buildWaniKaniCache.mockRejectedValue(new Error('build failed'));
+
+        await runtime._refreshWaniKani();
+
+        expect(runtime.waniKaniState.refreshed).toBe(false);
+        expect(runtime.waniKaniState.refreshing).toBe(false);
+        expect(consoleWarn).toHaveBeenCalledWith('WaniKani refresh failed:', expect.any(Error));
+    });
+
+    it('builds per-track WaniKani statistics while isolating a failed track', async () => {
+        const track0 = makeDictionaryTrack({ dictionaryColorizeSubtitles: true });
+        const track1 = makeDictionaryTrack({ dictionaryColorizeSubtitles: true });
+        const { subtitleAnnotations, storage } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        runtime.trackStates = [new TrackState(0, track0), new TrackState(1, track1)];
+        runtime.generateStatistics = true;
+        const assignment = { assignmentId: 21, subjectId: 11 };
+        const subject = { subjectId: 11 };
+        (storage.getRecords as any).mockImplementation(async (_profile: string, track: number) => {
+            if (track === 1) throw new Error('track offline');
+            return {
+                tokenRecords: [],
+                ankiCardRecords: {},
+                waniKaniAssignmentRecords: { 0: { 21: assignment } },
+                waniKaniSubjectRecords: { 0: { 11: subject } },
+            };
+        });
+        const replaceSnapshots = jest.spyOn(runtime.dictionaryStatistics, 'replaceWaniKaniSnapshots');
+
+        await runtime._refreshWaniKaniStatistics('Profile');
+
+        expect(storage.getRecords).toHaveBeenNthCalledWith(1, 'Profile', 0);
+        expect(storage.getRecords).toHaveBeenNthCalledWith(2, 'Profile', 1);
+        expect(replaceSnapshots).toHaveBeenCalledWith({
+            0: { available: true, assignments: [assignment], subjects: { 11: subject } },
+            1: { available: false, assignments: [], subjects: {} },
+        });
+        expect(runtime.waniKaniState.statisticsRefreshed).toBe(true);
+        expect(consoleError).toHaveBeenCalledWith(
+            'Error refreshing WaniKani for Track2 statistics:',
+            expect.any(Error)
+        );
+    });
+
+    it('runs annotation and external refresh work from the bound polling interval', () => {
+        jest.useFakeTimers();
+        const { subtitleAnnotations } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const buildAnnotations = jest.spyOn(runtime, '_buildAnnotations').mockResolvedValue(true);
+        subtitleAnnotations.setSubtitles([makeSubtitle()]);
+        buildAnnotations.mockClear();
+        runtime.tokensForRefresh.add('word');
+        runtime.ankiState.triggerRefresh = true;
+        runtime.waniKaniState.triggerRefresh = true;
+        const refreshAnki = jest.spyOn(runtime, '_refreshAnki').mockResolvedValue(undefined);
+        const refreshWaniKani = jest.spyOn(runtime, '_refreshWaniKani').mockResolvedValue(undefined);
+
+        subtitleAnnotations.bind();
+        jest.advanceTimersByTime(100);
+
+        expect(buildAnnotations).toHaveBeenCalledWith(0, 1);
+        expect(refreshAnki).toHaveBeenCalledTimes(1);
+        expect(refreshWaniKani).toHaveBeenCalledTimes(1);
+        expect(runtime.ankiState.triggerRefresh).toBe(false);
+        expect(runtime.waniKaniState.triggerRefresh).toBe(false);
+
+        subtitleAnnotations.unbind();
+        jest.advanceTimersByTime(200);
+        expect(refreshAnki).toHaveBeenCalledTimes(1);
+        expect(refreshWaniKani).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes the annotation pipeline and publishes a tokenized subtitle', async () => {
+        const track = makeDictionaryTrack({ dictionaryColorizeSubtitles: true });
+        const { subtitleAnnotations, storage, subtitleAnnotationsUpdated } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const initialBuild = jest.spyOn(runtime, '_buildAnnotations').mockResolvedValue(true);
+        subtitleAnnotations.setSubtitles([makeSubtitle({ text: 'word', originalText: 'word' })]);
+        initialBuild.mockRestore();
+        const yomitan = makeYomitan();
+        const trackState = new TrackState(0, track);
+        trackState.updateYomitan(yomitan as any);
+        runtime.profile = 'Profile';
+        runtime.trackStates = [trackState];
+        storage.getByLemmaBulk.mockResolvedValue({
+            word: [
+                {
+                    token: 'word',
+                    source: DictionaryTokenSource.LOCAL,
+                    statuses: [{ status: TokenStatus.MATURE, suspended: false }],
+                    states: [],
+                },
+            ],
+        });
+
+        await expect(runtime._buildAnnotations(0, 1, true)).resolves.toBe(true);
+
+        expect(yomitan.tokenizeBulk).toHaveBeenCalledWith(['word']);
+        expect(yomitan.tokenize).toHaveBeenCalledWith('word');
+        expect(yomitan.verifyTokenizeResult).toHaveBeenCalled();
+        expect(yomitan.frequency).toHaveBeenCalledWith('word');
+        expect(yomitan.inferFrequencyModesFromTokenOccurrences).toHaveBeenCalled();
+        expect(subtitleAnnotations.subtitles[0].tokenization?.tokens[0]).toEqual(
+            expect.objectContaining({
+                pos: [0, 4],
+                status: TokenStatus.MATURE,
+                frequency: 42,
+                states: [],
+            })
+        );
+        expect(runtime.initialized).toBe(true);
+        expect(runtime.annotationsBuilding).toBe(false);
+        expect(subtitleAnnotationsUpdated).toHaveBeenCalledWith(
+            [expect.objectContaining({ text: 'word', track: 0 })],
+            [track]
+        );
+    });
+
+    it('rejects overlapping annotation builds and resets Yomitan after a token request failure', async () => {
+        const track = makeDictionaryTrack({ dictionaryColorizeSubtitles: true });
+        const { subtitleAnnotations } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const initialBuild = jest.spyOn(runtime, '_buildAnnotations').mockResolvedValue(true);
+        subtitleAnnotations.setSubtitles([makeSubtitle()]);
+        initialBuild.mockRestore();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const yomitan = makeYomitan({
+            tokenize: jest.fn(async () => {
+                throw new Error('tokenization failed');
+            }),
+        });
+        const trackState = new TrackState(0, track);
+        trackState.updateYomitan(yomitan as any);
+        runtime.profile = 'Profile';
+        runtime.trackStates = [trackState];
+
+        runtime.annotationsBuilding = true;
+        await expect(runtime._buildAnnotations(0, 1, true)).resolves.toBe(false);
+        runtime.annotationsBuilding = false;
+
+        await expect(runtime._buildAnnotations(0, 1, true)).resolves.toBe(true);
+
+        expect(yomitan.resetCache).toHaveBeenCalledTimes(1);
+        expect(trackState.yt).toBeUndefined();
+        expect(subtitleAnnotations.subtitles[0].tokenization).toEqual({ tokens: [], error: true });
+        expect(runtime.initialized).toBe(false);
+        expect(runtime.annotationsBuilding).toBe(false);
+        expect(runtime.tokenRequestFailedForTracks).toEqual(new Set());
+        expect(consoleError).toHaveBeenCalledWith('Error annotating subtitle text for Track1:', expect.any(Error));
+    });
+
+    it('cancels an in-flight annotation build without publishing partial results', async () => {
+        const track = makeDictionaryTrack({ dictionaryColorizeSubtitles: true });
+        const { subtitleAnnotations, subtitleAnnotationsUpdated } = makeSubtitleAnnotations();
+        const runtime = privateAnnotations(subtitleAnnotations);
+        const initialBuild = jest.spyOn(runtime, '_buildAnnotations').mockResolvedValue(true);
+        subtitleAnnotations.setSubtitles([makeSubtitle()]);
+        initialBuild.mockRestore();
+        subtitleAnnotationsUpdated.mockClear();
+
+        let resolveTokenizeBulk!: (value: { text: string }[][]) => void;
+        const tokenizeBulkResult = new Promise<{ text: string }[][]>((resolve) => {
+            resolveTokenizeBulk = resolve;
+        });
+        const yomitan = makeYomitan({ tokenizeBulk: jest.fn(() => tokenizeBulkResult) });
+        const trackState = new TrackState(0, track);
+        trackState.updateYomitan(yomitan as any);
+        runtime.profile = 'Profile';
+        runtime.trackStates = [trackState];
+
+        const build = runtime._buildAnnotations(0, 1, true);
+        expect(yomitan.tokenizeBulk).toHaveBeenCalledWith(['word']);
+        runtime.shouldCancelBuild = true;
+        resolveTokenizeBulk([[{ text: 'word' }]]);
+
+        await expect(build).resolves.toBe(false);
+        expect(subtitleAnnotations.subtitles[0].tokenization).toBeUndefined();
+        expect(subtitleAnnotationsUpdated).not.toHaveBeenCalled();
+        expect(runtime.shouldCancelBuild).toBe(false);
+        expect(runtime.annotationsBuilding).toBe(false);
+        expect(runtime.initialized).toBe(false);
+    });
+});

--- a/common/annotations/token-collection.test.ts
+++ b/common/annotations/token-collection.test.ts
@@ -1,0 +1,419 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+    DictionaryTokenSource,
+    TokenMatchStrategy,
+    TokenMatchStrategyPriority,
+    TokenStatus,
+} from '@project/common/settings';
+import { getTokenStatus } from '@project/common/util';
+import { TrackState } from './subtitle-annotations';
+import { resolveTokenStatus } from './token-collection';
+import { makeDictionaryTrack } from './annotations-test-utils';
+
+const cardStatus = (status: TokenStatus, cardId = 1) => ({ cardId, status, suspended: false });
+
+const makeTrackState = (
+    overrides: Parameters<typeof makeDictionaryTrack>[0],
+    lemmas: string[] = ['lemma']
+): TrackState => {
+    const trackState = new TrackState(0, makeDictionaryTrack(overrides));
+    trackState.updateYomitan({ lemmatize: jest.fn(async () => lemmas) } as any);
+    return trackState;
+};
+
+type CollectedForm = 'exact' | 'lemma' | 'different-inflection';
+
+describe('getTokenStatus', () => {
+    it('folds empty, active, and suspended card statuses', () => {
+        expect(getTokenStatus([], 'NORMAL')).toBe(TokenStatus.UNKNOWN);
+        expect(getTokenStatus([{ cardId: 1, status: TokenStatus.LEARNING, suspended: false }], 'NORMAL')).toBe(
+            TokenStatus.LEARNING
+        );
+        expect(
+            getTokenStatus(
+                [
+                    { cardId: 1, status: TokenStatus.GRADUATED, suspended: false },
+                    { cardId: 2, status: TokenStatus.YOUNG, suspended: false },
+                ],
+                'NORMAL'
+            )
+        ).toBe(TokenStatus.YOUNG);
+        expect(
+            getTokenStatus(
+                [
+                    { cardId: 1, status: TokenStatus.MATURE, suspended: true },
+                    { cardId: 2, status: TokenStatus.LEARNING, suspended: false },
+                ],
+                TokenStatus.UNKNOWN
+            )
+        ).toBe(TokenStatus.LEARNING);
+        expect(getTokenStatus([{ cardId: 1, status: TokenStatus.MATURE, suspended: true }], TokenStatus.UNKNOWN)).toBe(
+            TokenStatus.UNKNOWN
+        );
+    });
+});
+
+describe('resolveTokenStatus', () => {
+    it('ignores capitalization when resolving collected word matches', async () => {
+        const trackState = new TrackState(
+            0,
+            makeDictionaryTrack({
+                dictionaryTokenMatchStrategy: TokenMatchStrategy.EXACT_FORM_COLLECTED,
+                dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+            })
+        );
+        trackState.updateYomitan({ lemmatize: jest.fn(async () => ['word']) } as any);
+        trackState.tokenCollectionExact.add(
+            [{ cardId: 1, status: TokenStatus.MATURE, suspended: false }],
+            DictionaryTokenSource.ANKI_WORD,
+            undefined,
+            'Word',
+            []
+        );
+
+        await expect(resolveTokenStatus('word', 'word', trackState)).resolves.toEqual({
+            status: TokenStatus.MATURE,
+            source: DictionaryTokenSource.ANKI_WORD,
+            externalCandidateStatuses: [{ cardId: 1, status: TokenStatus.MATURE, suspended: false }],
+        });
+    });
+
+    it('matches kana subtitle tokens against collected kanji forms only when cross-script matching is enabled', async () => {
+        const status = {
+            cardId: 1,
+            status: TokenStatus.MATURE,
+            suspended: false,
+        };
+        const makeTrackState = (dictionaryMatchAcrossScripts: boolean) => {
+            const trackState = new TrackState(
+                0,
+                makeDictionaryTrack({
+                    dictionaryMatchAcrossScripts,
+                    dictionaryTokenMatchStrategy: TokenMatchStrategy.ANY_FORM_COLLECTED,
+                    dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+                })
+            );
+            trackState.updateYomitan({ lemmatize: jest.fn(async () => ['見る']) } as any);
+            trackState.tokenCollectionAny.add([status], DictionaryTokenSource.ANKI_WORD, undefined, '見る', [], '見る');
+            return trackState;
+        };
+
+        await expect(resolveTokenStatus('みる', 'みる', makeTrackState(true))).resolves.toEqual({
+            status: TokenStatus.MATURE,
+            source: DictionaryTokenSource.ANKI_WORD,
+            externalCandidateStatuses: [status],
+        });
+        await expect(resolveTokenStatus('みる', 'みる', makeTrackState(false))).resolves.toEqual({
+            status: TokenStatus.UNCOLLECTED,
+        });
+    });
+
+    it('does not match kanji subtitle tokens against collected kana forms even when cross-script matching is enabled', async () => {
+        const trackState = makeTrackState(
+            {
+                dictionaryMatchAcrossScripts: true,
+                dictionaryTokenMatchStrategy: TokenMatchStrategy.ANY_FORM_COLLECTED,
+                dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+            },
+            ['みる']
+        );
+        trackState.tokenCollectionAny.add(
+            [cardStatus(TokenStatus.MATURE)],
+            DictionaryTokenSource.ANKI_WORD,
+            undefined,
+            'みる',
+            [],
+            'みる'
+        );
+
+        await expect(resolveTokenStatus('見る', '見る', trackState)).resolves.toEqual({
+            status: TokenStatus.UNCOLLECTED,
+        });
+    });
+
+    it.each<[TokenMatchStrategy, CollectedForm]>([
+        [TokenMatchStrategy.EXACT_FORM_COLLECTED, 'exact'],
+        [TokenMatchStrategy.LEMMA_FORM_COLLECTED, 'lemma'],
+        [TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED, 'lemma'],
+        [TokenMatchStrategy.ANY_FORM_COLLECTED, 'different-inflection'],
+    ])('matches the expected collected form for %s', async (strategy, collectedForm) => {
+        const trackState = makeTrackState(
+            {
+                dictionaryTokenMatchStrategy: strategy,
+                dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+            },
+            ['走る']
+        );
+        switch (collectedForm) {
+            case 'exact':
+                trackState.tokenCollectionExact.add(
+                    [cardStatus(TokenStatus.MATURE)],
+                    DictionaryTokenSource.ANKI_WORD,
+                    undefined,
+                    '走った',
+                    []
+                );
+                break;
+            case 'lemma':
+                trackState.tokenCollectionLemma.add(
+                    [cardStatus(TokenStatus.MATURE)],
+                    DictionaryTokenSource.ANKI_WORD,
+                    undefined,
+                    '走る',
+                    []
+                );
+                break;
+            case 'different-inflection':
+                trackState.tokenCollectionAny.add(
+                    [cardStatus(TokenStatus.MATURE)],
+                    DictionaryTokenSource.ANKI_WORD,
+                    undefined,
+                    '走る',
+                    [],
+                    '走れ'
+                );
+                break;
+        }
+
+        await expect(resolveTokenStatus('走った', '走った', trackState)).resolves.toMatchObject({
+            status: TokenStatus.MATURE,
+            source: DictionaryTokenSource.ANKI_WORD,
+        });
+    });
+
+    it.each<[TokenMatchStrategy, CollectedForm]>([
+        [TokenMatchStrategy.EXACT_FORM_COLLECTED, 'lemma'],
+        [TokenMatchStrategy.LEMMA_FORM_COLLECTED, 'exact'],
+        [TokenMatchStrategy.LEMMA_FORM_COLLECTED, 'different-inflection'],
+        [TokenMatchStrategy.LEMMA_OR_EXACT_FORM_COLLECTED, 'different-inflection'],
+    ])('does not match unsupported collected forms for %s', async (strategy, collectedForm) => {
+        const trackState = makeTrackState(
+            {
+                dictionaryTokenMatchStrategy: strategy,
+                dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+            },
+            ['走る']
+        );
+        switch (collectedForm) {
+            case 'exact':
+                trackState.tokenCollectionExact.add(
+                    [cardStatus(TokenStatus.MATURE)],
+                    DictionaryTokenSource.ANKI_WORD,
+                    undefined,
+                    '走った',
+                    []
+                );
+                break;
+            case 'lemma':
+                trackState.tokenCollectionLemma.add(
+                    [cardStatus(TokenStatus.MATURE)],
+                    DictionaryTokenSource.ANKI_WORD,
+                    undefined,
+                    '走る',
+                    []
+                );
+                break;
+            case 'different-inflection':
+                trackState.tokenCollectionAny.add(
+                    [cardStatus(TokenStatus.MATURE)],
+                    DictionaryTokenSource.ANKI_WORD,
+                    undefined,
+                    '走る',
+                    [],
+                    '走れ'
+                );
+                break;
+        }
+
+        await expect(resolveTokenStatus('走った', '走った', trackState)).resolves.toEqual({
+            status: TokenStatus.UNCOLLECTED,
+        });
+    });
+
+    it('uses exact matches before lemma and any-form matches when configured for exact priority', async () => {
+        const trackState = new TrackState(
+            0,
+            makeDictionaryTrack({
+                dictionaryTokenMatchStrategy: TokenMatchStrategy.ANY_FORM_COLLECTED,
+                dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+            })
+        );
+        trackState.updateYomitan({ lemmatize: jest.fn(async () => ['lemma']) } as any);
+        trackState.tokenCollectionAny.add(
+            [{ cardId: 1, status: TokenStatus.UNKNOWN, suspended: false }],
+            DictionaryTokenSource.ANKI_WORD,
+            undefined,
+            'lemma',
+            [],
+            'surface'
+        );
+        trackState.tokenCollectionAny.add(
+            [{ status: TokenStatus.MATURE, suspended: false }],
+            DictionaryTokenSource.WANIKANI,
+            undefined,
+            'lemma',
+            [],
+            'collected-lemma'
+        );
+
+        await expect(resolveTokenStatus('surface', 'surface', trackState)).resolves.toEqual({
+            status: TokenStatus.UNKNOWN,
+            source: DictionaryTokenSource.ANKI_WORD,
+            externalCandidateStatuses: [{ cardId: 1, status: TokenStatus.UNKNOWN, suspended: false }],
+        });
+    });
+
+    it.each([
+        [TokenMatchStrategyPriority.EXACT, TokenStatus.UNKNOWN],
+        [TokenMatchStrategyPriority.LEMMA, TokenStatus.MATURE],
+        [TokenMatchStrategyPriority.BEST_KNOWN, TokenStatus.MATURE],
+        [TokenMatchStrategyPriority.LEAST_KNOWN, TokenStatus.UNKNOWN],
+    ])('uses %s card choice priority when exact and lemma candidates both exist', async (priority, expectedStatus) => {
+        const trackState = makeTrackState({
+            dictionaryTokenMatchStrategy: TokenMatchStrategy.ANY_FORM_COLLECTED,
+            dictionaryTokenMatchStrategyPriority: priority,
+        });
+        trackState.tokenCollectionAny.add(
+            [cardStatus(TokenStatus.UNKNOWN, 1)],
+            DictionaryTokenSource.ANKI_WORD,
+            undefined,
+            'lemma',
+            [],
+            'surface'
+        );
+        trackState.tokenCollectionAny.add(
+            [cardStatus(TokenStatus.MATURE, 2)],
+            DictionaryTokenSource.ANKI_WORD,
+            undefined,
+            'lemma',
+            [],
+            'lemma'
+        );
+
+        await expect(resolveTokenStatus('surface', 'surface', trackState)).resolves.toMatchObject({
+            status: expectedStatus,
+            source: DictionaryTokenSource.ANKI_WORD,
+        });
+    });
+
+    it('can choose the best known word status across exact, lemma, and any-form matches', async () => {
+        const trackState = new TrackState(
+            0,
+            makeDictionaryTrack({
+                dictionaryTokenMatchStrategy: TokenMatchStrategy.ANY_FORM_COLLECTED,
+                dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.BEST_KNOWN,
+            })
+        );
+        trackState.updateYomitan({ lemmatize: jest.fn(async () => ['lemma']) } as any);
+        trackState.tokenCollectionAny.add(
+            [{ cardId: 1, status: TokenStatus.UNKNOWN, suspended: false }],
+            DictionaryTokenSource.ANKI_WORD,
+            undefined,
+            'lemma',
+            [],
+            'surface'
+        );
+        trackState.tokenCollectionAny.add(
+            [
+                {
+                    status: TokenStatus.MATURE,
+                    suspended: false,
+                    waniKani: { subjectId: 1, subjectLevel: 1, assignmentId: 1, availableAt: null },
+                },
+            ],
+            DictionaryTokenSource.WANIKANI,
+            undefined,
+            'lemma',
+            [],
+            'collected-lemma'
+        );
+
+        await expect(resolveTokenStatus('surface', 'surface', trackState)).resolves.toEqual({
+            status: TokenStatus.MATURE,
+            source: DictionaryTokenSource.WANIKANI,
+            externalCandidateStatuses: [
+                { cardId: 1, status: TokenStatus.UNKNOWN, suspended: false },
+                {
+                    status: TokenStatus.MATURE,
+                    suspended: false,
+                    waniKani: { subjectId: 1, subjectLevel: 1, assignmentId: 1, availableAt: null },
+                },
+            ],
+        });
+    });
+
+    it('uses sentence matches only when no word match is present', async () => {
+        const withWordAndSentence = makeTrackState({
+            dictionaryTokenMatchStrategy: TokenMatchStrategy.EXACT_FORM_COLLECTED,
+            dictionaryAnkiSentenceTokenMatchStrategy: TokenMatchStrategy.EXACT_FORM_COLLECTED,
+            dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+        });
+        withWordAndSentence.tokenCollectionExact.add(
+            [cardStatus(TokenStatus.UNKNOWN, 1)],
+            DictionaryTokenSource.ANKI_WORD,
+            undefined,
+            'surface',
+            []
+        );
+        withWordAndSentence.tokenCollectionExact.add(
+            [cardStatus(TokenStatus.MATURE, 2)],
+            DictionaryTokenSource.ANKI_SENTENCE,
+            undefined,
+            'surface',
+            []
+        );
+
+        await expect(resolveTokenStatus('surface', 'surface', withWordAndSentence)).resolves.toMatchObject({
+            status: TokenStatus.UNKNOWN,
+            source: DictionaryTokenSource.ANKI_WORD,
+        });
+
+        const sentenceOnly = makeTrackState({
+            dictionaryTokenMatchStrategy: TokenMatchStrategy.EXACT_FORM_COLLECTED,
+            dictionaryAnkiSentenceTokenMatchStrategy: TokenMatchStrategy.EXACT_FORM_COLLECTED,
+            dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+        });
+        sentenceOnly.tokenCollectionExact.add(
+            [cardStatus(TokenStatus.MATURE, 2)],
+            DictionaryTokenSource.ANKI_SENTENCE,
+            undefined,
+            'surface',
+            []
+        );
+
+        await expect(resolveTokenStatus('surface', 'surface', sentenceOnly)).resolves.toMatchObject({
+            status: TokenStatus.MATURE,
+            source: DictionaryTokenSource.ANKI_SENTENCE,
+        });
+    });
+
+    it('uses the sentence match strategy independently from the word match strategy', async () => {
+        const trackState = makeTrackState(
+            {
+                dictionaryTokenMatchStrategy: TokenMatchStrategy.EXACT_FORM_COLLECTED,
+                dictionaryAnkiSentenceTokenMatchStrategy: TokenMatchStrategy.LEMMA_FORM_COLLECTED,
+                dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+            },
+            ['lemma']
+        );
+        trackState.tokenCollectionExact.add(
+            [cardStatus(TokenStatus.UNKNOWN, 1)],
+            DictionaryTokenSource.ANKI_SENTENCE,
+            undefined,
+            'surface',
+            []
+        );
+        trackState.tokenCollectionLemma.add(
+            [cardStatus(TokenStatus.MATURE, 2)],
+            DictionaryTokenSource.ANKI_SENTENCE,
+            undefined,
+            'lemma',
+            []
+        );
+
+        await expect(resolveTokenStatus('surface', 'surface', trackState)).resolves.toMatchObject({
+            status: TokenStatus.MATURE,
+            source: DictionaryTokenSource.ANKI_SENTENCE,
+        });
+    });
+});

--- a/common/app/components/Player.tsx
+++ b/common/app/components/Player.tsx
@@ -5,7 +5,6 @@ import { v4 as uuidv4 } from 'uuid';
 import {
     AudioTrackModel,
     AutoPauseContext,
-    AutoPausePreference,
     CardModel,
     CardTextFieldValues,
     IndexedSubtitleModel,
@@ -43,6 +42,14 @@ import VideoChannel from '../services/video-channel';
 import ChromeExtension from '../services/chrome-extension';
 import PlaybackPreferences from '../services/playback-preferences';
 import PlayModeManager from '../services/play-mode-manager';
+import {
+    applySubtitleStopPlaybackModeEffect,
+    pendingPlaybackModeSeekTimestamp,
+    selectCondensedPlaybackSeekTimestamp,
+    selectFastForwardPlaybackRate,
+    selectSubtitleStopPlaybackModeEffect,
+    shouldAutoPauseAtSubtitleStart,
+} from '../services/playback-mode-effects';
 import { useWindowSize } from '../hooks/use-window-size';
 import { useAppBarHeight } from '../../hooks/use-app-bar-height';
 import { createBlobUrl } from '../../blob-url';
@@ -308,79 +315,45 @@ const Player = React.memo(function Player({
     const handleOnStartedShowingSubtitle = useCallback(
         (subtitle: SubtitleModel) => {
             if (
-                !playModes.has(PlayMode.autoPause) ||
-                settings.autoPausePreference !== AutoPausePreference.atStart ||
-                !isTrackSeekable(settings.seekableTracks, subtitle.track) ||
-                videoFileUrl // Let VideoPlayer do the auto-pausing
+                shouldAutoPauseAtSubtitleStart({
+                    playModes,
+                    autoPausePreference: settings.autoPausePreference,
+                    seekableTracks: settings.seekableTracks,
+                    subtitle,
+                    delegatedToVideoPlayer: Boolean(videoFileUrl),
+                })
             ) {
-                return;
+                pause(clock, mediaAdapter, true);
             }
-
-            pause(clock, mediaAdapter, true);
         },
         [playModes, clock, mediaAdapter, videoFileUrl, settings.autoPausePreference, settings.seekableTracks]
     );
 
     const handleOnWillStopShowingSubtitle = useCallback(
         async (subtitle: SubtitleModel) => {
-            if (!isTrackSeekable(settings.seekableTracks, subtitle.track)) {
-                return;
-            }
+            const effect = selectSubtitleStopPlaybackModeEffect({
+                playModes,
+                autoPausePreference: settings.autoPausePreference,
+                seekableTracks: settings.seekableTracks,
+                subtitle,
+                subtitleCollection,
+                delegatedToVideoPlayer: Boolean(videoFileUrl),
+                lastSeekDuration: lastSeekDurationRef.current,
+            });
 
-            resetPendingAutoRepeatTargetTimestamp();
-
-            const isAutoPauseAtEndEnabled =
-                playModes.has(PlayMode.autoPause) && settings.autoPausePreference === AutoPausePreference.atEnd;
-            const isAutoPauseAtStartEnabled =
-                playModes.has(PlayMode.autoPause) && settings.autoPausePreference === AutoPausePreference.atStart;
-            const isRepeatEnabled = playModes.has(PlayMode.repeat);
-            const isCondensedEnabled = playModes.has(PlayMode.condensed);
-
-            if (!isAutoPauseAtEndEnabled && !isRepeatEnabled && !isAutoPauseAtStartEnabled) return;
-
-            if (isAutoPauseAtEndEnabled && !videoFileUrl) {
-                pause(clock, mediaAdapter, true);
-            }
-
-            if (isRepeatEnabled) {
-                if (isAutoPauseAtEndEnabled) {
-                    pendingAutoRepeatTargetTimestamp.current = subtitle.start;
-                } else {
-                    void seek(subtitle.start, clock, true);
-                }
-                return;
-            }
-
-            if (isCondensedEnabled) {
-                const slice = subtitleCollection.subtitlesAt(subtitle.end + 1);
-
-                if (slice.nextToShow && slice.nextToShow.length > 0) {
-                    const nextSubtitle = slice.nextToShow[0];
-                    const timeGap = nextSubtitle.start - subtitle.end;
-
-                    const baseThreshold = lastSeekDurationRef.current || 1000;
-                    const safetyBuffer = 500;
-                    const seekThreshold = baseThreshold + safetyBuffer;
-
-                    if (timeGap < seekThreshold) {
-                        return;
-                    }
-
-                    if (isAutoPauseAtEndEnabled) {
-                        pendingAutoRepeatTargetTimestamp.current = nextSubtitle.start;
-                    } else {
-                        const wasPlaying = clock.running;
-
-                        if (wasPlaying) clock.stop();
-
-                        const t0 = Date.now();
-                        await seek(nextSubtitle.start, clock, true);
-                        lastSeekDurationRef.current = Date.now() - t0;
-
-                        if (wasPlaying) clock.start();
-                    }
-                }
-            }
+            await applySubtitleStopPlaybackModeEffect({
+                effect,
+                clock,
+                pause: () => pause(clock, mediaAdapter, true),
+                seek: (timestamp) => seek(timestamp, clock, true),
+                resetPendingAutoRepeatTargetTimestamp,
+                setPendingAutoRepeatTargetTimestamp: (timestamp) => {
+                    pendingAutoRepeatTargetTimestamp.current = timestamp;
+                },
+                setLastSeekDuration: (duration) => {
+                    lastSeekDurationRef.current = duration;
+                },
+            });
         },
         [
             playModes,
@@ -808,11 +781,12 @@ const Player = React.memo(function Player({
     );
     const play = useCallback(
         (clock: Clock, mediaAdapter: MediaAdapter, forwardToMedia: boolean) => {
-            if (
-                (playModesRef.current.has(PlayMode.repeat) || playModesRef.current.has(PlayMode.autoPause)) &&
-                pendingAutoRepeatTargetTimestamp.current > 0
-            ) {
-                void seek(pendingAutoRepeatTargetTimestamp.current, clock, forwardToMedia);
+            const pendingSeekTimestamp = pendingPlaybackModeSeekTimestamp(
+                playModesRef.current,
+                pendingAutoRepeatTargetTimestamp.current
+            );
+            if (pendingSeekTimestamp !== undefined) {
+                void seek(pendingSeekTimestamp, clock, forwardToMedia);
                 resetPendingAutoRepeatTargetTimestamp();
             }
 
@@ -986,20 +960,15 @@ const Player = React.memo(function Player({
         const interval = setInterval(() => {
             void (async () => {
                 const timestamp = clock.time(calculateLength());
-                const slice = seekableSubtitleCollection.subtitlesAt(timestamp);
+                const seekTimestamp = selectCondensedPlaybackSeekTimestamp({
+                    slice: seekableSubtitleCollection.subtitlesAt(timestamp),
+                    timestamp,
+                    expectedSeekTime,
+                    pendingAutoRepeatTargetTimestamp: pendingAutoRepeatTargetTimestamp.current,
+                });
 
-                if (slice.nextToShow && slice.nextToShow.length > 0) {
-                    const nextSubtitle = slice.nextToShow[0];
-
-                    if (nextSubtitle.start - timestamp < expectedSeekTime + 500) {
-                        return;
-                    }
-
+                if (seekTimestamp !== undefined) {
                     const playing = clock.running;
-
-                    if (pendingAutoRepeatTargetTimestamp.current > 0) {
-                        return;
-                    }
 
                     if (playing) {
                         clock.stop();
@@ -1007,7 +976,7 @@ const Player = React.memo(function Player({
                     if (!seeking) {
                         seeking = true;
                         const t0 = Date.now();
-                        await seek(nextSubtitle.start, clock, true);
+                        await seek(seekTimestamp, clock, true);
                         expectedSeekTime = Date.now() - t0;
                         seeking = false;
                     }
@@ -1036,15 +1005,14 @@ const Player = React.memo(function Player({
             const timestamp = clock.time(calculateLength());
             const slice = seekableSubtitleCollection.subtitlesAt(timestamp);
 
-            if (
-                slice.showing.length === 0 &&
-                (slice.nextToShow === undefined ||
-                    (slice.nextToShow.length > 0 && slice.nextToShow[0].start - timestamp > 1000))
-            ) {
-                updatePlaybackRate(settings.fastForwardModePlaybackRate, true);
-            } else {
-                updatePlaybackRate(1, true);
-            }
+            updatePlaybackRate(
+                selectFastForwardPlaybackRate({
+                    slice,
+                    timestamp,
+                    fastForwardModePlaybackRate: settings.fastForwardModePlaybackRate,
+                }),
+                true
+            );
         }, 100);
 
         return () => clearInterval(interval);

--- a/common/app/components/VideoPlayer.tsx
+++ b/common/app/components/VideoPlayer.tsx
@@ -7,7 +7,6 @@ import {
     AudioTrackModel,
     PostMineAction,
     PlayMode,
-    AutoPausePreference,
     AutoPauseContext,
     OffscreenDomCache,
     CardTextFieldValues,
@@ -27,7 +26,6 @@ import {
     allTextSubtitleSettings,
     TokenState,
     ApplyStrategy,
-    isTrackSeekable,
     DictionaryTrack,
 } from '@project/common/settings';
 import {
@@ -71,6 +69,7 @@ import BlurOverlay from './BlurOverlay';
 import { CachedLocalStorage } from '../services/cached-local-storage';
 import useLastScrollableControlType from '../../hooks/use-last-scrollable-control-type';
 import { type Theme } from '@mui/material/styles';
+import { shouldAutoPauseAtSubtitleEnd, shouldAutoPauseAtSubtitleStart } from '../services/playback-mode-effects';
 
 const overlayContainerHeight = 48;
 
@@ -452,25 +451,27 @@ export default function VideoPlayer({
         const context = new AutoPauseContext();
         context.onStartedShowing = (subtitle: SubtitleModel) => {
             if (
-                !playModes.has(PlayMode.autoPause) ||
-                miscSettings.autoPausePreference !== AutoPausePreference.atStart ||
-                !isTrackSeekable(miscSettings.seekableTracks, subtitle.track)
-            ) {
-                return;
-            }
-
-            playerChannel.pause();
+                shouldAutoPauseAtSubtitleStart({
+                    playModes,
+                    autoPausePreference: miscSettings.autoPausePreference,
+                    seekableTracks: miscSettings.seekableTracks,
+                    subtitle,
+                    delegatedToVideoPlayer: false,
+                })
+            )
+                playerChannel.pause();
         };
         context.onWillStopShowing = async (subtitle: SubtitleModel) => {
             if (
-                !playModes.has(PlayMode.autoPause) ||
-                miscSettings.autoPausePreference !== AutoPausePreference.atEnd ||
-                !isTrackSeekable(miscSettings.seekableTracks, subtitle.track)
-            ) {
-                return;
-            }
-
-            playerChannel.pause();
+                shouldAutoPauseAtSubtitleEnd({
+                    playModes,
+                    autoPausePreference: miscSettings.autoPausePreference,
+                    seekableTracks: miscSettings.seekableTracks,
+                    subtitle,
+                    delegatedToVideoPlayer: false,
+                })
+            )
+                playerChannel.pause();
         };
         return context;
     }, [playerChannel, miscSettings, playModes]);

--- a/common/app/components/progress-bar.test.ts
+++ b/common/app/components/progress-bar.test.ts
@@ -5,6 +5,7 @@ import {
     progressBarProgress,
     progressBarTrackWidth,
 } from './progress-bar';
+import { expect, it } from '@jest/globals';
 
 const bounds = { left: 100, right: 300 };
 

--- a/common/app/components/video-subtitle-split.test.ts
+++ b/common/app/components/video-subtitle-split.test.ts
@@ -1,5 +1,6 @@
 import { VideoSubtitleSplitBehavior } from '@project/common/settings';
 import { clampSubtitlePlayerWidth, resolveVideoSubtitleSplitLayout } from './video-subtitle-split';
+import { expect, it } from '@jest/globals';
 
 it('uses the saved split width in remember mode', () => {
     expect(

--- a/common/app/services/cached-local-storage.test.ts
+++ b/common/app/services/cached-local-storage.test.ts
@@ -1,4 +1,5 @@
 import { CachedLocalStorage } from './cached-local-storage';
+import { expect, it, beforeEach } from '@jest/globals';
 
 beforeEach(() => {
     localStorage.clear();

--- a/common/app/services/play-mode-manager.test.ts
+++ b/common/app/services/play-mode-manager.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { PlayMode } from '@project/common';
+import PlayModeManager from '@project/common/app/services/play-mode-manager';
+
+const sortedModes = (modes: Set<PlayMode>) => [...modes].sort((left, right) => left - right);
+
+describe('PlayModeManager', () => {
+    it('defaults 0 initial modes to normal', () => {
+        const manager = new PlayModeManager(new Set());
+
+        expect(sortedModes(manager.getModes())).toEqual([PlayMode.normal]);
+        expect(manager.has(PlayMode.normal)).toBe(true);
+        expect(manager.size).toBe(1);
+    });
+
+    it('treats normal as exclusive when constructed from a mixed mode set', () => {
+        const manager = new PlayModeManager(new Set([PlayMode.normal, PlayMode.autoPause, PlayMode.repeat]));
+
+        expect(sortedModes(manager.getModes())).toEqual([PlayMode.autoPause, PlayMode.repeat]);
+        expect(manager.has(PlayMode.normal)).toBe(false);
+    });
+
+    it('returns added and removed changes for 1 old mode and 2 new modes', () => {
+        const changes = PlayModeManager.getModeChanges(
+            new Set([PlayMode.normal]),
+            new Set([PlayMode.condensed, PlayMode.repeat])
+        );
+
+        expect(sortedModes(changes.added)).toEqual([PlayMode.condensed, PlayMode.repeat]);
+        expect(sortedModes(changes.removed)).toEqual([PlayMode.normal]);
+    });
+
+    it('keeps normal enabled when toggling normal with only normal selected', () => {
+        const manager = new PlayModeManager(new Set([PlayMode.normal]));
+        const resolveConflicts = jest.fn();
+
+        const modes = manager.toggle(PlayMode.normal, resolveConflicts);
+
+        expect(sortedModes(modes)).toEqual([PlayMode.normal]);
+        expect(resolveConflicts).not.toHaveBeenCalled();
+    });
+
+    it('replaces normal when enabling a non-normal mode', () => {
+        const manager = new PlayModeManager(new Set([PlayMode.normal]));
+
+        const modes = manager.toggle(PlayMode.autoPause);
+
+        expect(sortedModes(modes)).toEqual([PlayMode.autoPause]);
+        expect(manager.has(PlayMode.normal)).toBe(false);
+    });
+
+    it('falls back to normal when toggling off the last non-normal mode', () => {
+        const manager = new PlayModeManager(new Set([PlayMode.repeat]));
+
+        const modes = manager.toggle(PlayMode.repeat);
+
+        expect(sortedModes(modes)).toEqual([PlayMode.normal]);
+        expect(manager.size).toBe(1);
+    });
+
+    it('removes fast forward and requests a playback-rate reset when condensed playback conflicts with it', () => {
+        const manager = new PlayModeManager(new Set([PlayMode.fastForward]));
+        const resolveConflicts = jest.fn();
+
+        const modes = manager.toggle(PlayMode.condensed, resolveConflicts);
+
+        expect(sortedModes(modes)).toEqual([PlayMode.condensed]);
+        expect(resolveConflicts).toHaveBeenCalledTimes(1);
+        expect(resolveConflicts).toHaveBeenCalledWith({
+            mode: PlayMode.fastForward,
+            shouldResetPlaybackRate: true,
+        });
+    });
+
+    it('removes condensed playback without requesting a playback-rate reset when fast forward conflicts with it', () => {
+        const manager = new PlayModeManager(new Set([PlayMode.condensed]));
+        const resolveConflicts = jest.fn();
+
+        const modes = manager.toggle(PlayMode.fastForward, resolveConflicts);
+
+        expect(sortedModes(modes)).toEqual([PlayMode.fastForward]);
+        expect(resolveConflicts).toHaveBeenCalledTimes(1);
+        expect(resolveConflicts).toHaveBeenCalledWith({
+            mode: PlayMode.condensed,
+            shouldResetPlaybackRate: false,
+        });
+    });
+
+    it('resets fast forward when normal mode clears a 2-mode selection', () => {
+        const manager = new PlayModeManager(new Set([PlayMode.fastForward, PlayMode.repeat]));
+        const resolveConflicts = jest.fn();
+
+        const modes = manager.toggle(PlayMode.normal, resolveConflicts);
+
+        expect(sortedModes(modes)).toEqual([PlayMode.normal]);
+        expect(resolveConflicts).toHaveBeenCalledTimes(1);
+        expect(resolveConflicts).toHaveBeenCalledWith({
+            mode: PlayMode.fastForward,
+            shouldResetPlaybackRate: true,
+        });
+    });
+
+    it('returns a defensive copy from getModes', () => {
+        const manager = new PlayModeManager(new Set([PlayMode.repeat]));
+        const modes = manager.getModes();
+
+        modes.add(PlayMode.condensed);
+
+        expect(sortedModes(manager.getModes())).toEqual([PlayMode.repeat]);
+    });
+
+    it('preserves non-conflicting modes across multi-step toggles', () => {
+        const manager = new PlayModeManager(new Set([PlayMode.normal]));
+        const resolveConflicts = jest.fn();
+
+        expect(sortedModes(manager.toggle(PlayMode.autoPause, resolveConflicts))).toEqual([PlayMode.autoPause]);
+        expect(sortedModes(manager.toggle(PlayMode.repeat, resolveConflicts))).toEqual([
+            PlayMode.autoPause,
+            PlayMode.repeat,
+        ]);
+        expect(sortedModes(manager.toggle(PlayMode.autoPause, resolveConflicts))).toEqual([PlayMode.repeat]);
+        expect(sortedModes(manager.toggle(PlayMode.condensed, resolveConflicts))).toEqual([
+            PlayMode.condensed,
+            PlayMode.repeat,
+        ]);
+
+        expect(resolveConflicts).not.toHaveBeenCalled();
+    });
+
+    it('resolves conflicting modes that are already present when one conflict target is toggled', () => {
+        const manager = new PlayModeManager(new Set([PlayMode.condensed, PlayMode.fastForward, PlayMode.repeat]));
+        const resolveConflicts = jest.fn();
+
+        const modes = manager.toggle(PlayMode.fastForward, resolveConflicts);
+
+        expect(sortedModes(modes)).toEqual([PlayMode.condensed, PlayMode.repeat]);
+        expect(resolveConflicts).toHaveBeenCalledWith({
+            mode: PlayMode.fastForward,
+            shouldResetPlaybackRate: true,
+        });
+    });
+});

--- a/common/app/services/play-mode-manager.ts
+++ b/common/app/services/play-mode-manager.ts
@@ -18,6 +18,8 @@ export default class PlayModeManager {
         this._modes = new Set(initialModes);
         if (this._modes.size === 0) {
             this._modes.add(PlayMode.normal);
+        } else if (this._modes.size > 1) {
+            this._modes.delete(PlayMode.normal);
         }
     }
 
@@ -82,7 +84,9 @@ export default class PlayModeManager {
             resolveConflicts({ mode: PlayMode.fastForward, shouldResetPlaybackRate: true });
         }
 
-        this._resolvePlayModeConflicts(targetMode, resolveConflicts);
+        if (this._modes.has(targetMode)) {
+            this._resolvePlayModeConflicts(targetMode, resolveConflicts);
+        }
 
         return this.getModes();
     }

--- a/common/app/services/playback-mode-effects.test.ts
+++ b/common/app/services/playback-mode-effects.test.ts
@@ -1,0 +1,558 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { AutoPausePreference, PlayMode, type SubtitleModel } from '@project/common';
+import { SubtitleCollection, type SubtitleSlice } from '@project/common/subtitle-collection';
+import {
+    applySubtitleStopPlaybackModeEffect,
+    pendingPlaybackModeSeekTimestamp,
+    selectCondensedPlaybackSeekTimestamp,
+    selectFastForwardPlaybackRate,
+    selectSubtitleStopPlaybackModeEffect,
+    shouldAutoPauseAtSubtitleEnd,
+    shouldAutoPauseAtSubtitleStart,
+} from './playback-mode-effects';
+
+const makeSubtitle = (overrides: Partial<SubtitleModel> = {}): SubtitleModel => ({
+    text: 'subtitle',
+    start: 0,
+    end: 1000,
+    originalStart: 0,
+    originalEnd: 1000,
+    track: 0,
+    index: 0,
+    ...overrides,
+});
+
+const makeCollection = (subtitles: SubtitleModel[]) => {
+    const collection = new SubtitleCollection<SubtitleModel>({ returnLastShown: true, returnNextToShow: true });
+    collection.setSubtitles(subtitles);
+    return collection;
+};
+
+const emptyCollection = makeCollection([]);
+
+describe('app playback mode effects', () => {
+    it('pauses at subtitle start only when app auto-pause at start applies locally', () => {
+        const subtitle = makeSubtitle();
+        const playModes = new Set([PlayMode.autoPause]);
+
+        expect(
+            shouldAutoPauseAtSubtitleStart({
+                playModes,
+                autoPausePreference: AutoPausePreference.atStart,
+                seekableTracks: 1,
+                subtitle,
+                delegatedToVideoPlayer: false,
+            })
+        ).toBe(true);
+        expect(
+            shouldAutoPauseAtSubtitleStart({
+                playModes,
+                autoPausePreference: AutoPausePreference.atStart,
+                seekableTracks: 1,
+                subtitle,
+                delegatedToVideoPlayer: true,
+            })
+        ).toBe(false);
+        expect(
+            shouldAutoPauseAtSubtitleStart({
+                playModes,
+                autoPausePreference: AutoPausePreference.atEnd,
+                seekableTracks: 1,
+                subtitle,
+                delegatedToVideoPlayer: false,
+            })
+        ).toBe(false);
+        expect(
+            shouldAutoPauseAtSubtitleStart({
+                playModes,
+                autoPausePreference: AutoPausePreference.atStart,
+                seekableTracks: 0,
+                subtitle,
+                delegatedToVideoPlayer: false,
+            })
+        ).toBe(false);
+        expect(
+            shouldAutoPauseAtSubtitleStart({
+                playModes: new Set([PlayMode.normal]),
+                autoPausePreference: AutoPausePreference.atStart,
+                seekableTracks: 1,
+                subtitle,
+                delegatedToVideoPlayer: false,
+            })
+        ).toBe(false);
+    });
+
+    it('pauses at subtitle end only when app auto-pause at end applies locally', () => {
+        const subtitle = makeSubtitle();
+        const playModes = new Set([PlayMode.autoPause]);
+
+        expect(
+            shouldAutoPauseAtSubtitleEnd({
+                playModes,
+                autoPausePreference: AutoPausePreference.atEnd,
+                seekableTracks: 1,
+                subtitle,
+                delegatedToVideoPlayer: false,
+            })
+        ).toBe(true);
+        expect(
+            shouldAutoPauseAtSubtitleEnd({
+                playModes,
+                autoPausePreference: AutoPausePreference.atStart,
+                seekableTracks: 1,
+                subtitle,
+                delegatedToVideoPlayer: false,
+            })
+        ).toBe(false);
+        expect(
+            shouldAutoPauseAtSubtitleEnd({
+                playModes,
+                autoPausePreference: AutoPausePreference.atEnd,
+                seekableTracks: 0,
+                subtitle,
+                delegatedToVideoPlayer: false,
+            })
+        ).toBe(false);
+        expect(
+            shouldAutoPauseAtSubtitleEnd({
+                playModes,
+                autoPausePreference: AutoPausePreference.atEnd,
+                seekableTracks: 1,
+                subtitle,
+                delegatedToVideoPlayer: true,
+            })
+        ).toBe(false);
+    });
+
+    it('pauses at subtitle end for local auto-pause mode', () => {
+        const effect = selectSubtitleStopPlaybackModeEffect({
+            playModes: new Set([PlayMode.autoPause]),
+            autoPausePreference: AutoPausePreference.atEnd,
+            seekableTracks: 1,
+            subtitle: makeSubtitle({ start: 2000, end: 2600 }),
+            subtitleCollection: emptyCollection,
+            delegatedToVideoPlayer: false,
+            lastSeekDuration: 0,
+        });
+
+        expect(effect).toEqual({
+            resetPendingAutoRepeatTargetTimestamp: true,
+            pause: true,
+            preservePlaybackStateWhileSeeking: false,
+            recordSeekDuration: false,
+        });
+    });
+
+    it('does not reset pending repeat state or pause when the subtitle track is not seekable', () => {
+        const effect = selectSubtitleStopPlaybackModeEffect({
+            playModes: new Set([PlayMode.autoPause, PlayMode.repeat]),
+            autoPausePreference: AutoPausePreference.atEnd,
+            seekableTracks: 0,
+            subtitle: makeSubtitle({ start: 2000, end: 2600 }),
+            subtitleCollection: emptyCollection,
+            delegatedToVideoPlayer: false,
+            lastSeekDuration: 0,
+        });
+
+        expect(effect).toEqual({
+            resetPendingAutoRepeatTargetTimestamp: false,
+            pause: false,
+            preservePlaybackStateWhileSeeking: false,
+            recordSeekDuration: false,
+        });
+    });
+
+    it('keeps auto-pause end state local to the delegated video player without pausing in the app', () => {
+        const effect = selectSubtitleStopPlaybackModeEffect({
+            playModes: new Set([PlayMode.autoPause]),
+            autoPausePreference: AutoPausePreference.atEnd,
+            seekableTracks: 1,
+            subtitle: makeSubtitle({ start: 2000, end: 2600 }),
+            subtitleCollection: emptyCollection,
+            delegatedToVideoPlayer: true,
+            lastSeekDuration: 0,
+        });
+
+        expect(effect).toEqual({
+            resetPendingAutoRepeatTargetTimestamp: true,
+            pause: false,
+            preservePlaybackStateWhileSeeking: false,
+            recordSeekDuration: false,
+        });
+    });
+
+    it('seeks to the subtitle start for repeat mode without auto-pause at end', () => {
+        const effect = selectSubtitleStopPlaybackModeEffect({
+            playModes: new Set([PlayMode.repeat]),
+            autoPausePreference: AutoPausePreference.atEnd,
+            seekableTracks: 1,
+            subtitle: makeSubtitle({ start: 2000, end: 2600 }),
+            subtitleCollection: emptyCollection,
+            delegatedToVideoPlayer: false,
+            lastSeekDuration: 0,
+        });
+
+        expect(effect).toEqual({
+            resetPendingAutoRepeatTargetTimestamp: true,
+            pause: false,
+            seekTimestamp: 2000,
+            preservePlaybackStateWhileSeeking: false,
+            recordSeekDuration: false,
+        });
+    });
+
+    it('pauses and schedules the repeat target when auto-pause at end and repeat are combined', () => {
+        const effect = selectSubtitleStopPlaybackModeEffect({
+            playModes: new Set([PlayMode.autoPause, PlayMode.repeat]),
+            autoPausePreference: AutoPausePreference.atEnd,
+            seekableTracks: 1,
+            subtitle: makeSubtitle({ start: 2000, end: 2600 }),
+            subtitleCollection: emptyCollection,
+            delegatedToVideoPlayer: false,
+            lastSeekDuration: 0,
+        });
+
+        expect(effect).toEqual({
+            resetPendingAutoRepeatTargetTimestamp: true,
+            pause: true,
+            pendingAutoRepeatTargetTimestamp: 2000,
+            preservePlaybackStateWhileSeeking: false,
+            recordSeekDuration: false,
+        });
+    });
+
+    it('delegates pausing while preserving repeat and condensed targets for the video player', () => {
+        const current = makeSubtitle({ start: 2000, end: 2600, index: 0 });
+        const next = makeSubtitle({ start: 5000, end: 6000, index: 1 });
+        const commonArgs = {
+            autoPausePreference: AutoPausePreference.atEnd,
+            seekableTracks: 1,
+            subtitle: current,
+            subtitleCollection: makeCollection([current, next]),
+            delegatedToVideoPlayer: true,
+            lastSeekDuration: 100,
+        };
+
+        expect(
+            selectSubtitleStopPlaybackModeEffect({
+                ...commonArgs,
+                playModes: new Set([PlayMode.autoPause, PlayMode.repeat]),
+            })
+        ).toMatchObject({ pause: false, pendingAutoRepeatTargetTimestamp: 2000 });
+        expect(
+            selectSubtitleStopPlaybackModeEffect({
+                ...commonArgs,
+                playModes: new Set([PlayMode.autoPause, PlayMode.condensed]),
+            })
+        ).toMatchObject({ pause: false, pendingAutoRepeatTargetTimestamp: 5000 });
+    });
+
+    it('selects the next subtitle for app condensed mode after a large enough gap', () => {
+        const current = makeSubtitle({ start: 1000, end: 2000, index: 0 });
+        const next = makeSubtitle({ start: 3300, end: 4300, index: 1 });
+        const collection = makeCollection([current, next]);
+
+        const effect = selectSubtitleStopPlaybackModeEffect({
+            playModes: new Set([PlayMode.autoPause, PlayMode.condensed]),
+            autoPausePreference: AutoPausePreference.atStart,
+            seekableTracks: 1,
+            subtitle: current,
+            subtitleCollection: collection,
+            delegatedToVideoPlayer: false,
+            lastSeekDuration: 100,
+        });
+
+        expect(effect).toEqual({
+            resetPendingAutoRepeatTargetTimestamp: true,
+            pause: false,
+            seekTimestamp: 3300,
+            preservePlaybackStateWhileSeeking: true,
+            recordSeekDuration: true,
+        });
+    });
+
+    it('schedules the next subtitle when auto-pause at end and condensed mode are combined', () => {
+        const current = makeSubtitle({ start: 1000, end: 2000, index: 0 });
+        const next = makeSubtitle({ start: 5000, end: 6000, index: 1 });
+
+        const effect = selectSubtitleStopPlaybackModeEffect({
+            playModes: new Set([PlayMode.autoPause, PlayMode.condensed]),
+            autoPausePreference: AutoPausePreference.atEnd,
+            seekableTracks: 1,
+            subtitle: current,
+            subtitleCollection: makeCollection([current, next]),
+            delegatedToVideoPlayer: false,
+            lastSeekDuration: 100,
+        });
+
+        expect(effect).toEqual({
+            resetPendingAutoRepeatTargetTimestamp: true,
+            pause: true,
+            pendingAutoRepeatTargetTimestamp: 5000,
+            preservePlaybackStateWhileSeeking: false,
+            recordSeekDuration: false,
+        });
+    });
+
+    it('does not apply stop-time condensed seeking without local auto-pause at start', () => {
+        const current = makeSubtitle({ start: 1000, end: 2000, index: 0 });
+        const next = makeSubtitle({ start: 5000, end: 6000, index: 1 });
+
+        const effect = selectSubtitleStopPlaybackModeEffect({
+            playModes: new Set([PlayMode.condensed]),
+            autoPausePreference: AutoPausePreference.atStart,
+            seekableTracks: 1,
+            subtitle: current,
+            subtitleCollection: makeCollection([current, next]),
+            delegatedToVideoPlayer: false,
+            lastSeekDuration: 100,
+        });
+
+        expect(effect).toEqual({
+            resetPendingAutoRepeatTargetTimestamp: true,
+            pause: false,
+            preservePlaybackStateWhileSeeking: false,
+            recordSeekDuration: false,
+        });
+    });
+
+    it('does not select a condensed seek target for small gaps or pending repeat targets', () => {
+        const next = makeSubtitle({ start: 1400, end: 2000, index: 1 });
+        const slice: SubtitleSlice<SubtitleModel> = {
+            showing: [],
+            nextToShow: [next],
+            startedShowing: undefined,
+            willStopShowing: undefined,
+        };
+
+        expect(
+            selectCondensedPlaybackSeekTimestamp({
+                slice,
+                timestamp: 1000,
+                expectedSeekTime: 100,
+                pendingAutoRepeatTargetTimestamp: 0,
+            })
+        ).toBeUndefined();
+        expect(
+            selectCondensedPlaybackSeekTimestamp({
+                slice: { ...slice, nextToShow: [makeSubtitle({ start: 3000, index: 2 })] },
+                timestamp: 1000,
+                expectedSeekTime: 100,
+                pendingAutoRepeatTargetTimestamp: 2500,
+            })
+        ).toBeUndefined();
+    });
+
+    it('handles zero next subtitles and seeks at the exact condensed threshold', () => {
+        const baseSlice: SubtitleSlice<SubtitleModel> = {
+            showing: [],
+            startedShowing: undefined,
+            willStopShowing: undefined,
+        };
+
+        expect(
+            selectCondensedPlaybackSeekTimestamp({
+                slice: baseSlice,
+                timestamp: 1000,
+                expectedSeekTime: 100,
+                pendingAutoRepeatTargetTimestamp: 0,
+            })
+        ).toBeUndefined();
+        expect(
+            selectCondensedPlaybackSeekTimestamp({
+                slice: { ...baseSlice, nextToShow: [] },
+                timestamp: 1000,
+                expectedSeekTime: 100,
+                pendingAutoRepeatTargetTimestamp: 0,
+            })
+        ).toBeUndefined();
+        expect(
+            selectCondensedPlaybackSeekTimestamp({
+                slice: { ...baseSlice, nextToShow: [makeSubtitle({ start: 1600 })] },
+                timestamp: 1000,
+                expectedSeekTime: 100,
+                pendingAutoRepeatTargetTimestamp: 0,
+            })
+        ).toBe(1600);
+    });
+
+    it('selects fast-forward speed only in subtitle gaps with enough lead time', () => {
+        expect(
+            selectFastForwardPlaybackRate({
+                slice: {
+                    showing: [],
+                    nextToShow: [makeSubtitle({ start: 3000, index: 1 })],
+                    startedShowing: undefined,
+                    willStopShowing: undefined,
+                },
+                timestamp: 1000,
+                fastForwardModePlaybackRate: 2.7,
+            })
+        ).toBe(2.7);
+        expect(
+            selectFastForwardPlaybackRate({
+                slice: {
+                    showing: [makeSubtitle({ start: 1000, end: 1500 })],
+                    startedShowing: undefined,
+                    willStopShowing: undefined,
+                },
+                timestamp: 1200,
+                fastForwardModePlaybackRate: 2.7,
+            })
+        ).toBe(1);
+        expect(
+            selectFastForwardPlaybackRate({
+                slice: {
+                    showing: [],
+                    nextToShow: [makeSubtitle({ start: 1800, index: 1 })],
+                    startedShowing: undefined,
+                    willStopShowing: undefined,
+                },
+                timestamp: 1000,
+                fastForwardModePlaybackRate: 2.7,
+            })
+        ).toBe(1);
+    });
+
+    it('fast-forwards after the last subtitle but not for an explicit empty next-subtitle list', () => {
+        const baseSlice: SubtitleSlice<SubtitleModel> = {
+            showing: [],
+            startedShowing: undefined,
+            willStopShowing: undefined,
+        };
+
+        expect(
+            selectFastForwardPlaybackRate({
+                slice: baseSlice,
+                timestamp: 3000,
+                fastForwardModePlaybackRate: 2.7,
+            })
+        ).toBe(2.7);
+        expect(
+            selectFastForwardPlaybackRate({
+                slice: { ...baseSlice, nextToShow: [] },
+                timestamp: 3000,
+                fastForwardModePlaybackRate: 2.7,
+            })
+        ).toBe(1);
+    });
+
+    it('consumes pending playback targets only for auto-pause or repeat modes', () => {
+        expect(pendingPlaybackModeSeekTimestamp(new Set([PlayMode.normal]), 0)).toBeUndefined();
+        expect(pendingPlaybackModeSeekTimestamp(new Set([PlayMode.normal]), 2500)).toBeUndefined();
+        expect(pendingPlaybackModeSeekTimestamp(new Set([PlayMode.autoPause]), 2500)).toBe(2500);
+        expect(pendingPlaybackModeSeekTimestamp(new Set([PlayMode.repeat]), 2500)).toBe(2500);
+    });
+
+    it('applies pause and pending-target effects without seeking', async () => {
+        const clock = { running: false, stop: jest.fn(), start: jest.fn() };
+        const pause = jest.fn();
+        const seek = jest.fn(async () => undefined);
+        const resetPending = jest.fn();
+        const setPending = jest.fn();
+        const setLastSeekDuration = jest.fn();
+
+        await applySubtitleStopPlaybackModeEffect({
+            effect: {
+                resetPendingAutoRepeatTargetTimestamp: true,
+                pause: true,
+                pendingAutoRepeatTargetTimestamp: 2000,
+                preservePlaybackStateWhileSeeking: false,
+                recordSeekDuration: false,
+            },
+            clock,
+            pause,
+            seek,
+            resetPendingAutoRepeatTargetTimestamp: resetPending,
+            setPendingAutoRepeatTargetTimestamp: setPending,
+            setLastSeekDuration,
+        });
+
+        expect(resetPending).toHaveBeenCalledTimes(1);
+        expect(pause).toHaveBeenCalledTimes(1);
+        expect(setPending).toHaveBeenCalledWith(2000);
+        expect(seek).not.toHaveBeenCalled();
+        expect(clock.stop).not.toHaveBeenCalled();
+        expect(clock.start).not.toHaveBeenCalled();
+        expect(setLastSeekDuration).not.toHaveBeenCalled();
+    });
+
+    it('preserves playback state and records duration around an applied seek effect', async () => {
+        const clock = { running: true, stop: jest.fn(), start: jest.fn() };
+        const seek = jest.fn(async () => undefined);
+        const setLastSeekDuration = jest.fn();
+        const now = jest.fn<() => number>().mockReturnValueOnce(100).mockReturnValueOnce(145);
+
+        await applySubtitleStopPlaybackModeEffect({
+            effect: {
+                resetPendingAutoRepeatTargetTimestamp: true,
+                pause: false,
+                seekTimestamp: 3300,
+                preservePlaybackStateWhileSeeking: true,
+                recordSeekDuration: true,
+            },
+            clock,
+            pause: jest.fn(),
+            seek,
+            resetPendingAutoRepeatTargetTimestamp: jest.fn(),
+            setPendingAutoRepeatTargetTimestamp: jest.fn(),
+            setLastSeekDuration,
+            now,
+        });
+
+        expect(clock.stop).toHaveBeenCalledTimes(1);
+        expect(seek).toHaveBeenCalledWith(3300);
+        expect(setLastSeekDuration).toHaveBeenCalledWith(45);
+        expect(clock.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not stop or restart playback when a seek effect does not preserve playback state', async () => {
+        const clock = { running: true, stop: jest.fn(), start: jest.fn() };
+        const seek = jest.fn(async () => undefined);
+
+        await applySubtitleStopPlaybackModeEffect({
+            effect: {
+                resetPendingAutoRepeatTargetTimestamp: true,
+                pause: false,
+                seekTimestamp: 3300,
+                preservePlaybackStateWhileSeeking: false,
+                recordSeekDuration: false,
+            },
+            clock,
+            pause: jest.fn(),
+            seek,
+            resetPendingAutoRepeatTargetTimestamp: jest.fn(),
+            setPendingAutoRepeatTargetTimestamp: jest.fn(),
+            setLastSeekDuration: jest.fn(),
+        });
+
+        expect(seek).toHaveBeenCalledWith(3300);
+        expect(clock.stop).not.toHaveBeenCalled();
+        expect(clock.start).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when an applied effect does not reset pending state', async () => {
+        const resetPending = jest.fn();
+        const pause = jest.fn();
+        const seek = jest.fn(async () => undefined);
+
+        await applySubtitleStopPlaybackModeEffect({
+            effect: {
+                resetPendingAutoRepeatTargetTimestamp: false,
+                pause: false,
+                preservePlaybackStateWhileSeeking: false,
+                recordSeekDuration: false,
+            },
+            clock: { running: false, stop: jest.fn(), start: jest.fn() },
+            pause,
+            seek,
+            resetPendingAutoRepeatTargetTimestamp: resetPending,
+            setPendingAutoRepeatTargetTimestamp: jest.fn(),
+            setLastSeekDuration: jest.fn(),
+        });
+
+        expect(resetPending).not.toHaveBeenCalled();
+        expect(pause).not.toHaveBeenCalled();
+        expect(seek).not.toHaveBeenCalled();
+    });
+});

--- a/common/app/services/playback-mode-effects.ts
+++ b/common/app/services/playback-mode-effects.ts
@@ -1,0 +1,218 @@
+import { AutoPausePreference, PlayMode, SubtitleModel } from '@project/common';
+import { isTrackSeekable } from '@project/common/settings';
+import { type SubtitleCollection, SubtitleSlice } from '@project/common/subtitle-collection';
+
+export interface SubtitleStopPlaybackModeEffect {
+    resetPendingAutoRepeatTargetTimestamp: boolean;
+    pause: boolean;
+    seekTimestamp?: number;
+    pendingAutoRepeatTargetTimestamp?: number;
+    preservePlaybackStateWhileSeeking: boolean;
+    recordSeekDuration: boolean;
+}
+
+export interface PlaybackModeEffectClock {
+    readonly running: boolean;
+    stop(): void;
+    start(): void;
+}
+
+const noSubtitleStopPlaybackModeEffect: SubtitleStopPlaybackModeEffect = {
+    resetPendingAutoRepeatTargetTimestamp: false,
+    pause: false,
+    preservePlaybackStateWhileSeeking: false,
+    recordSeekDuration: false,
+};
+
+export function shouldAutoPauseAtSubtitleStart({
+    playModes,
+    autoPausePreference,
+    seekableTracks,
+    subtitle,
+    delegatedToVideoPlayer,
+}: {
+    playModes: Set<PlayMode>;
+    autoPausePreference: AutoPausePreference;
+    seekableTracks: number;
+    subtitle: SubtitleModel;
+    delegatedToVideoPlayer: boolean;
+}) {
+    return (
+        playModes.has(PlayMode.autoPause) &&
+        autoPausePreference === AutoPausePreference.atStart &&
+        isTrackSeekable(seekableTracks, subtitle.track) &&
+        !delegatedToVideoPlayer
+    );
+}
+
+export function shouldAutoPauseAtSubtitleEnd({
+    playModes,
+    autoPausePreference,
+    seekableTracks,
+    subtitle,
+    delegatedToVideoPlayer,
+}: {
+    playModes: Set<PlayMode>;
+    autoPausePreference: AutoPausePreference;
+    seekableTracks: number;
+    subtitle: SubtitleModel;
+    delegatedToVideoPlayer: boolean;
+}) {
+    return (
+        playModes.has(PlayMode.autoPause) &&
+        autoPausePreference === AutoPausePreference.atEnd &&
+        isTrackSeekable(seekableTracks, subtitle.track) &&
+        !delegatedToVideoPlayer
+    );
+}
+
+export function pendingPlaybackModeSeekTimestamp(playModes: Set<PlayMode>, pendingTimestamp: number) {
+    if (pendingTimestamp <= 0) return;
+    if (playModes.has(PlayMode.repeat) || playModes.has(PlayMode.autoPause)) return pendingTimestamp;
+}
+
+export async function applySubtitleStopPlaybackModeEffect({
+    effect,
+    clock,
+    pause,
+    seek,
+    resetPendingAutoRepeatTargetTimestamp,
+    setPendingAutoRepeatTargetTimestamp,
+    setLastSeekDuration,
+    now = Date.now,
+}: {
+    effect: SubtitleStopPlaybackModeEffect;
+    clock: PlaybackModeEffectClock;
+    pause: () => void;
+    seek: (timestamp: number) => Promise<void>;
+    resetPendingAutoRepeatTargetTimestamp: () => void;
+    setPendingAutoRepeatTargetTimestamp: (timestamp: number) => void;
+    setLastSeekDuration: (duration: number) => void;
+    now?: () => number;
+}) {
+    if (!effect.resetPendingAutoRepeatTargetTimestamp) return;
+
+    resetPendingAutoRepeatTargetTimestamp();
+
+    if (effect.pause) pause();
+
+    if (effect.pendingAutoRepeatTargetTimestamp !== undefined) {
+        setPendingAutoRepeatTargetTimestamp(effect.pendingAutoRepeatTargetTimestamp);
+        return;
+    }
+
+    if (effect.seekTimestamp === undefined) return;
+
+    const wasPlaying = clock.running;
+    if (effect.preservePlaybackStateWhileSeeking && wasPlaying) clock.stop();
+
+    const startedAt = now();
+    await seek(effect.seekTimestamp);
+    if (effect.recordSeekDuration) setLastSeekDuration(now() - startedAt);
+
+    if (effect.preservePlaybackStateWhileSeeking && wasPlaying) clock.start();
+}
+
+export function selectSubtitleStopPlaybackModeEffect({
+    playModes,
+    autoPausePreference,
+    seekableTracks,
+    subtitle,
+    subtitleCollection,
+    delegatedToVideoPlayer,
+    lastSeekDuration,
+}: {
+    playModes: Set<PlayMode>;
+    autoPausePreference: AutoPausePreference;
+    seekableTracks: number;
+    subtitle: SubtitleModel;
+    subtitleCollection: Pick<SubtitleCollection<SubtitleModel>, 'subtitlesAt'>;
+    delegatedToVideoPlayer: boolean;
+    lastSeekDuration: number;
+}): SubtitleStopPlaybackModeEffect {
+    if (!isTrackSeekable(seekableTracks, subtitle.track)) return noSubtitleStopPlaybackModeEffect;
+
+    const effect: SubtitleStopPlaybackModeEffect = {
+        resetPendingAutoRepeatTargetTimestamp: true,
+        pause: false,
+        preservePlaybackStateWhileSeeking: false,
+        recordSeekDuration: false,
+    };
+    const isAutoPauseAtEndEnabled =
+        playModes.has(PlayMode.autoPause) && autoPausePreference === AutoPausePreference.atEnd;
+    const isAutoPauseAtStartEnabled =
+        playModes.has(PlayMode.autoPause) && autoPausePreference === AutoPausePreference.atStart;
+    const isRepeatEnabled = playModes.has(PlayMode.repeat);
+    const isCondensedEnabled = playModes.has(PlayMode.condensed);
+
+    if (!isAutoPauseAtEndEnabled && !isRepeatEnabled && !isAutoPauseAtStartEnabled) return effect;
+
+    if (isAutoPauseAtEndEnabled && !delegatedToVideoPlayer) effect.pause = true;
+
+    if (isRepeatEnabled) {
+        if (isAutoPauseAtEndEnabled) {
+            effect.pendingAutoRepeatTargetTimestamp = subtitle.start;
+        } else {
+            effect.seekTimestamp = subtitle.start;
+        }
+        return effect;
+    }
+
+    if (isCondensedEnabled) {
+        const seekTimestamp = selectCondensedPlaybackSeekTimestamp({
+            slice: subtitleCollection.subtitlesAt(subtitle.end + 1),
+            timestamp: subtitle.end,
+            expectedSeekTime: lastSeekDuration || 1000,
+            pendingAutoRepeatTargetTimestamp: 0,
+        });
+
+        if (seekTimestamp !== undefined) {
+            if (isAutoPauseAtEndEnabled) {
+                effect.pendingAutoRepeatTargetTimestamp = seekTimestamp;
+            } else {
+                effect.seekTimestamp = seekTimestamp;
+                effect.preservePlaybackStateWhileSeeking = true;
+                effect.recordSeekDuration = true;
+            }
+        }
+    }
+
+    return effect;
+}
+
+export function selectCondensedPlaybackSeekTimestamp<T extends SubtitleModel>({
+    slice,
+    timestamp,
+    expectedSeekTime,
+    pendingAutoRepeatTargetTimestamp,
+}: {
+    slice: SubtitleSlice<T>;
+    timestamp: number;
+    expectedSeekTime: number;
+    pendingAutoRepeatTargetTimestamp: number;
+}) {
+    if (pendingAutoRepeatTargetTimestamp > 0 || !slice.nextToShow || slice.nextToShow.length === 0) return;
+    const nextSubtitle = slice.nextToShow[0];
+    if (nextSubtitle.start - timestamp < expectedSeekTime + 500) return;
+    return nextSubtitle.start;
+}
+
+export function selectFastForwardPlaybackRate<T extends SubtitleModel>({
+    slice,
+    timestamp,
+    fastForwardModePlaybackRate,
+}: {
+    slice: SubtitleSlice<T>;
+    timestamp: number;
+    fastForwardModePlaybackRate: number;
+}) {
+    if (
+        slice.showing.length === 0 &&
+        (slice.nextToShow === undefined ||
+            (slice.nextToShow.length > 0 && slice.nextToShow[0].start - timestamp > 1000))
+    ) {
+        return fastForwardModePlaybackRate;
+    }
+
+    return 1;
+}

--- a/common/app/services/playback-preferences.test.ts
+++ b/common/app/services/playback-preferences.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import PlaybackPreferences from './playback-preferences';
+
+const makeSettings = (overrides: Record<string, unknown> = {}) => ({
+    rememberSubtitleOffset: true,
+    lastSubtitleOffset: 250,
+    subtitleAlignment: 'bottom' as const,
+    subtitlePositionOffset: 0,
+    topSubtitlePositionOffset: 0,
+    ...overrides,
+});
+
+const makeExtension = (supportsAppIntegration = false) => ({
+    supportsAppIntegration,
+    setSettings: jest.fn(async () => undefined),
+});
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+describe('PlaybackPreferences', () => {
+    it('uses user-facing defaults when storage is empty', () => {
+        const preferences = new PlaybackPreferences(makeSettings(), makeExtension() as any);
+
+        expect(preferences.volume).toBe(100);
+        expect(preferences.theaterMode).toBe(false);
+        expect(preferences.hideSubtitleList).toBe(false);
+        expect(preferences.displaySubtitles).toBe(true);
+        expect(preferences.offset).toBe(0);
+        expect(preferences.subtitlePlayerWidth).toBeUndefined();
+    });
+
+    it('persists scalar playback preferences with their expected storage representation', () => {
+        const preferences = new PlaybackPreferences(makeSettings(), makeExtension() as any);
+
+        preferences.volume = 65;
+        preferences.theaterMode = true;
+        preferences.hideSubtitleList = true;
+        preferences.displaySubtitles = false;
+        preferences.subtitlePlayerWidth = 720;
+        preferences.offset = -125;
+
+        expect(preferences.volume).toBe(65);
+        expect(preferences.theaterMode).toBe(true);
+        expect(preferences.hideSubtitleList).toBe(true);
+        expect(preferences.displaySubtitles).toBe(false);
+        expect(preferences.subtitlePlayerWidth).toBe(720);
+        expect(preferences.offset).toBe(-125);
+        expect({ ...localStorage }).toEqual(
+            expect.objectContaining({
+                volume: '65',
+                theaterMode: 'true',
+                hideSubtitleList: 'true',
+                displaySubtitles: 'false',
+                subtitlePlayerWidth: '720',
+                offset: '-125',
+            })
+        );
+    });
+
+    it('ignores stored offsets when remembering is disabled', () => {
+        localStorage.setItem('offset', '900');
+        const preferences = new PlaybackPreferences(
+            makeSettings({ rememberSubtitleOffset: false }),
+            makeExtension() as any
+        );
+
+        expect(preferences.offset).toBe(0);
+    });
+
+    it('reads and writes the settings-backed offset for app integration', () => {
+        localStorage.setItem('offset', '900');
+        const extension = makeExtension(true);
+        const preferences = new PlaybackPreferences(makeSettings({ lastSubtitleOffset: 375 }), extension as any);
+
+        expect(preferences.offset).toBe(375);
+        preferences.offset = 500;
+
+        expect(extension.setSettings).toHaveBeenCalledWith({ lastSubtitleOffset: 500 });
+        expect(localStorage.getItem('offset')).toBe('900');
+    });
+});

--- a/common/app/services/util.test.ts
+++ b/common/app/services/util.test.ts
@@ -1,0 +1,30 @@
+import { keysAreEqual } from '@project/common/app/services/util';
+import { describe, expect, it } from '@jest/globals';
+
+describe('keysAreEqual', () => {
+    it('treats 0-key objects as equal', () => {
+        expect(keysAreEqual({}, {})).toBe(true);
+    });
+
+    it('returns true for 1 matching key even when values differ', () => {
+        expect(keysAreEqual({ a: 1 }, { a: undefined })).toBe(true);
+    });
+
+    it('returns false when one side has an extra key', () => {
+        expect(keysAreEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+        expect(keysAreEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+    });
+
+    it('compares all keys for 2-key objects', () => {
+        expect(keysAreEqual({ a: 1, b: 2 }, { a: 3, b: 4 })).toBe(true);
+        expect(keysAreEqual({ a: 1, b: 2 }, { a: 3, c: 4 })).toBe(false);
+    });
+
+    it('compares own keys without counting inherited prototype keys', () => {
+        const objectWithInheritedKey = Object.create({ inherited: 1 });
+        objectWithInheritedKey.a = 1;
+
+        expect(keysAreEqual(objectWithInheritedKey, { a: 2 })).toBe(true);
+        expect(keysAreEqual(objectWithInheritedKey, { a: 2, inherited: 3 })).toBe(false);
+    });
+});

--- a/common/app/services/util.ts
+++ b/common/app/services/util.ts
@@ -1,15 +1,6 @@
 export function keysAreEqual(a: any, b: any) {
-    for (const key in a) {
-        if (!(key in b)) {
-            return false;
-        }
-    }
-
-    for (const key in b) {
-        if (!(key in a)) {
-            return false;
-        }
-    }
-
-    return true;
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every((key) => Object.prototype.hasOwnProperty.call(b, key));
 }

--- a/common/audio-clip/audio-clip.test.ts
+++ b/common/audio-clip/audio-clip.test.ts
@@ -1,5 +1,6 @@
 import AudioClip from './audio-clip';
 import { AudioErrorCode } from '@project/common';
+import { expect, it, jest } from '@jest/globals';
 
 // Mock the download utility so tests don't touch the DOM
 jest.mock('@project/common/util', () => ({

--- a/common/components/WordBrowserDialog.tsx
+++ b/common/components/WordBrowserDialog.tsx
@@ -52,6 +52,8 @@ import {
     DictionaryTokenSource,
     DictionaryTrack,
     getFullyKnownTokenStatus,
+    isAnkiSource,
+    isWaniKaniSource,
     TokenState,
     TokenStatus,
 } from '@project/common/settings';
@@ -1151,10 +1153,8 @@ export default function WordBrowserDialog({
             const trackConfig =
                 record.track === LOCAL_TOKEN_TRACK ? defaultDictionaryTrack : dictionaryTracks[record.track];
             const treatSuspended = trackConfig?.dictionaryAnkiTreatSuspended ?? 'NORMAL';
-            const isAnkiRecord =
-                record.source === DictionaryTokenSource.ANKI_WORD ||
-                record.source === DictionaryTokenSource.ANKI_SENTENCE;
-            const isWaniKaniRecord = record.source === DictionaryTokenSource.WANIKANI;
+            const isAnkiRecord = isAnkiSource(record.source);
+            const isWaniKaniRecord = isWaniKaniSource(record.source);
             const trackCardRecords = records.ankiCardRecords[record.track];
             const cardRecords = isAnkiRecord
                 ? record.cardIds
@@ -1353,10 +1353,7 @@ export default function WordBrowserDialog({
             if (includedTrackFilters.length > 0 && !includedTrackFilters.includes(row.trackSortValue)) return false;
             if (excludedTrackFilters.includes(row.trackSortValue)) return false;
             if (appliedViewCriteria.suspendedFilter !== 'all') {
-                if (
-                    row.source === DictionaryTokenSource.ANKI_WORD ||
-                    row.source === DictionaryTokenSource.ANKI_SENTENCE
-                ) {
+                if (isAnkiSource(row.source)) {
                     if (row.suspendedFilterValue !== appliedViewCriteria.suspendedFilter) return false;
                 } else {
                     if (appliedViewCriteria.suspendedFilter !== 'no') return false;

--- a/common/copy-history/copy-history-repository.test.ts
+++ b/common/copy-history/copy-history-repository.test.ts
@@ -1,6 +1,7 @@
 import 'core-js/stable/structured-clone'; // fake-indexeddb requires structured clone polyfill
 import 'fake-indexeddb/auto';
 import { IndexedDBCopyHistoryRepository } from './copy-history-repository';
+import { expect, it, beforeEach } from '@jest/globals';
 
 beforeEach(async () => {
     const repository = new IndexedDBCopyHistoryRepository(1);

--- a/common/dictionary-db/dictionary-db-anki.test.ts
+++ b/common/dictionary-db/dictionary-db-anki.test.ts
@@ -1,0 +1,1567 @@
+import 'core-js/stable/structured-clone';
+import 'fake-indexeddb/auto';
+import { Dexie } from 'dexie';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { DictionaryBuildAnkiCacheStateErrorCode, DictionaryBuildAnkiCacheStateType } from '@project/common';
+import {
+    AsbplayerSettings,
+    defaultSettings,
+    DictionaryTokenSource,
+    TokenState,
+    TokenStatus,
+} from '@project/common/settings';
+
+const mockAnkiInstances: any[] = [];
+const mockAnkiOverrides: any[] = [];
+const mockYomitanInstances: any[] = [];
+const mockYomitanOverrides: any[] = [];
+
+jest.mock('uuid', () => ({ v4: () => 'test-build-id' }));
+jest.mock('@project/common/anki', () => ({
+    Anki: jest.fn().mockImplementation((settings) => {
+        const instance = {
+            settings,
+            requestPermission: jest.fn<() => Promise<{ permission: string }>>().mockResolvedValue({
+                permission: 'granted',
+            }),
+            findNotes: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([]),
+            notesInfo: jest.fn<(noteIds: number[]) => Promise<any[]>>().mockResolvedValue([]),
+            cardsModTime: jest
+                .fn<(cardIds: number[]) => Promise<{ cardId: number; mod: number }[]>>()
+                .mockResolvedValue([]),
+            cardsInfo: jest
+                .fn<(cardIds: number[], progress?: (progress: any) => Promise<void>) => Promise<any[]>>()
+                .mockResolvedValue([]),
+            areSuspended: jest.fn<(cardIds: number[]) => Promise<boolean[]>>().mockResolvedValue([]),
+            findCards: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([]),
+        };
+        Object.assign(instance, mockAnkiOverrides.shift());
+        mockAnkiInstances.push(instance);
+        return instance;
+    }),
+    escapeAnkiDeckQuery: (query: string) => query.replace(/"/g, '\\"'),
+    escapeAnkiQuery: (query: string) => query.replace(/"/g, '\\"'),
+}));
+jest.mock('@project/common/yomitan', () => ({
+    Yomitan: jest.fn().mockImplementation((dt) => {
+        const instance = {
+            dt,
+            version: jest.fn<() => Promise<string>>().mockResolvedValue('26.4.6'),
+            tokenizeBulk: jest.fn<(texts: string[]) => Promise<unknown>>().mockResolvedValue(undefined),
+            tokenize: jest.fn<(text: string) => Promise<{ text: string }[][]>>().mockResolvedValue([]),
+            verifyTokenizeResult: jest.fn(),
+            lemmatize: jest.fn<(token: string) => Promise<string[] | undefined>>().mockResolvedValue([]),
+            resetCache: jest.fn(),
+        };
+        Object.assign(instance, mockYomitanOverrides.shift());
+        mockYomitanInstances.push(instance);
+        return instance;
+    }),
+}));
+jest.mock('@project/common/yomitan/yomitan', () => ({
+    Yomitan: jest.fn().mockImplementation((dt) => {
+        const instance = {
+            dt,
+            version: jest.fn<() => Promise<string>>().mockResolvedValue('26.4.6'),
+            tokenizeBulk: jest.fn<(texts: string[]) => Promise<unknown>>().mockResolvedValue(undefined),
+            tokenize: jest.fn<(text: string) => Promise<{ text: string }[][]>>().mockResolvedValue([]),
+            verifyTokenizeResult: jest.fn(),
+            lemmatize: jest.fn<(token: string) => Promise<string[] | undefined>>().mockResolvedValue([]),
+            resetCache: jest.fn(),
+        };
+        Object.assign(instance, mockYomitanOverrides.shift());
+        mockYomitanInstances.push(instance);
+        return instance;
+    }),
+}));
+
+import {
+    DictionaryDB,
+    _buildIdHealthCheck,
+    _clearBuildIds,
+    _ensureBuildId,
+    _gatherModifiedTokens,
+} from './dictionary-db';
+import {
+    _buildAnkiCardStatuses,
+    _buildTokensForTracks,
+    _deleteCardBulk,
+    _getAnkiCardKeys,
+    _getAnkiCardsByNoteIdBulk,
+    _orphanAllCardIds,
+    _processAnkiCardStatuses,
+    _processTracks,
+    _saveTokensForDB,
+    _syncTrackStatesWithAnki,
+    _updateBuildAnkiCacheProgress,
+} from './dictionary-db-anki';
+import {
+    makeAnkiCardRecord,
+    makeDictionaryTrack,
+    makeMetaRecord,
+    makeModifiedCard,
+    makeNoteInfo,
+    makeSettings,
+    makeTokenRecord,
+    otherProfile,
+    otherTrack,
+    privateDb,
+    profile,
+    tokenKey,
+    track,
+} from './dictionary-db-test-utils';
+
+describe('DictionaryDB Anki cache', () => {
+    let dictionaryDB: DictionaryDB;
+    let settings: AsbplayerSettings;
+
+    const useSettings = (dictionaryTracks = [makeDictionaryTrack()]) => {
+        settings = makeSettings(dictionaryTracks);
+        return settings;
+    };
+
+    const installHelperAdapters = () => {
+        const db = privateDb(dictionaryDB);
+        Object.assign(dictionaryDB as any, {
+            _buildAnkiCardStatuses,
+            _buildIdHealthCheck: (buildId: string, activeTracks: [string, number][]) =>
+                _buildIdHealthCheck(db, buildId, 'anki', activeTracks),
+            _buildTokensForTracks: (
+                ...args: Parameters<typeof _buildTokensForTracks> extends [any, ...infer Rest] ? Rest : never
+            ) => _buildTokensForTracks(db, ...args),
+            _clearBuildId: (key: [string, number], buildId: string) => _clearBuildIds(db, [key], buildId, 'anki'),
+            _clearBuildIds: (activeTracks: [string, number][], buildId: string) =>
+                _clearBuildIds(db, activeTracks, buildId, 'anki'),
+            _deleteCardBulk: (
+                profile: string,
+                orphanedTrackCardIds: Map<number, number[]>,
+                modifiedTokens: Set<string>
+            ) => _deleteCardBulk(db, profile, orphanedTrackCardIds, modifiedTokens),
+            _ensureBuildId: (key: [string, number], buildId: string, options: { buildTs: number }) =>
+                _ensureBuildId(db, key, buildId, 'anki', { mode: 'claim', buildTs: options.buildTs }),
+            _gatherModifiedTokens: (profile: string, modifiedTokens: Set<string>) =>
+                _gatherModifiedTokens(db, profile, modifiedTokens),
+            _getAnkiCardKeys: (profile: string) => _getAnkiCardKeys(db, profile),
+            _getAnkiCardsByNoteIdBulk: (profile: string, noteIds: number[]) =>
+                _getAnkiCardsByNoteIdBulk(db, profile, noteIds),
+            _orphanAllCardIds: (profile: string, tracks: number[]) => _orphanAllCardIds(db, profile, tracks),
+            _processAnkiCardStatuses,
+            _processTracks: (...args: Parameters<typeof _processTracks> extends [any, ...infer Rest] ? Rest : never) =>
+                _processTracks(db, ...args),
+            _saveTokensForDB: (
+                ...args: Parameters<typeof _saveTokensForDB> extends [any, ...infer Rest] ? Rest : never
+            ) => _saveTokensForDB(db, ...args),
+            _syncTrackStatesWithAnki: (
+                ...args: Parameters<typeof _syncTrackStatesWithAnki> extends [any, ...infer Rest] ? Rest : never
+            ) => _syncTrackStatesWithAnki(db, ...args),
+            _updateBuildAnkiCacheProgress: (
+                ...args: Parameters<typeof _updateBuildAnkiCacheProgress> extends [any, ...infer Rest] ? Rest : never
+            ) => _updateBuildAnkiCacheProgress(db, ...args),
+        });
+    };
+
+    beforeEach(async () => {
+        mockAnkiInstances.length = 0;
+        mockAnkiOverrides.length = 0;
+        mockYomitanInstances.length = 0;
+        mockYomitanOverrides.length = 0;
+        await Dexie.delete('DictionaryDatabase');
+        settings = makeSettings([makeDictionaryTrack()]);
+        dictionaryDB = new DictionaryDB({
+            getAll: jest.fn(async () => settings),
+            getSingle: jest.fn(async (key: keyof AsbplayerSettings) => settings[key]),
+        } as any);
+        installHelperAdapters();
+    });
+
+    afterEach(async () => {
+        jest.restoreAllMocks();
+        privateDb(dictionaryDB).close();
+        await Dexie.delete('DictionaryDatabase');
+    });
+
+    const seedTokens = async (...records: ReturnType<typeof makeTokenRecord>[]) => {
+        await privateDb(dictionaryDB).tokens.bulkPut(records);
+    };
+
+    const seedAnkiCards = async (...records: ReturnType<typeof makeAnkiCardRecord>[]) => {
+        await privateDb(dictionaryDB).ankiCards.bulkPut(records);
+    };
+
+    const waitForAnkiBuildToFinish = async (key: [string, number] = [profile, track]) => {
+        for (let i = 0; i < 20; i++) {
+            const meta = await privateDb(dictionaryDB).meta.get(key);
+            if (meta?.ankiMeta.buildId === null) return;
+            await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        }
+        throw new Error('Timed out waiting for Anki build to finish');
+    };
+
+    it('uses exact deck, child deck, and field matches when building Anki card statuses', async () => {
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryAnkiDecks: ['Japanese', 'Mining'],
+            dictionaryAnkiWordFields: ['Word'],
+            dictionaryAnkiSentenceFields: ['Sentence'],
+            dictionaryAnkiMatureCutoff: 20,
+        });
+        const modifiedCards = new Map<number, any>([
+            [
+                1,
+                makeModifiedCard({
+                    noteId: 1,
+                    deckName: 'Japanese',
+                    fields: new Map([['Word', 'alpha']]),
+                    modifiedAt: 100,
+                    statuses: new Map(),
+                    suspended: false,
+                }),
+            ],
+            [
+                2,
+                makeModifiedCard({
+                    noteId: 2,
+                    deckName: 'Japanese::Anime',
+                    fields: new Map([['Sentence', 'sentence']]),
+                    modifiedAt: 100,
+                    statuses: new Map(),
+                    suspended: false,
+                }),
+            ],
+            [
+                3,
+                makeModifiedCard({
+                    noteId: 3,
+                    deckName: 'Other',
+                    fields: new Map([['Word', 'beta']]),
+                    modifiedAt: 100,
+                    statuses: new Map(),
+                    suspended: false,
+                }),
+            ],
+            [
+                4,
+                makeModifiedCard({
+                    noteId: 4,
+                    deckName: 'Mining',
+                    fields: new Map([['Unrelated', 'gamma']]),
+                    modifiedAt: 100,
+                    statuses: new Map(),
+                    suspended: false,
+                }),
+            ],
+        ]);
+        const anki = { findCards: jest.fn<(query: string) => Promise<number[]>>() };
+        anki.findCards.mockResolvedValueOnce([1, 2, 3, 4]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+        await (dictionaryDB as any)._buildAnkiCardStatuses(track, { dt: dictionaryTrack }, modifiedCards, anki);
+
+        expect(anki.findCards).toHaveBeenCalledTimes(1);
+        expect(anki.findCards.mock.calls[0][0]).toBe(
+            'is:new (("deck:Japanese" OR "deck:Mining") ("Word:_*" OR "Sentence:_*"))'
+        );
+        expect(modifiedCards.get(1).statuses.get(track)).toBe(TokenStatus.UNKNOWN);
+        expect(modifiedCards.get(2).statuses.get(track)).toBe(TokenStatus.UNKNOWN);
+        expect(modifiedCards.get(3).statuses.has(track)).toBe(false);
+        expect(modifiedCards.get(4).statuses.has(track)).toBe(false);
+    });
+
+    it('treats an empty deck list as all decks when building Anki card statuses', async () => {
+        const dictionaryTrack = makeDictionaryTrack({ dictionaryAnkiDecks: [], dictionaryAnkiWordFields: ['Word'] });
+        const modifiedCards = new Map<number, any>([
+            [
+                1,
+                makeModifiedCard({
+                    noteId: 1,
+                    deckName: 'Any Deck',
+                    fields: new Map([['Word', 'alpha']]),
+                    modifiedAt: 100,
+                    statuses: new Map(),
+                    suspended: false,
+                }),
+            ],
+        ]);
+        const anki = { findCards: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValueOnce([1]) };
+
+        await (dictionaryDB as any)._buildAnkiCardStatuses(track, { dt: dictionaryTrack }, modifiedCards, anki);
+
+        expect(anki.findCards).toHaveBeenCalledWith('is:new ("Word:_*")');
+        expect(modifiedCards.get(1).statuses.get(track)).toBe(TokenStatus.UNKNOWN);
+    });
+
+    it('fetches Anki card keys and groups cards by note ID within a profile', async () => {
+        const firstCard = makeAnkiCardRecord({ cardId: 1, noteId: 10 });
+        const secondCard = makeAnkiCardRecord({ cardId: 2, noteId: 10 });
+        const otherProfileCard = makeAnkiCardRecord({ cardId: 3, noteId: 20, profile: otherProfile });
+
+        await seedAnkiCards(firstCard, secondCard, otherProfileCard);
+
+        await expect((dictionaryDB as any)._getAnkiCardKeys(profile)).resolves.toEqual([
+            [1, track, profile],
+            [2, track, profile],
+        ]);
+        await expect((dictionaryDB as any)._getAnkiCardsByNoteIdBulk(profile, [])).resolves.toEqual(new Map());
+        await expect((dictionaryDB as any)._getAnkiCardsByNoteIdBulk(profile, [10, 20])).resolves.toEqual(
+            new Map([[10, [firstCard, secondCard]]])
+        );
+    });
+
+    it('orphans and deletes Anki cards while updating related token modifications', async () => {
+        const modifiedTokens = new Set<string>();
+        await seedTokens(
+            makeTokenRecord({
+                token: 'alpha',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['lemma-alpha'],
+                cardIds: [1, 2],
+            }),
+            makeTokenRecord({
+                token: 'beta',
+                track,
+                source: DictionaryTokenSource.ANKI_SENTENCE,
+                status: null,
+                lemmas: ['lemma-beta'],
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'other-track',
+                track: otherTrack,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['other-track'],
+                cardIds: [3],
+            })
+        );
+        await seedAnkiCards(
+            makeAnkiCardRecord({ cardId: 1 }),
+            makeAnkiCardRecord({ cardId: 2 }),
+            makeAnkiCardRecord({ cardId: 3, track: otherTrack })
+        );
+
+        await (dictionaryDB as any)._deleteCardBulk(profile, new Map([[track, []]]), modifiedTokens);
+        await expect(privateDb(dictionaryDB).ankiCards.count()).resolves.toBe(3);
+
+        await (dictionaryDB as any)._deleteCardBulk(profile, new Map([[track, [1]]]), modifiedTokens);
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('alpha', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toMatchObject({
+            status: null,
+            states: [],
+            cardIds: [2],
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('beta', DictionaryTokenSource.ANKI_SENTENCE, track))
+        ).resolves.toBeUndefined();
+        await expect(privateDb(dictionaryDB).ankiCards.get([1, track, profile])).resolves.toBeUndefined();
+        expect(modifiedTokens).toEqual(new Set(['alpha', 'lemma-alpha', 'beta', 'lemma-beta']));
+
+        await expect((dictionaryDB as any)._orphanAllCardIds(profile, [])).resolves.toEqual(new Map());
+        await expect((dictionaryDB as any)._orphanAllCardIds(profile, [track, otherTrack])).resolves.toEqual(
+            new Map([
+                [track, [2]],
+                [otherTrack, [3]],
+            ])
+        );
+    });
+
+    it('manages build IDs, health checks, clearing, and progress expiration', async () => {
+        const key = [profile, track];
+        const statusUpdates = jest.fn();
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const dateNow = jest.spyOn(Date, 'now').mockReturnValue(2000);
+
+        await expect((dictionaryDB as any)._ensureBuildId(key, 'build-1', { buildTs: 1000 })).resolves.toBe(true);
+        await expect((dictionaryDB as any)._ensureBuildId(key, 'build-2', { buildTs: 2000 })).resolves.toBe(false);
+        await expect((dictionaryDB as any)._buildIdHealthCheck('build-1', [key])).resolves.toBeUndefined();
+        await expect((dictionaryDB as any)._buildIdHealthCheck('build-2', [key])).rejects.toThrow(
+            'buildId was corrupted for track 1'
+        );
+        await expect((dictionaryDB as any)._ensureBuildId(key, 'build-2', { buildTs: 302000 })).resolves.toBe(true);
+        expect(consoleWarn).toHaveBeenCalledTimes(1);
+
+        await (dictionaryDB as any)._updateBuildAnkiCacheProgress(
+            'build-2',
+            [key],
+            { current: 1, total: 3, startedAt: 1000 },
+            ['alpha'],
+            statusUpdates,
+            true
+        );
+        await expect(privateDb(dictionaryDB).meta.get(key)).resolves.toMatchObject({
+            ankiMeta: {
+                buildId: 'build-2',
+                lastBuildExpiresAt: 302000,
+            },
+        });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildAnkiCacheStateType.progress,
+            body: { current: 1, total: 3, buildTimestamp: 1000, modifiedTokens: ['alpha'], forAnkiSync: true },
+        });
+
+        await (dictionaryDB as any)._clearBuildId(key, 'wrong-build');
+        await expect(privateDb(dictionaryDB).meta.get(key)).resolves.toMatchObject({
+            ankiMeta: { buildId: 'build-2' },
+        });
+        await (dictionaryDB as any)._clearBuildIds([key], 'build-2');
+        await expect(privateDb(dictionaryDB).meta.get(key)).resolves.toMatchObject({ ankiMeta: { buildId: null } });
+        dateNow.mockRestore();
+    });
+
+    it('processes Anki card status assignments once per card and skips irrelevant cards', () => {
+        const modifiedCards = new Map<number, any>([
+            [1, makeModifiedCard({ statuses: new Map() })],
+            [2, makeModifiedCard({ statuses: new Map([[track, TokenStatus.UNKNOWN]]) })],
+            [3, makeModifiedCard({ statuses: new Map() })],
+        ]);
+
+        expect(
+            (dictionaryDB as any)._processAnkiCardStatuses(
+                track,
+                [99, 1, 1, 2, 3],
+                modifiedCards,
+                TokenStatus.MATURE,
+                2
+            )
+        ).toBe(0);
+        expect(modifiedCards.get(1).statuses.get(track)).toBe(TokenStatus.MATURE);
+        expect(modifiedCards.get(2).statuses.get(track)).toBe(TokenStatus.UNKNOWN);
+        expect(modifiedCards.get(3).statuses.get(track)).toBe(TokenStatus.MATURE);
+    });
+
+    it('builds Anki statuses through learn, FSRS, and interval fallback queries', async () => {
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryAnkiWordFields: ['Word'],
+            dictionaryAnkiMatureCutoff: 20,
+        });
+        const modifiedCards = new Map<number, any>([
+            [1, makeModifiedCard({ cardId: 1, statuses: new Map() })],
+            [2, makeModifiedCard({ cardId: 2, statuses: new Map() })],
+            [3, makeModifiedCard({ cardId: 3, statuses: new Map() })],
+        ]);
+        const anki = { findCards: jest.fn<(query: string) => Promise<number[]>>() };
+        anki.findCards
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([1])
+            .mockResolvedValueOnce([2])
+            .mockResolvedValueOnce([3]);
+
+        await (dictionaryDB as any)._buildAnkiCardStatuses(track, { dt: dictionaryTrack }, modifiedCards, anki);
+
+        expect(anki.findCards.mock.calls.map((call) => call[0])).toEqual([
+            'is:new ("Word:_*")',
+            'is:learn ("Word:_*")',
+            'prop:s>=0 ("Word:_*")',
+            '-is:new -is:learn prop:ivl<10 ("Word:_*")',
+            '-is:new -is:learn prop:ivl>=10 prop:ivl<20 ("Word:_*")',
+            '-is:new -is:learn prop:ivl>=20 ("Word:_*")',
+        ]);
+        expect(modifiedCards.get(1).statuses.get(track)).toBe(TokenStatus.GRADUATED);
+        expect(modifiedCards.get(2).statuses.get(track)).toBe(TokenStatus.YOUNG);
+        expect(modifiedCards.get(3).statuses.get(track)).toBe(TokenStatus.MATURE);
+    });
+
+    it('throws when Anki status queries cannot classify all relevant cards', async () => {
+        const dictionaryTrack = makeDictionaryTrack({ dictionaryAnkiWordFields: ['Word'] });
+        const modifiedCards = new Map<number, any>([[1, makeModifiedCard({ statuses: new Map() })]]);
+        const anki = { findCards: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([]) };
+
+        await expect(
+            (dictionaryDB as any)._buildAnkiCardStatuses(track, { dt: dictionaryTrack }, modifiedCards, anki)
+        ).rejects.toThrow('Anki changed during status build, some cards statuses could not be determined.');
+    });
+
+    it('does not query Anki card statuses when there are no modified cards or configured Anki fields', async () => {
+        const anki = { findCards: jest.fn<(query: string) => Promise<number[]>>() };
+
+        await (dictionaryDB as any)._buildAnkiCardStatuses(
+            track,
+            { dt: makeDictionaryTrack({ dictionaryAnkiWordFields: ['Word'] }) },
+            new Map(),
+            anki
+        );
+        await (dictionaryDB as any)._buildAnkiCardStatuses(
+            track,
+            { dt: makeDictionaryTrack({ dictionaryAnkiWordFields: [], dictionaryAnkiSentenceFields: [] }) },
+            new Map([[1, makeModifiedCard({ statuses: new Map() })]]),
+            anki
+        );
+
+        expect(anki.findCards).not.toHaveBeenCalled();
+    });
+
+    it('syncs track states with Anki, trims fields, detects suspended cards, and records orphaned card IDs', async () => {
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryAnkiDecks: ['Japanese'],
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        const trackStates = new Map([[track, { dt: dictionaryTrack, yomitan: {} }]]);
+        const modifiedCards = new Map<number, any>();
+        const orphanedTrackCardIds = new Map<number, number[]>();
+        const anki = {
+            findNotes: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([10]),
+            notesInfo: jest.fn<(noteIds: number[]) => Promise<any[]>>().mockResolvedValue([
+                makeNoteInfo({
+                    noteId: 10,
+                    fields: { Word: { value: ' alpha ', order: 0 }, Empty: { value: '   ', order: 1 } },
+                    cards: [1, 2],
+                    mod: 100,
+                }),
+            ]),
+            cardsModTime: jest
+                .fn<(cardIds: number[]) => Promise<{ cardId: number; mod: number }[]>>()
+                .mockResolvedValue([
+                    { cardId: 1, mod: 110 },
+                    { cardId: 2, mod: 110 },
+                ]),
+            cardsInfo: jest
+                .fn<(cardIds: number[], progress?: (progress: any) => Promise<void>) => Promise<any[]>>()
+                .mockResolvedValue([
+                    { cardId: 1, deckName: 'Japanese' },
+                    { cardId: 2, deckName: 'Other' },
+                ]),
+            areSuspended: jest.fn<(cardIds: number[]) => Promise<boolean[]>>().mockResolvedValue([false, true]),
+        };
+        await seedAnkiCards(
+            makeAnkiCardRecord({ cardId: 2, noteId: 10, modifiedAt: 50 }),
+            makeAnkiCardRecord({ cardId: 3, noteId: 11, modifiedAt: 50 })
+        );
+
+        await expect(
+            (dictionaryDB as any)._syncTrackStatesWithAnki(
+                profile,
+                trackStates,
+                modifiedCards,
+                orphanedTrackCardIds,
+                anki,
+                'build',
+                [[profile, track]],
+                jest.fn()
+            )
+        ).resolves.toBe(3);
+
+        expect(anki.findNotes).toHaveBeenCalledWith('("deck:Japanese") ("Word:_*")');
+        expect(modifiedCards.get(1)).toMatchObject({
+            noteId: 10,
+            modifiedAt: 110,
+            suspended: false,
+            data: { deckName: 'Japanese' },
+        });
+        expect(modifiedCards.get(1).fields).toEqual(new Map([['Word', 'alpha']]));
+        expect(modifiedCards.get(2)).toMatchObject({
+            noteId: 10,
+            modifiedAt: 110,
+            suspended: true,
+            data: { deckName: 'Other' },
+        });
+        expect(orphanedTrackCardIds).toEqual(new Map([[track, [2, 3]]]));
+    });
+
+    it('does not sync unchanged notes/cards and does not call expensive card details APIs', async () => {
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryAnkiDecks: ['Japanese'],
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        const trackStates = new Map([[track, { dt: dictionaryTrack, yomitan: {} }]]);
+        const modifiedCards = new Map<number, any>();
+        const orphanedTrackCardIds = new Map<number, number[]>();
+        const anki = {
+            findNotes: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([10]),
+            notesInfo: jest
+                .fn<(noteIds: number[]) => Promise<any[]>>()
+                .mockResolvedValue([makeNoteInfo({ noteId: 10, cards: [1], mod: 100 })]),
+            cardsModTime: jest
+                .fn<(cardIds: number[]) => Promise<{ cardId: number; mod: number }[]>>()
+                .mockResolvedValue([{ cardId: 1, mod: 100 }]),
+            cardsInfo: jest.fn<(cardIds: number[], progress?: (progress: any) => Promise<void>) => Promise<any[]>>(),
+            areSuspended: jest.fn<(cardIds: number[]) => Promise<boolean[]>>(),
+        };
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 1, noteId: 10, modifiedAt: 100 }));
+
+        await expect(
+            (dictionaryDB as any)._syncTrackStatesWithAnki(
+                profile,
+                trackStates,
+                modifiedCards,
+                orphanedTrackCardIds,
+                anki,
+                'build',
+                [[profile, track]],
+                jest.fn()
+            )
+        ).resolves.toBe(0);
+
+        expect(modifiedCards.size).toBe(0);
+        expect(orphanedTrackCardIds).toEqual(new Map([[track, []]]));
+        expect(anki.cardsInfo).not.toHaveBeenCalled();
+        expect(anki.areSuspended).not.toHaveBeenCalled();
+    });
+
+    it('syncs card-only review/suspension changes even when note fields are unchanged', async () => {
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryAnkiDecks: ['Japanese'],
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        const trackStates = new Map([[track, { dt: dictionaryTrack, yomitan: {} }]]);
+        const modifiedCards = new Map<number, any>();
+        const orphanedTrackCardIds = new Map<number, number[]>();
+        const anki = {
+            findNotes: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([10]),
+            notesInfo: jest
+                .fn<(noteIds: number[]) => Promise<any[]>>()
+                .mockResolvedValue([makeNoteInfo({ noteId: 10, cards: [1], mod: 100 })]),
+            cardsModTime: jest
+                .fn<(cardIds: number[]) => Promise<{ cardId: number; mod: number }[]>>()
+                .mockResolvedValue([{ cardId: 1, mod: 150 }]),
+            cardsInfo: jest
+                .fn<(cardIds: number[], progress?: (progress: any) => Promise<void>) => Promise<any[]>>()
+                .mockResolvedValue([{ cardId: 1, deckName: 'Japanese' }]),
+            areSuspended: jest.fn<(cardIds: number[]) => Promise<boolean[]>>().mockResolvedValue([true]),
+        };
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 1, noteId: 10, modifiedAt: 100, suspended: false }));
+
+        await expect(
+            (dictionaryDB as any)._syncTrackStatesWithAnki(
+                profile,
+                trackStates,
+                modifiedCards,
+                orphanedTrackCardIds,
+                anki,
+                'build',
+                [[profile, track]],
+                jest.fn()
+            )
+        ).resolves.toBe(1);
+
+        expect(modifiedCards.get(1)).toMatchObject({
+            modifiedAt: 150,
+            suspended: true,
+            data: { deckName: 'Japanese' },
+        });
+        expect(orphanedTrackCardIds).toEqual(new Map([[track, []]]));
+    });
+
+    it('ignores notes that do not contain configured fields when syncing track states', async () => {
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryAnkiDecks: ['Japanese'],
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        const trackStates = new Map([[track, { dt: dictionaryTrack, yomitan: {} }]]);
+        const modifiedCards = new Map<number, any>();
+        const orphanedTrackCardIds = new Map<number, number[]>();
+        const anki = {
+            findNotes: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([10]),
+            notesInfo: jest.fn<(noteIds: number[]) => Promise<any[]>>().mockResolvedValue([
+                makeNoteInfo({
+                    noteId: 10,
+                    fields: { Sentence: { value: 'alpha', order: 0 } },
+                    cards: [1],
+                    mod: 150,
+                }),
+            ]),
+            cardsModTime: jest
+                .fn<(cardIds: number[]) => Promise<{ cardId: number; mod: number }[]>>()
+                .mockResolvedValue([{ cardId: 1, mod: 150 }]),
+            cardsInfo: jest.fn<(cardIds: number[], progress?: (progress: any) => Promise<void>) => Promise<any[]>>(),
+            areSuspended: jest.fn<(cardIds: number[]) => Promise<boolean[]>>(),
+        };
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 1, noteId: 10, modifiedAt: 100 }));
+
+        await expect(
+            (dictionaryDB as any)._syncTrackStatesWithAnki(
+                profile,
+                trackStates,
+                modifiedCards,
+                orphanedTrackCardIds,
+                anki,
+                'build',
+                [[profile, track]],
+                jest.fn()
+            )
+        ).resolves.toBe(0);
+
+        expect(modifiedCards.size).toBe(0);
+        expect(orphanedTrackCardIds).toEqual(new Map([[track, []]]));
+        expect(anki.cardsInfo).not.toHaveBeenCalled();
+        expect(anki.areSuspended).not.toHaveBeenCalled();
+    });
+
+    it('throws when Anki note or card modification responses are incomplete during sync', async () => {
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryAnkiDecks: ['Japanese'],
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        const trackStates = new Map([[track, { dt: dictionaryTrack, yomitan: {} }]]);
+        const makeAnki = (overrides: Record<string, unknown> = {}) => ({
+            findNotes: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([10]),
+            notesInfo: jest
+                .fn<(noteIds: number[]) => Promise<any[]>>()
+                .mockResolvedValue([makeNoteInfo({ cards: [1, 2] })]),
+            cardsModTime: jest
+                .fn<(cardIds: number[]) => Promise<{ cardId: number; mod: number }[]>>()
+                .mockResolvedValue([{ cardId: 1, mod: 100 }]),
+            cardsInfo: jest.fn<(cardIds: number[], progress?: (progress: any) => Promise<void>) => Promise<any[]>>(),
+            areSuspended: jest.fn<(cardIds: number[]) => Promise<boolean[]>>(),
+            ...overrides,
+        });
+
+        await expect(
+            (dictionaryDB as any)._syncTrackStatesWithAnki(
+                profile,
+                trackStates,
+                new Map(),
+                new Map(),
+                makeAnki({ notesInfo: jest.fn<(noteIds: number[]) => Promise<any[]>>().mockResolvedValue([]) }),
+                'build',
+                [[profile, track]],
+                jest.fn()
+            )
+        ).rejects.toThrow('Anki changed during cards record build, some notes info could not be retrieved.');
+
+        await expect(
+            (dictionaryDB as any)._syncTrackStatesWithAnki(
+                profile,
+                trackStates,
+                new Map(),
+                new Map(),
+                makeAnki(),
+                'build',
+                [[profile, track]],
+                jest.fn()
+            )
+        ).rejects.toThrow('Anki changed during cards record build, some cards mod time could not be retrieved.');
+    });
+
+    it('orphans all existing cards for active tracks when Anki returns no notes', async () => {
+        const dictionaryTrack = makeDictionaryTrack({ dictionaryAnkiWordFields: ['Word'] });
+        const trackStates = new Map([[track, { dt: dictionaryTrack, yomitan: {} }]]);
+        const orphanedTrackCardIds = new Map<number, number[]>();
+        const anki = { findNotes: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([]) };
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 1 }), makeAnkiCardRecord({ cardId: 2, track: otherTrack }));
+
+        await expect(
+            (dictionaryDB as any)._syncTrackStatesWithAnki(
+                profile,
+                trackStates,
+                new Map(),
+                orphanedTrackCardIds,
+                anki,
+                'build',
+                [[profile, track]],
+                jest.fn()
+            )
+        ).resolves.toBe(1);
+        expect(orphanedTrackCardIds).toEqual(new Map([[track, [1]]]));
+    });
+
+    it('saves new Anki tokens and removes stale token card references from the DB', async () => {
+        const modifiedTokens = new Set<string>();
+        const currentRecord = makeTokenRecord({
+            token: 'current',
+            track,
+            source: DictionaryTokenSource.ANKI_WORD,
+            status: null,
+            lemmas: ['current-lemma'],
+            cardIds: [1],
+        });
+        const ankiCard = makeAnkiCardRecord({ cardId: 1, status: TokenStatus.LEARNING });
+        const partialTokenRecordsByTrack = new Map([
+            [
+                track,
+                new Map([
+                    [
+                        DictionaryTokenSource.ANKI_WORD,
+                        new Map([['current', { lemmas: ['current-lemma'], cardIds: new Set([1]) }]]),
+                    ],
+                    [DictionaryTokenSource.ANKI_SENTENCE, new Map()],
+                ]),
+            ],
+        ]);
+        await seedTokens(
+            makeTokenRecord({
+                token: 'stale-delete',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['stale-delete-lemma'],
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'stale-retain',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['stale-retain-lemma'],
+                cardIds: [1, 2],
+            })
+        );
+
+        await (dictionaryDB as any)._saveTokensForDB(
+            profile,
+            new Map([[track, { dt: makeDictionaryTrack(), yomitan: {} }]]),
+            [currentRecord],
+            [ankiCard],
+            new Map([[1, makeModifiedCard()]]),
+            partialTokenRecordsByTrack,
+            modifiedTokens
+        );
+
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('current', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toEqual(currentRecord);
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('stale-delete', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toBeUndefined();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('stale-retain', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toMatchObject({
+            cardIds: [2],
+        });
+        await expect(privateDb(dictionaryDB).ankiCards.get([1, track, profile])).resolves.toEqual(ankiCard);
+        expect(modifiedTokens).toEqual(
+            new Set([
+                'current',
+                'current-lemma',
+                'stale-delete',
+                'stale-delete-lemma',
+                'stale-retain',
+                'stale-retain-lemma',
+            ])
+        );
+    });
+
+    it('gathers modified tokens through lemma relationships within the same profile', async () => {
+        const modifiedTokens = new Set(['alpha']);
+        await seedTokens(
+            makeTokenRecord({ token: 'related', lemmas: ['alpha', 'related-lemma'] }),
+            makeTokenRecord({ token: 'other-profile-related', profile: otherProfile, lemmas: ['alpha'] })
+        );
+
+        await (dictionaryDB as any)._gatherModifiedTokens(profile, modifiedTokens);
+
+        expect(modifiedTokens).toEqual(new Set(['alpha', 'related', 'related-lemma']));
+    });
+
+    it('returns without tokenization or progress when there are no modified cards to build', async () => {
+        const yomitan = {
+            tokenizeBulk: jest.fn(),
+            tokenize: jest.fn(),
+            verifyTokenizeResult: jest.fn(),
+            lemmatize: jest.fn(),
+            resetCache: jest.fn(),
+        };
+        const statusUpdates = jest.fn();
+
+        await (dictionaryDB as any)._buildTokensForTracks(
+            profile,
+            new Map([[track, { dt: makeDictionaryTrack({ dictionaryAnkiWordFields: ['Word'] }), yomitan }]]),
+            new Map(),
+            'build',
+            [[profile, track]],
+            { current: 0, total: 0, startedAt: 1000 },
+            statusUpdates
+        );
+
+        expect(yomitan.tokenizeBulk).not.toHaveBeenCalled();
+        expect(yomitan.tokenize).not.toHaveBeenCalled();
+        expect(yomitan.resetCache).not.toHaveBeenCalled();
+        expect(statusUpdates).not.toHaveBeenCalled();
+    });
+
+    it('builds modified cards in 100-card batches without losing progress or records', async () => {
+        const dictionaryTrack = makeDictionaryTrack({ dictionaryAnkiWordFields: ['Word'] });
+        const tokenize = jest.fn<(text: string) => Promise<{ text: string }[][]>>((text) =>
+            Promise.resolve([[{ text }]])
+        );
+        const lemmatize = jest.fn<(token: string) => Promise<string[]>>((token) => Promise.resolve([token]));
+        const yomitan = {
+            tokenizeBulk: jest.fn(),
+            tokenize,
+            verifyTokenizeResult: jest.fn(),
+            lemmatize,
+            resetCache: jest.fn(),
+        };
+        const modifiedCards = new Map(
+            Array.from({ length: 101 }, (_, index) => {
+                const cardId = index + 1;
+                return [
+                    cardId,
+                    makeModifiedCard({
+                        noteId: cardId * 10,
+                        fields: new Map([['Word', `word${cardId}`]]),
+                        statuses: new Map([[track, TokenStatus.UNKNOWN]]),
+                    }),
+                ] as const;
+            })
+        );
+        const statusUpdates = jest.fn();
+        const key = [profile, track];
+        await (dictionaryDB as any)._ensureBuildId(key, 'build', { buildTs: 1000 });
+
+        await (dictionaryDB as any)._buildTokensForTracks(
+            profile,
+            new Map([[track, { dt: dictionaryTrack, yomitan }]]),
+            modifiedCards,
+            'build',
+            [key],
+            { current: 0, total: 101, startedAt: 1000 },
+            statusUpdates
+        );
+
+        expect(yomitan.tokenizeBulk.mock.calls.map(([texts]) => (texts as string[]).length)).toEqual([100, 1]);
+        expect(tokenize).toHaveBeenCalledTimes(101);
+        expect(lemmatize).toHaveBeenCalledTimes(101);
+        await expect(privateDb(dictionaryDB).tokens.count()).resolves.toBe(101);
+        await expect(privateDb(dictionaryDB).ankiCards.count()).resolves.toBe(101);
+        expect(statusUpdates.mock.calls.map(([state]) => (state as any).body.current)).toEqual([100, 101]);
+    });
+
+    it('builds tokens for tracks, preserving surviving card IDs while clearing local-only Anki fields and reporting progress', async () => {
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryAnkiDecks: ['Japanese'],
+            dictionaryAnkiWordFields: ['Word'],
+            dictionaryAnkiSentenceFields: ['Sentence'],
+        });
+        const tokenize = jest.fn<(text: string) => Promise<{ text: string }[][]>>((text) => {
+            if (text === 'alpha 123 beta')
+                return Promise.resolve([[{ text: 'alpha' }], [{ text: '123' }], [{ text: 'beta' }]]);
+            if (text === 'sentence') return Promise.resolve([[{ text: 'sentence' }]]);
+            return Promise.resolve([]);
+        });
+        const lemmatize = jest.fn<(token: string) => Promise<string[]>>((token) => {
+            if (token === 'alpha') return Promise.resolve(['lemma-alpha']);
+            if (token === 'sentence') return Promise.resolve(['lemma-sentence']);
+            return Promise.resolve([]);
+        });
+        const yomitan = {
+            tokenizeBulk: jest.fn(),
+            tokenize,
+            verifyTokenizeResult: jest.fn(),
+            lemmatize,
+            resetCache: jest.fn(),
+        };
+        const statusUpdates = jest.fn();
+        const key = [profile, track];
+        await (dictionaryDB as any)._ensureBuildId(key, 'build', { buildTs: 1000 });
+        await seedTokens(
+            makeTokenRecord({
+                token: 'alpha',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['old-alpha'],
+                states: [TokenState.IGNORED],
+                cardIds: [2],
+            })
+        );
+
+        await (dictionaryDB as any)._buildTokensForTracks(
+            profile,
+            new Map([[track, { dt: dictionaryTrack, yomitan }]]),
+            new Map([
+                [
+                    10,
+                    makeModifiedCard({
+                        fields: new Map([
+                            ['Word', 'alpha 123 beta'],
+                            ['Sentence', 'sentence'],
+                        ]),
+                    }),
+                ],
+            ]),
+            'build',
+            [key],
+            { current: 0, total: 1, startedAt: 1000 },
+            statusUpdates
+        );
+
+        expect(yomitan.tokenizeBulk).toHaveBeenCalledWith(['alpha 123 beta', 'sentence']);
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('alpha', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toMatchObject({
+            status: null,
+            lemmas: ['lemma-alpha'],
+            states: [],
+            cardIds: [2, 10],
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('sentence', DictionaryTokenSource.ANKI_SENTENCE, track))
+        ).resolves.toMatchObject({
+            status: null,
+            states: [],
+            lemmas: ['lemma-sentence'],
+            cardIds: [10],
+        });
+        await expect(privateDb(dictionaryDB).ankiCards.get([10, track, profile])).resolves.toMatchObject({
+            cardId: 10,
+            status: TokenStatus.UNKNOWN,
+        });
+        expect(statusUpdates).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: DictionaryBuildAnkiCacheStateType.progress,
+                body: expect.objectContaining({ current: 1, total: 1 }),
+            })
+        );
+    });
+
+    it('drops generated Anki tokens without card IDs when saving build output', async () => {
+        const modifiedTokens = new Set<string>();
+
+        await (dictionaryDB as any)._saveTokensForDB(
+            profile,
+            new Map([[track, { dt: makeDictionaryTrack(), yomitan: {} }]]),
+            [
+                makeTokenRecord({
+                    token: 'no-card-ids',
+                    track,
+                    source: DictionaryTokenSource.ANKI_WORD,
+                    status: TokenStatus.UNKNOWN,
+                    lemmas: ['lemma-no-card-ids'],
+                    states: [TokenState.IGNORED],
+                    cardIds: [],
+                }),
+            ],
+            [],
+            new Map(),
+            new Map([
+                [
+                    track,
+                    new Map([
+                        [DictionaryTokenSource.ANKI_WORD, new Map()],
+                        [DictionaryTokenSource.ANKI_SENTENCE, new Map()],
+                    ]),
+                ],
+            ]),
+            modifiedTokens
+        );
+
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('no-card-ids', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toBeUndefined();
+        expect(modifiedTokens).toEqual(new Set(['no-card-ids', 'lemma-no-card-ids']));
+    });
+
+    it('replaces stale tokens when a modified card produces different tokens', async () => {
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryAnkiDecks: ['Japanese'],
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        const yomitan = {
+            tokenizeBulk: jest.fn(),
+            tokenize: jest
+                .fn<(text: string) => Promise<{ text: string }[][]>>()
+                .mockResolvedValue([[{ text: 'new-token' }]]),
+            verifyTokenizeResult: jest.fn(),
+            lemmatize: jest.fn<(token: string) => Promise<string[]>>().mockResolvedValue(['new-lemma']),
+            resetCache: jest.fn(),
+        };
+        const statusUpdates = jest.fn();
+        const key = [profile, track];
+        await (dictionaryDB as any)._ensureBuildId(key, 'build', { buildTs: 1000 });
+        await seedTokens(
+            makeTokenRecord({
+                token: 'old-delete',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['old-delete-lemma'],
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'old-retain',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['old-retain-lemma'],
+                cardIds: [1, 2],
+            }),
+            makeTokenRecord({
+                token: 'other-profile-retain',
+                profile: otherProfile,
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['other-profile-retain-lemma'],
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'other-track-retain',
+                track: otherTrack,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['other-track-retain-lemma'],
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'local-retain',
+                track,
+                source: DictionaryTokenSource.LOCAL,
+                status: TokenStatus.UNKNOWN,
+                lemmas: ['local-retain-lemma'],
+                cardIds: [1],
+            })
+        );
+
+        await (dictionaryDB as any)._buildTokensForTracks(
+            profile,
+            new Map([[track, { dt: dictionaryTrack, yomitan }]]),
+            new Map([[1, makeModifiedCard({ fields: new Map([['Word', 'new-token']]) })]]),
+            'build',
+            [key],
+            { current: 0, total: 1, startedAt: 1000 },
+            statusUpdates
+        );
+
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('new-token', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toMatchObject({
+            lemmas: ['new-lemma'],
+            cardIds: [1],
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('old-delete', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toBeUndefined();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('old-retain', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toMatchObject({
+            cardIds: [2],
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(
+                tokenKey('other-profile-retain', DictionaryTokenSource.ANKI_WORD, track, otherProfile)
+            )
+        ).resolves.toMatchObject({
+            cardIds: [1],
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(
+                tokenKey('other-track-retain', DictionaryTokenSource.ANKI_WORD, otherTrack)
+            )
+        ).resolves.toMatchObject({
+            cardIds: [1],
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('local-retain', DictionaryTokenSource.LOCAL, track))
+        ).resolves.toMatchObject({
+            cardIds: [1],
+        });
+        expect(statusUpdates).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: DictionaryBuildAnkiCacheStateType.progress,
+                body: expect.objectContaining({
+                    modifiedTokens: expect.arrayContaining([
+                        'new-token',
+                        'new-lemma',
+                        'old-delete',
+                        'old-delete-lemma',
+                        'old-retain',
+                        'old-retain-lemma',
+                    ]),
+                }),
+            })
+        );
+    });
+
+    it('processes tracks by deleting orphaned cards, clearing build IDs, gathering related tokens, and publishing stats', async () => {
+        const statusUpdates = jest.fn();
+        const key = [profile, track];
+        await (dictionaryDB as any)._ensureBuildId(key, 'build', { buildTs: 1000 });
+        await seedTokens(makeTokenRecord({ token: 'related', lemmas: ['alpha'] }));
+
+        await (dictionaryDB as any)._processTracks(
+            profile,
+            'build',
+            new Map([[track, { dt: makeDictionaryTrack(), yomitan: {} }]]),
+            new Map(),
+            new Map([[track, []]]),
+            [],
+            0,
+            new Set(['alpha']),
+            [key],
+            1,
+            123,
+            statusUpdates
+        );
+
+        await expect(privateDb(dictionaryDB).meta.get(key)).resolves.toMatchObject({ ankiMeta: { buildId: null } });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildAnkiCacheStateType.stats,
+            body: {
+                buildTimestamp: 123,
+                tracksToBuild: [track],
+                modifiedCards: 1,
+                orphanedCards: 0,
+                tracksToClear: [],
+                modifiedTokens: expect.arrayContaining(['alpha', 'related']),
+            },
+        });
+    });
+
+    it('reports build failures from processTracks and still clears build IDs', async () => {
+        const statusUpdates = jest.fn();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const key = [profile, track];
+        await (dictionaryDB as any)._ensureBuildId(key, 'build', { buildTs: 1000 });
+        const yomitan = {
+            tokenizeBulk: jest
+                .fn<(texts: string[]) => Promise<unknown>>()
+                .mockRejectedValue(new Error('tokenize failed')),
+            tokenize: jest.fn(),
+            verifyTokenizeResult: jest.fn(),
+            lemmatize: jest.fn(),
+            resetCache: jest.fn(),
+        };
+
+        await (dictionaryDB as any)._processTracks(
+            profile,
+            'build',
+            new Map([[track, { dt: makeDictionaryTrack({ dictionaryAnkiWordFields: ['Word'] }), yomitan }]]),
+            new Map([[1, makeModifiedCard()]]),
+            new Map([[track, []]]),
+            [],
+            0,
+            new Set<string>(),
+            [key],
+            1,
+            123,
+            statusUpdates
+        );
+
+        expect(consoleError).toHaveBeenCalled();
+        await expect(privateDb(dictionaryDB).meta.get(key)).resolves.toMatchObject({ ankiMeta: { buildId: null } });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildAnkiCacheStateType.error,
+            body: expect.objectContaining({
+                code: DictionaryBuildAnkiCacheStateErrorCode.failedToBuild,
+                msg: 'tokenize failed',
+            }),
+        });
+    });
+
+    it('reports noAnki when buildAnkiCache cannot obtain Anki permission', async () => {
+        const statusUpdates = jest.fn();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockAnkiOverrides.push({
+            requestPermission: jest
+                .fn<() => Promise<{ permission: string }>>()
+                .mockResolvedValue({ permission: 'denied' }),
+        });
+
+        useSettings([makeDictionaryTrack({ dictionaryColorizeSubtitles: true })]);
+        await dictionaryDB.buildAnkiCache(profile, statusUpdates);
+
+        expect(consoleError).toHaveBeenCalled();
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildAnkiCacheStateType.error,
+            body: {
+                code: DictionaryBuildAnkiCacheStateErrorCode.noAnki,
+                msg: 'permission denied',
+                modifiedTokens: [],
+            },
+        });
+    });
+
+    it('reports noYomitan and clears build IDs when Yomitan is unavailable', async () => {
+        const statusUpdates = jest.fn();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockYomitanOverrides.push({
+            version: jest.fn<() => Promise<string>>().mockRejectedValue(new Error('offline')),
+        });
+
+        useSettings([makeDictionaryTrack({ dictionaryColorizeSubtitles: true, dictionaryAnkiWordFields: ['Word'] })]);
+        await dictionaryDB.buildAnkiCache(profile, statusUpdates);
+
+        expect(consoleError).toHaveBeenCalled();
+        await expect(privateDb(dictionaryDB).meta.get([profile, track])).resolves.toMatchObject({
+            ankiMeta: { buildId: null },
+        });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildAnkiCacheStateType.error,
+            body: expect.objectContaining({
+                code: DictionaryBuildAnkiCacheStateErrorCode.noYomitan,
+                msg: 'offline',
+                data: { track },
+            }),
+        });
+    });
+
+    it('reports concurrentBuild without syncing when an unexpired build is already active', async () => {
+        const statusUpdates = jest.fn();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const dateNow = jest.spyOn(Date, 'now').mockReturnValue(1000);
+        await privateDb(dictionaryDB).meta.put(
+            makeMetaRecord({
+                ankiMeta: {
+                    lastBuildStartedAt: 500,
+                    lastBuildExpiresAt: 2000,
+                    buildId: 'other-build',
+                    settings: null,
+                },
+            })
+        );
+
+        useSettings([makeDictionaryTrack({ dictionaryColorizeSubtitles: true, dictionaryAnkiWordFields: ['Word'] })]);
+        await dictionaryDB.buildAnkiCache(profile, statusUpdates);
+
+        expect(consoleError).toHaveBeenCalled();
+        expect(mockYomitanInstances).toHaveLength(0);
+        await expect(privateDb(dictionaryDB).meta.get([profile, track])).resolves.toMatchObject({
+            ankiMeta: { buildId: 'other-build' },
+        });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildAnkiCacheStateType.error,
+            body: expect.objectContaining({
+                code: DictionaryBuildAnkiCacheStateErrorCode.concurrentBuild,
+                data: { expiration: 2000 },
+            }),
+        });
+        dateNow.mockRestore();
+    });
+
+    it('reports sync failures from buildAnkiCache and clears active build IDs', async () => {
+        const statusUpdates = jest.fn();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockAnkiOverrides.push({
+            findNotes: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([10]),
+            notesInfo: jest.fn<(noteIds: number[]) => Promise<any[]>>().mockResolvedValue([]),
+        });
+
+        useSettings([makeDictionaryTrack({ dictionaryColorizeSubtitles: true, dictionaryAnkiWordFields: ['Word'] })]);
+        await dictionaryDB.buildAnkiCache(profile, statusUpdates);
+
+        expect(consoleError).toHaveBeenCalled();
+        await expect(privateDb(dictionaryDB).meta.get([profile, track])).resolves.toMatchObject({
+            ankiMeta: { buildId: null },
+        });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildAnkiCacheStateType.error,
+            body: expect.objectContaining({
+                code: DictionaryBuildAnkiCacheStateErrorCode.failedToSyncTrackStates,
+                msg: 'Anki changed during cards record build, some notes info could not be retrieved.',
+            }),
+        });
+    });
+
+    it('orchestrates the build Anki cache pipeline for enabled tracks', async () => {
+        const statusUpdates = jest.fn();
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        mockAnkiOverrides.push({
+            findNotes: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([10]),
+            notesInfo: jest
+                .fn<(noteIds: number[]) => Promise<any[]>>()
+                .mockResolvedValue([makeNoteInfo({ noteId: 10, cards: [1], mod: 100 })]),
+            cardsModTime: jest
+                .fn<(cardIds: number[]) => Promise<{ cardId: number; mod: number }[]>>()
+                .mockResolvedValue([{ cardId: 1, mod: 100 }]),
+            cardsInfo: jest
+                .fn<(cardIds: number[], progress?: (progress: any) => Promise<void>) => Promise<any[]>>()
+                .mockResolvedValue([{ cardId: 1, deckName: 'Japanese', modelName: 'Model', due: 0 }]),
+            areSuspended: jest.fn<(cardIds: number[]) => Promise<boolean[]>>().mockResolvedValue([false]),
+            findCards: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValueOnce([1]),
+        });
+        mockYomitanOverrides.push({
+            tokenize: jest
+                .fn<(text: string) => Promise<{ text: string }[][]>>()
+                .mockResolvedValue([[{ text: 'alpha' }]]),
+            lemmatize: jest.fn<(token: string) => Promise<string[]>>().mockResolvedValue(['alpha']),
+        });
+
+        useSettings([dictionaryTrack]);
+        await dictionaryDB.buildAnkiCache(profile, statusUpdates);
+        await waitForAnkiBuildToFinish();
+
+        expect(mockAnkiInstances).toHaveLength(1);
+        expect(mockYomitanInstances).toHaveLength(1);
+        expect(mockYomitanInstances[0].version).toHaveBeenCalled();
+        expect(mockAnkiInstances[0].findNotes).toHaveBeenCalledWith('"Word:_*"');
+        expect(mockAnkiInstances[0].findCards).toHaveBeenCalledWith('is:new ("Word:_*")');
+        await expect(privateDb(dictionaryDB).ankiCards.get([1, track, profile])).resolves.toMatchObject({
+            cardId: 1,
+            status: TokenStatus.UNKNOWN,
+            data: { deckName: 'Japanese' },
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('alpha', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toMatchObject({ cardIds: [1], lemmas: ['alpha'] });
+        expect(statusUpdates).toHaveBeenCalledWith(
+            expect.objectContaining({ type: DictionaryBuildAnkiCacheStateType.start })
+        );
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildAnkiCacheStateType.stats,
+            body: expect.objectContaining({ tracksToBuild: [track], modifiedCards: 1, modifiedTokens: [] }),
+        });
+    });
+
+    it('does not sync disabled tracks and keeps existing cache records', async () => {
+        const statusUpdates = jest.fn();
+        const syncSpy = jest.spyOn(dictionaryDB as any, '_syncTrackStatesWithAnki');
+        await seedTokens(
+            makeTokenRecord({
+                token: 'cached',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['cached'],
+                cardIds: [1],
+            })
+        );
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 1 }));
+
+        useSettings([makeDictionaryTrack()]);
+        await dictionaryDB.buildAnkiCache(profile, statusUpdates);
+
+        expect(mockYomitanInstances).toHaveLength(0);
+        expect(syncSpy).not.toHaveBeenCalled();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('cached', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toBeDefined();
+        await expect(privateDb(dictionaryDB).ankiCards.get([1, track, profile])).resolves.toBeDefined();
+        expect(statusUpdates).toHaveBeenLastCalledWith({
+            type: DictionaryBuildAnkiCacheStateType.stats,
+            body: expect.objectContaining({ modifiedTokens: [] }),
+        });
+    });
+
+    it('clears Anki cache without syncing when an enabled track has no Anki fields', async () => {
+        const statusUpdates = jest.fn();
+        const syncSpy = jest.spyOn(dictionaryDB as any, '_syncTrackStatesWithAnki');
+        await seedTokens(
+            makeTokenRecord({
+                token: 'cached',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['cached-lemma'],
+                cardIds: [1],
+            })
+        );
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 1 }));
+
+        useSettings([
+            makeDictionaryTrack({
+                dictionaryColorizeSubtitles: true,
+                dictionaryAnkiWordFields: [],
+                dictionaryAnkiSentenceFields: [],
+            }),
+        ]);
+        await dictionaryDB.buildAnkiCache(profile, statusUpdates);
+
+        expect(mockYomitanInstances).toHaveLength(0);
+        expect(syncSpy).not.toHaveBeenCalled();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('cached', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toBeUndefined();
+        await expect(privateDb(dictionaryDB).ankiCards.get([1, track, profile])).resolves.toBeUndefined();
+        expect(statusUpdates).toHaveBeenLastCalledWith({
+            type: DictionaryBuildAnkiCacheStateType.stats,
+            body: expect.objectContaining({ tracksToClear: [track], orphanedCards: 1 }),
+        });
+    });
+
+    it('clears existing Anki cache when Anki cache settings change before syncing', async () => {
+        const statusUpdates = jest.fn();
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        await seedTokens(
+            makeTokenRecord({
+                token: 'cached',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['cached-lemma'],
+                cardIds: [1],
+            })
+        );
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 1 }));
+        await privateDb(dictionaryDB).meta.put(
+            makeMetaRecord({
+                ankiMeta: {
+                    lastBuildStartedAt: 1,
+                    lastBuildExpiresAt: 2,
+                    buildId: null,
+                    settings: JSON.stringify({ stale: true }),
+                },
+            })
+        );
+
+        useSettings([dictionaryTrack]);
+        await dictionaryDB.buildAnkiCache(profile, statusUpdates);
+        await waitForAnkiBuildToFinish();
+
+        expect(mockYomitanInstances).toHaveLength(1);
+        expect(mockAnkiInstances[0].findNotes).toHaveBeenCalled();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('cached', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toBeUndefined();
+        await expect(privateDb(dictionaryDB).ankiCards.get([1, track, profile])).resolves.toBeUndefined();
+        await expect(privateDb(dictionaryDB).meta.get([profile, track])).resolves.toMatchObject({
+            ankiMeta: { settings: expect.stringContaining('dictionaryAnkiWordFields') },
+        });
+    });
+
+    it('does not clear existing Anki cache when cache settings are unchanged', async () => {
+        const statusUpdates = jest.fn();
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryAnkiWordFields: ['Word'],
+        });
+        const currentSettings = {
+            ankiConnectUrl: defaultSettings.ankiConnectUrl,
+            dictionaryYomitanUrl: dictionaryTrack.dictionaryYomitanUrl,
+            dictionaryYomitanParser: dictionaryTrack.dictionaryYomitanParser,
+            dictionaryYomitanScanLength: dictionaryTrack.dictionaryYomitanScanLength,
+            dictionaryAnkiDecks: dictionaryTrack.dictionaryAnkiDecks,
+            dictionaryAnkiWordFields: dictionaryTrack.dictionaryAnkiWordFields,
+            dictionaryAnkiSentenceFields: dictionaryTrack.dictionaryAnkiSentenceFields,
+            dictionaryAnkiMatureCutoff: dictionaryTrack.dictionaryAnkiMatureCutoff,
+        };
+        mockAnkiOverrides.push({
+            findNotes: jest.fn<(query: string) => Promise<number[]>>().mockResolvedValue([10]),
+            notesInfo: jest
+                .fn<(noteIds: number[]) => Promise<any[]>>()
+                .mockResolvedValue([makeNoteInfo({ noteId: 10, cards: [1], mod: 100 })]),
+            cardsModTime: jest
+                .fn<(cardIds: number[]) => Promise<{ cardId: number; mod: number }[]>>()
+                .mockResolvedValue([{ cardId: 1, mod: 100 }]),
+        });
+        await seedTokens(
+            makeTokenRecord({
+                token: 'cached',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['cached-lemma'],
+                cardIds: [1],
+            })
+        );
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 1 }));
+        await privateDb(dictionaryDB).meta.put(
+            makeMetaRecord({
+                ankiMeta: {
+                    lastBuildStartedAt: 1,
+                    lastBuildExpiresAt: 2,
+                    buildId: null,
+                    settings: JSON.stringify(currentSettings),
+                },
+            })
+        );
+
+        useSettings([dictionaryTrack]);
+        await dictionaryDB.buildAnkiCache(profile, statusUpdates);
+        await waitForAnkiBuildToFinish();
+
+        expect(mockYomitanInstances).toHaveLength(1);
+        expect(mockAnkiInstances[0].cardsInfo).not.toHaveBeenCalled();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('cached', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toBeDefined();
+        await expect(privateDb(dictionaryDB).ankiCards.get([1, track, profile])).resolves.toBeDefined();
+    });
+});

--- a/common/dictionary-db/dictionary-db-anki.ts
+++ b/common/dictionary-db/dictionary-db-anki.ts
@@ -15,7 +15,6 @@ import {
     DictionaryTokenSource,
     DictionaryTrack,
     isAnkiSource,
-    TokenState,
     TokenStatus,
 } from '@project/common/settings';
 import { HAS_LETTER_REGEX, inBatches, mapAsync } from '@project/common/util';
@@ -289,11 +288,11 @@ export async function buildAnkiCachePipeline(
 /**
  * primaryKeys() and keys() are faster than toArray(), we don't need all fields
  */
-async function _getAnkiCardKeys(db: _DictionaryDatabase, profile: string): Promise<DictionaryAnkiCardKey[]> {
+export async function _getAnkiCardKeys(db: _DictionaryDatabase, profile: string): Promise<DictionaryAnkiCardKey[]> {
     return db.ankiCards.where('profile').equals(profile).primaryKeys();
 }
 
-async function _getAnkiCardsByNoteIdBulk(
+export async function _getAnkiCardsByNoteIdBulk(
     db: _DictionaryDatabase,
     profile: string,
     noteIds: number[]
@@ -323,7 +322,7 @@ async function _getAnkiCardsByNoteIdBulk(
  * 4. The card field value no longer produce the same tokens (handled by _saveTokensForDB())
  * 5. Based on track settings such as no Anki fields (handled by tracksToClear)
  */
-async function _deleteCardBulk(
+export async function _deleteCardBulk(
     db: _DictionaryDatabase,
     profile: string,
     orphanedTrackCardIds: Map<number, number[]>,
@@ -365,7 +364,7 @@ async function _deleteCardBulk(
     });
 }
 
-async function _orphanAllCardIds(
+export async function _orphanAllCardIds(
     db: _DictionaryDatabase,
     profile: string,
     tracks: number[]
@@ -394,7 +393,7 @@ async function _orphanAllCardIds(
  * @param statusUpdates The status update callback.
  * @returns The number of modified cards.
  */
-async function _syncTrackStatesWithAnki(
+export async function _syncTrackStatesWithAnki(
     db: _DictionaryDatabase,
     profile: string,
     trackStates: AnkiTrackStatesForDB,
@@ -551,18 +550,18 @@ async function _syncTrackStatesWithAnki(
     return numUpdatedCards;
 }
 
-function _hasDeck(dt: DictionaryTrack, cardDeck: string): boolean {
+export function _hasDeck(dt: DictionaryTrack, cardDeck: string): boolean {
     if (!dt.dictionaryAnkiDecks.length) return true;
     return dt.dictionaryAnkiDecks.some((deck) => deck === cardDeck || cardDeck.startsWith(`${deck}::`));
 }
 
-function _hasField(dt: DictionaryTrack, fields: string[]): boolean {
+export function _hasField(dt: DictionaryTrack, fields: string[]): boolean {
     return fields.some(
         (field) => dt.dictionaryAnkiWordFields.includes(field) || dt.dictionaryAnkiSentenceFields.includes(field)
     );
 }
 
-async function _buildAnkiCardStatuses(
+export async function _buildAnkiCardStatuses(
     track: number,
     ts: TrackStateForDB,
     modifiedCards: CardsForDB,
@@ -633,7 +632,7 @@ async function _buildAnkiCardStatuses(
     }
 }
 
-function _processAnkiCardStatuses(
+export function _processAnkiCardStatuses(
     track: number,
     cardIds: number[],
     modifiedCards: CardsForDB,
@@ -649,7 +648,7 @@ function _processAnkiCardStatuses(
     return numRemaining;
 }
 
-async function _updateBuildAnkiCacheProgress(
+export async function _updateBuildAnkiCacheProgress(
     db: _DictionaryDatabase,
     buildId: string,
     activeTracks: DictionaryMetaKey[],
@@ -686,7 +685,7 @@ async function _updateBuildAnkiCacheProgress(
     });
 }
 
-async function _processTracks(
+export async function _processTracks(
     db: _DictionaryDatabase,
     profile: string,
     buildId: string,
@@ -763,7 +762,7 @@ async function _processTracks(
     }
 }
 
-async function _buildTokensForTracks(
+export async function _buildTokensForTracks(
     db: _DictionaryDatabase,
     profile: string,
     trackStates: Map<number, TrackStateForDB>,
@@ -862,13 +861,9 @@ async function _buildTokensForTracks(
                     );
                     for (const [token, val] of tokenCardsMap.entries()) {
                         const existingRecord = tokenRecordMap.get(token); // Merge with existing record
-                        const states: TokenState[] = [];
                         if (existingRecord) {
                             for (const cardId of existingRecord.cardIds) {
                                 if (!modifiedCardsBatch.has(cardId)) val.cardIds.add(cardId); // If card was updated, it may no longer apply to this token. Should already be in cardIds if it's still valid.
-                            }
-                            for (const state of existingRecord.states) {
-                                if (!states.includes(state)) states.push(state);
                             }
                         }
                         records.push({
@@ -878,7 +873,7 @@ async function _buildTokensForTracks(
                             token,
                             status: ankiTokenStatus,
                             lemmas: val.lemmas,
-                            states,
+                            states: [],
                             cardIds: Array.from(val.cardIds).sort((lhs, rhs) => lhs - rhs),
                         });
                     }
@@ -929,7 +924,7 @@ async function _buildTokensForTracks(
     );
 }
 
-async function _saveTokensForDB(
+export async function _saveTokensForDB(
     db: _DictionaryDatabase,
     profile: string,
     trackStates: Map<number, TrackStateForDB>,
@@ -942,10 +937,21 @@ async function _saveTokensForDB(
     >,
     modifiedTokens: Set<string>
 ): Promise<void> {
-    for (const record of records) {
+    for (let i = records.length - 1; i >= 0; i--) {
+        const record = records[i];
+
         modifiedTokens.add(record.token);
         for (const lemma of record.lemmas) modifiedTokens.add(lemma);
+
+        if (!isAnkiSource(record.source)) continue;
+        if (!record.cardIds.length) {
+            records.splice(i, 1); // Anki tokens must have at least one card
+            continue;
+        }
+        record.status = null; // Anki status is derived from cards
+        record.states = []; // Anki tokens cannot have states (could change in the future)
     }
+
     return db.transaction('rw', db.tokens, db.ankiCards, async () => {
         await Promise.all([_saveRecordBulk(db, records), db.ankiCards.bulkPut(ankiCards)]);
         await db.tokens
@@ -963,6 +969,8 @@ async function _saveTokensForDB(
                 for (const lemma of record.lemmas) modifiedTokens.add(lemma);
                 if (validCardIds.length) {
                     record.cardIds = validCardIds;
+                    record.status = null;
+                    record.states = [];
                 } else {
                     delete (ref as any).value;
                 }

--- a/common/dictionary-db/dictionary-db-test-utils.ts
+++ b/common/dictionary-db/dictionary-db-test-utils.ts
@@ -1,0 +1,246 @@
+import {
+    AsbplayerSettings,
+    defaultSettings,
+    DictionaryTokenSource,
+    DictionaryTrack,
+    TokenFrequencyAnnotation,
+    TokenMatchStrategy,
+    TokenMatchStrategyPriority,
+    TokenReadingAnnotation,
+    TokenState,
+    TokenStatus,
+    TokenStyling,
+} from '@project/common/settings';
+import {
+    DictionaryAnkiCardRecord,
+    DictionaryDB,
+    DictionaryTokenKey,
+    DictionaryTokenRecord,
+    DictionaryWaniKaniAssignmentRecord,
+    DictionaryWaniKaniSubjectRecord,
+    LOCAL_TOKEN_TRACK,
+} from './dictionary-db';
+import { WaniKaniSpacedRepetitionSystem } from '@project/common/wanikani';
+
+export const profile = 'Profile';
+export const otherProfile = 'Other Profile';
+export const track = 0;
+export const otherTrack = 1;
+
+export const tokenKey = (
+    token: string,
+    source: DictionaryTokenSource = DictionaryTokenSource.LOCAL,
+    recordTrack = LOCAL_TOKEN_TRACK,
+    recordProfile = profile
+): DictionaryTokenKey => [token, source, recordTrack, recordProfile];
+
+export const makeTokenRecord = (overrides: Partial<DictionaryTokenRecord> = {}): DictionaryTokenRecord => ({
+    profile,
+    track: LOCAL_TOKEN_TRACK,
+    source: DictionaryTokenSource.LOCAL,
+    token: 'alpha',
+    status: TokenStatus.UNKNOWN,
+    lemmas: ['alpha'],
+    states: [],
+    cardIds: [],
+    ...overrides,
+});
+
+export const makeAnkiCardRecord = (overrides: Partial<DictionaryAnkiCardRecord> = {}): DictionaryAnkiCardRecord => ({
+    profile,
+    track,
+    cardId: 1,
+    noteId: 10,
+    modifiedAt: 100,
+    status: TokenStatus.UNKNOWN,
+    suspended: false,
+    ...overrides,
+});
+
+export const cloneAnnotationConfig = (track: DictionaryTrack) => ({
+    ...track.dictionaryTokenAnnotationConfig,
+    video: {
+        color: { ...track.dictionaryTokenAnnotationConfig.video.color },
+        reading: { ...track.dictionaryTokenAnnotationConfig.video.reading },
+        frequency: { ...track.dictionaryTokenAnnotationConfig.video.frequency },
+        pitchAccent: { ...track.dictionaryTokenAnnotationConfig.video.pitchAccent },
+    },
+    subtitlePlayer: {
+        color: { ...track.dictionaryTokenAnnotationConfig.subtitlePlayer.color },
+        reading: { ...track.dictionaryTokenAnnotationConfig.subtitlePlayer.reading },
+        frequency: { ...track.dictionaryTokenAnnotationConfig.subtitlePlayer.frequency },
+        pitchAccent: { ...track.dictionaryTokenAnnotationConfig.subtitlePlayer.pitchAccent },
+    },
+    onStatuses: track.dictionaryTokenAnnotationConfig.onStatuses.map((config) => ({ ...config })),
+    onStates: track.dictionaryTokenAnnotationConfig.onStates.map((config) => ({ ...config })),
+});
+
+export const makeDictionaryTrack = (overrides: Partial<DictionaryTrack> = {}): DictionaryTrack => {
+    const track: DictionaryTrack = {
+        ...defaultSettings.dictionaryTracks[0],
+        dictionaryTokenStatusColors: [...defaultSettings.dictionaryTracks[0].dictionaryTokenStatusColors],
+        dictionaryTokenStatusConfig: defaultSettings.dictionaryTracks[0].dictionaryTokenStatusConfig.map((config) => ({
+            ...config,
+        })),
+        dictionaryColorizeSubtitles: false,
+        dictionaryAutoGenerateStatistics: false,
+        dictionaryColorizeOnHoverOnly: false,
+        dictionaryHighlightOnHover: false,
+        dictionaryTokenMatchStrategy: TokenMatchStrategy.ANY_FORM_COLLECTED,
+        dictionaryMatchAcrossScripts: true,
+        dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+        dictionaryYomitanUrl: 'http://127.0.0.1:50500',
+        dictionaryYomitanParser: 'scanning-parser',
+        dictionaryYomitanScanLength: 25,
+        dictionaryTokenReadingAnnotation: TokenReadingAnnotation.NEVER,
+        dictionaryDisplayIgnoredTokenReadings: false,
+        dictionaryTokenFrequencyAnnotation: TokenFrequencyAnnotation.NEVER,
+        dictionaryAnkiDecks: [],
+        dictionaryAnkiWordFields: [],
+        dictionaryAnkiSentenceFields: [],
+        dictionaryAnkiSentenceTokenMatchStrategy: TokenMatchStrategy.ANY_FORM_COLLECTED,
+        dictionaryAnkiMatureCutoff: 21,
+        dictionaryAnkiTreatSuspended: 'NORMAL',
+        dictionaryTokenStyling: TokenStyling.TEXT,
+        dictionaryTokenStylingThickness: 1,
+        dictionaryColorizeFullyKnownTokens: false,
+        ...overrides,
+    };
+    const dictionaryTokenAnnotationConfig = cloneAnnotationConfig(track);
+    dictionaryTokenAnnotationConfig.colorizeEnabled = track.dictionaryColorizeSubtitles;
+
+    for (const target of [dictionaryTokenAnnotationConfig.video, dictionaryTokenAnnotationConfig.subtitlePlayer]) {
+        target.color.onHoverEnabled = track.dictionaryColorizeOnHoverOnly;
+        target.reading.onHoverEnabled = track.dictionaryColorizeOnHoverOnly;
+        target.frequency.onHoverEnabled = track.dictionaryColorizeOnHoverOnly;
+    }
+
+    for (const [status, config] of dictionaryTokenAnnotationConfig.onStatuses.entries()) {
+        config.reading =
+            track.dictionaryTokenReadingAnnotation === TokenReadingAnnotation.ALWAYS ||
+            (track.dictionaryTokenReadingAnnotation === TokenReadingAnnotation.LEARNING_OR_BELOW &&
+                status <= TokenStatus.LEARNING) ||
+            (track.dictionaryTokenReadingAnnotation === TokenReadingAnnotation.UNKNOWN_OR_BELOW &&
+                status <= TokenStatus.UNKNOWN);
+        config.frequency =
+            track.dictionaryTokenFrequencyAnnotation === TokenFrequencyAnnotation.ALWAYS ||
+            (track.dictionaryTokenFrequencyAnnotation === TokenFrequencyAnnotation.UNCOLLECTED_ONLY &&
+                status === TokenStatus.UNCOLLECTED);
+    }
+    dictionaryTokenAnnotationConfig.onStates[TokenState.IGNORED].reading =
+        track.dictionaryDisplayIgnoredTokenReadings ||
+        dictionaryTokenAnnotationConfig.onStates[TokenState.IGNORED].reading;
+
+    return { ...track, dictionaryTokenAnnotationConfig };
+};
+
+export const makeSettings = (dictionaryTracks: DictionaryTrack[]): AsbplayerSettings => ({
+    ...defaultSettings,
+    dictionaryTracks,
+});
+
+export const makeModifiedCard = (overrides: Record<string, unknown> = {}) => {
+    const deckName = (overrides.deckName as string | undefined) ?? 'Japanese';
+    const data = {
+        deckName,
+        modelName: 'Model',
+        due: 0,
+        ...((overrides.data as Record<string, unknown> | undefined) ?? {}),
+    };
+
+    return {
+        noteId: 10,
+        deckName,
+        fields: new Map<string, string>([['Word', 'alpha']]),
+        modifiedAt: 100,
+        statuses: new Map<number, TokenStatus>([[track, TokenStatus.UNKNOWN]]),
+        suspended: false,
+        ...overrides,
+        data,
+    };
+};
+
+export const makeNoteInfo = (overrides: Record<string, unknown> = {}) => ({
+    noteId: 10,
+    profile: 'User',
+    modelName: 'Model',
+    tags: [],
+    fields: {
+        Word: { value: ' alpha ', order: 0 },
+    },
+    mod: 100,
+    cards: [1],
+    ...overrides,
+});
+
+export const makeMetaRecord = (overrides: Record<string, unknown> = {}) => ({
+    profile,
+    track,
+    ankiMeta: {
+        lastBuildStartedAt: 0,
+        lastBuildExpiresAt: 0,
+        buildId: null,
+        settings: null,
+    },
+    waniKaniMeta: {
+        lastBuildStartedAt: 0,
+        lastBuildExpiresAt: 0,
+        buildId: null,
+        settings: null,
+        dataUpdatedAt: {},
+        spacedRepetitionSystems: [],
+    },
+    ...overrides,
+});
+
+export const makeWaniKaniSubjectRecord = (
+    overrides: Partial<DictionaryWaniKaniSubjectRecord> = {}
+): DictionaryWaniKaniSubjectRecord => ({
+    profile,
+    track,
+    subjectId: 1,
+    data: {
+        characters: '単語',
+        hidden_at: null,
+        level: 1,
+        spaced_repetition_system_id: 1,
+    },
+    ...overrides,
+});
+
+export const makeWaniKaniAssignmentRecord = (
+    overrides: Partial<DictionaryWaniKaniAssignmentRecord> = {}
+): DictionaryWaniKaniAssignmentRecord => ({
+    profile,
+    track,
+    assignmentId: 1,
+    subjectId: 1,
+    data: {
+        srs_stage: 1,
+        hidden: false,
+        available_at: null,
+    },
+    ...overrides,
+});
+
+export const makeWaniKaniSpacedRepetitionSystem = (
+    overrides: Partial<WaniKaniSpacedRepetitionSystem> = {}
+): WaniKaniSpacedRepetitionSystem => ({
+    id: 1,
+    object: 'spaced_repetition_system',
+    url: 'https://api.wanikani.com/v2/spaced_repetition_systems/1',
+    data_updated_at: '2024-01-01T00:00:00.000000Z',
+    data: {
+        created_at: '2024-01-01T00:00:00.000000Z',
+        name: 'Default',
+        description: 'Default',
+        unlocking_stage_position: 0,
+        starting_stage_position: 1,
+        passing_stage_position: 5,
+        burning_stage_position: 9,
+        stages: [],
+    },
+    ...overrides,
+});
+
+export const privateDb = (dictionaryDB: DictionaryDB) => (dictionaryDB as any).db;

--- a/common/dictionary-db/dictionary-db-wanikani.test.ts
+++ b/common/dictionary-db/dictionary-db-wanikani.test.ts
@@ -1,0 +1,1091 @@
+import 'core-js/stable/structured-clone';
+import 'fake-indexeddb/auto';
+import { Dexie } from 'dexie';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { DictionaryBuildWaniKaniCacheStateErrorCode, DictionaryBuildWaniKaniCacheStateType } from '@project/common';
+import { AsbplayerSettings, DictionaryTokenSource, TokenState, TokenStatus } from '@project/common/settings';
+
+const mockWaniKaniInstances: any[] = [];
+const mockWaniKaniOverrides: any[] = [];
+const mockYomitanInstances: any[] = [];
+const mockYomitanOverrides: any[] = [];
+
+jest.mock('uuid', () => ({ v4: () => 'test-build-id' }));
+jest.mock('@project/common/wanikani', () => {
+    class WaniKaniApiError extends Error {
+        readonly status: number;
+        readonly code?: number;
+
+        constructor(status: number, message: string, code?: number) {
+            super(message);
+            this.name = 'WaniKaniApiError';
+            this.status = status;
+            this.code = code;
+        }
+    }
+
+    return {
+        WaniKaniApiError,
+        WaniKani: jest.fn().mockImplementation((apiToken) => {
+            const instance = {
+                apiToken,
+                resets: jest.fn(async () => ({ data: [], dataUpdatedAt: null, totalCount: 0 })),
+                spacedRepetitionSystems: jest.fn(async () => ({ data: [], dataUpdatedAt: null, totalCount: 0 })),
+                assignments: jest.fn(async () => ({ data: [], dataUpdatedAt: null, totalCount: 0 })),
+                subjects: jest.fn(async () => ({ data: [], dataUpdatedAt: null, totalCount: 0 })),
+            };
+            Object.assign(instance, mockWaniKaniOverrides.shift());
+            mockWaniKaniInstances.push(instance);
+            return instance;
+        }),
+    };
+});
+jest.mock('@project/common/yomitan/yomitan', () => ({
+    Yomitan: jest.fn().mockImplementation((dt) => {
+        const instance = {
+            dt,
+            version: jest.fn<() => Promise<string>>().mockResolvedValue('26.4.6'),
+            tokenizeBulk: jest.fn<(texts: string[]) => Promise<unknown>>().mockResolvedValue(undefined),
+            tokenize: jest.fn<(text: string) => Promise<{ text: string }[][]>>((text) => Promise.resolve([[{ text }]])),
+            verifyTokenizeResult: jest.fn(),
+            lemmatize: jest.fn<(token: string) => Promise<string[] | undefined>>((token) => Promise.resolve([token])),
+            resetCache: jest.fn(),
+        };
+        Object.assign(instance, mockYomitanOverrides.shift());
+        mockYomitanInstances.push(instance);
+        return instance;
+    }),
+}));
+
+import { WaniKaniApiError, type WaniKaniAssignment, type WaniKaniSubject } from '@project/common/wanikani';
+import {
+    DictionaryDB,
+    _buildIdHealthCheck,
+    _clearBuildIds,
+    _ensureBuildId,
+    _gatherModifiedTokensForTrack,
+    _getFromSourceBulk,
+    _saveRecordBulk,
+} from './dictionary-db';
+import {
+    _buildWaniKaniTokensForTrack,
+    _deleteWaniKaniResourcesForTracks,
+    _deleteWaniKaniTokensForTracks,
+    _mergeWaniKaniSpaceRepetitionSystems,
+    _processWaniKaniTracks,
+    _saveWaniKaniTokenBatchForDB,
+    _updateBuildWaniKaniCacheProgress,
+    _waniKaniAssignmentRecord,
+    _waniKaniSubjectRecord,
+} from './dictionary-db-wanikani';
+import {
+    makeAnkiCardRecord,
+    makeDictionaryTrack,
+    makeMetaRecord,
+    makeSettings,
+    makeTokenRecord,
+    makeWaniKaniAssignmentRecord,
+    makeWaniKaniSpacedRepetitionSystem,
+    makeWaniKaniSubjectRecord,
+    otherProfile,
+    otherTrack,
+    privateDb,
+    profile,
+    tokenKey,
+    track,
+} from './dictionary-db-test-utils';
+
+const collection = <T>(data: T[], dataUpdatedAt = '2024-01-01T00:00:00.000000Z') => ({
+    data,
+    dataUpdatedAt,
+    totalCount: data.length,
+});
+
+const emptyCollection = <T>(dataUpdatedAt: string | null = null) => ({
+    data: [] as T[],
+    dataUpdatedAt,
+    totalCount: 0,
+});
+
+const waniKaniSettingsString = (dt: ReturnType<typeof makeDictionaryTrack>) =>
+    JSON.stringify({
+        dictionaryYomitanUrl: dt.dictionaryYomitanUrl,
+        dictionaryYomitanParser: dt.dictionaryYomitanParser,
+        dictionaryYomitanScanLength: dt.dictionaryYomitanScanLength,
+        dictionaryWaniKaniApiToken: dt.dictionaryWaniKaniApiToken.trim(),
+    });
+
+const makeWaniKaniAssignment = (overrides: Partial<WaniKaniAssignment> = {}): WaniKaniAssignment => ({
+    id: 1,
+    object: 'assignment',
+    url: 'https://api.wanikani.com/v2/assignments/1',
+    data_updated_at: '2024-01-01T00:00:00.000000Z',
+    data: {
+        subject_id: 1,
+        subject_type: 'vocabulary',
+        srs_stage: 5,
+        hidden: false,
+        available_at: '2024-02-01T00:00:00.000000Z',
+    },
+    ...overrides,
+});
+
+const makeWaniKaniSubject = (overrides: Partial<WaniKaniSubject> = {}): WaniKaniSubject => ({
+    id: 1,
+    object: 'vocabulary',
+    url: 'https://api.wanikani.com/v2/subjects/1',
+    data_updated_at: '2024-01-01T00:00:00.000000Z',
+    data: {
+        characters: '単語',
+        level: 3,
+        hidden_at: null,
+        spaced_repetition_system_id: 1,
+    },
+    ...overrides,
+});
+
+describe('DictionaryDB WaniKani cache', () => {
+    let dictionaryDB: DictionaryDB;
+    let settings: AsbplayerSettings;
+
+    const useSettings = (dictionaryTracks = [makeDictionaryTrack()]) => {
+        settings = makeSettings(dictionaryTracks);
+        return settings;
+    };
+
+    const installHelperAdapters = () => {
+        const db = privateDb(dictionaryDB);
+        Object.assign(dictionaryDB as any, {
+            _buildIdHealthCheck: (buildId: string, activeTracks: [string, number][]) =>
+                _buildIdHealthCheck(db, buildId, 'waniKani', activeTracks),
+            _buildWaniKaniTokensForTrack: (
+                ...args: Parameters<typeof _buildWaniKaniTokensForTrack> extends [any, ...infer Rest] ? Rest : never
+            ) => _buildWaniKaniTokensForTrack(db, ...args),
+            _clearBuildId: (key: [string, number], buildId: string) => _clearBuildIds(db, [key], buildId, 'waniKani'),
+            _clearBuildIds: (activeTracks: [string, number][], buildId: string) =>
+                _clearBuildIds(db, activeTracks, buildId, 'waniKani'),
+            _deleteWaniKaniResourcesForTracks: (profile: string, tracks: Iterable<number>) =>
+                _deleteWaniKaniResourcesForTracks(db, profile, tracks),
+            _deleteWaniKaniTokensForTracks: (
+                profile: string,
+                tracks: Iterable<number>,
+                modifiedTokensByTrack: Map<number, Set<string>>
+            ) => _deleteWaniKaniTokensForTracks(db, profile, tracks, modifiedTokensByTrack),
+            _ensureBuildId: (key: [string, number], buildId: string, options: { buildTs: number }) =>
+                _ensureBuildId(db, key, buildId, 'waniKani', { mode: 'claim', buildTs: options.buildTs }),
+            _gatherModifiedTokensForTrack: (profile: string, track: number, modifiedTokens: Set<string>) =>
+                _gatherModifiedTokensForTrack(db, profile, track, modifiedTokens),
+            _getFromSourceBulk: (profile: string, track: number, source: DictionaryTokenSource, tokens: string[]) =>
+                _getFromSourceBulk(db, profile, track, source, tokens),
+            _processWaniKaniTracks: (
+                ...args: Parameters<typeof _processWaniKaniTracks> extends [any, ...infer Rest] ? Rest : never
+            ) => _processWaniKaniTracks(db, ...args),
+            _saveRecordBulk: (records: ReturnType<typeof makeTokenRecord>[]) => _saveRecordBulk(db, records),
+            _saveWaniKaniTokenBatchForDB: (
+                ...args: Parameters<typeof _saveWaniKaniTokenBatchForDB> extends [any, ...infer Rest] ? Rest : never
+            ) => _saveWaniKaniTokenBatchForDB(db, ...args),
+            _updateBuildWaniKaniCacheProgress: (
+                ...args: Parameters<typeof _updateBuildWaniKaniCacheProgress> extends [any, ...infer Rest]
+                    ? Rest
+                    : never
+            ) => _updateBuildWaniKaniCacheProgress(db, ...args),
+        });
+    };
+
+    beforeEach(async () => {
+        mockWaniKaniInstances.length = 0;
+        mockWaniKaniOverrides.length = 0;
+        mockYomitanInstances.length = 0;
+        mockYomitanOverrides.length = 0;
+        await Dexie.delete('DictionaryDatabase');
+        settings = makeSettings([makeDictionaryTrack()]);
+        dictionaryDB = new DictionaryDB({
+            getAll: jest.fn(async () => settings),
+            getSingle: jest.fn(async (key: keyof AsbplayerSettings) => settings[key]),
+        } as any);
+        installHelperAdapters();
+    });
+
+    afterEach(async () => {
+        jest.restoreAllMocks();
+        privateDb(dictionaryDB).close();
+        await Dexie.delete('DictionaryDatabase');
+    });
+
+    const seedTokens = async (...records: ReturnType<typeof makeTokenRecord>[]) => {
+        await privateDb(dictionaryDB).tokens.bulkPut(records);
+    };
+
+    const seedAnkiCards = async (...records: ReturnType<typeof makeAnkiCardRecord>[]) => {
+        await privateDb(dictionaryDB).ankiCards.bulkPut(records);
+    };
+
+    const seedWaniKaniSubjects = async (...records: ReturnType<typeof makeWaniKaniSubjectRecord>[]) => {
+        await privateDb(dictionaryDB).waniKaniSubjects.bulkPut(records);
+    };
+
+    const seedWaniKaniAssignments = async (...records: ReturnType<typeof makeWaniKaniAssignmentRecord>[]) => {
+        await privateDb(dictionaryDB).waniKaniAssignments.bulkPut(records);
+    };
+
+    const waitForWaniKaniBuildToFinish = async (key: [string, number] = [profile, track]) => {
+        for (let i = 0; i < 20; i++) {
+            const meta = await privateDb(dictionaryDB).meta.get(key);
+            if (meta?.waniKaniMeta.buildId === null) return;
+            await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        }
+        throw new Error('Timed out waiting for WaniKani build to finish');
+    };
+
+    const makeYomitan = (overrides: Record<string, unknown> = {}) => ({
+        tokenizeBulk: jest.fn<(texts: string[]) => Promise<unknown>>().mockResolvedValue(undefined),
+        tokenize: jest.fn<(text: string) => Promise<{ text: string }[][]>>((text) => Promise.resolve([[{ text }]])),
+        verifyTokenizeResult: jest.fn(),
+        lemmatize: jest.fn<(token: string) => Promise<string[] | undefined>>((token) =>
+            Promise.resolve([`${token}-lemma`])
+        ),
+        resetCache: jest.fn(),
+        ...overrides,
+    });
+
+    const makeWaniKaniTrackState = (overrides: Record<string, unknown> = {}) => ({
+        dt: makeDictionaryTrack({ dictionaryColorizeSubtitles: true, dictionaryWaniKaniApiToken: 'wk-token' }),
+        yomitan: makeYomitan(),
+        assignmentsToPut: [],
+        subjectsToPut: [],
+        spacedRepetitionSystems: [],
+        numFetchedAssignments: 0,
+        numFetchedSubjects: 0,
+        affectedSubjectIds: new Set<number>(),
+        clearTokens: false,
+        clearResources: false,
+        settings: 'settings',
+        dataUpdatedAt: {},
+        ...overrides,
+    });
+
+    it('merges WaniKani SRS metadata and maps API records to DB records', () => {
+        const srs = (id: number, name: string) => {
+            const base = makeWaniKaniSpacedRepetitionSystem({ id });
+            return { ...base, data: { ...base.data, name } };
+        };
+
+        expect(
+            _mergeWaniKaniSpaceRepetitionSystems([srs(2, 'old two'), srs(1, 'one')], [srs(2, 'two'), srs(3, 'three')])
+        ).toMatchObject([
+            { id: 1, data: { name: 'one' } },
+            { id: 2, data: { name: 'two' } },
+            { id: 3, data: { name: 'three' } },
+        ]);
+
+        expect(
+            _waniKaniAssignmentRecord(
+                profile,
+                track,
+                makeWaniKaniAssignment({
+                    id: 7,
+                    data: {
+                        ...makeWaniKaniAssignment().data,
+                        subject_id: 9,
+                        srs_stage: 8,
+                        hidden: true,
+                        available_at: null,
+                    },
+                })
+            )
+        ).toEqual({
+            profile,
+            track,
+            assignmentId: 7,
+            subjectId: 9,
+            data: { srs_stage: 8, hidden: true, available_at: null },
+        });
+        expect(
+            _waniKaniSubjectRecord(
+                profile,
+                track,
+                makeWaniKaniSubject({
+                    id: 9,
+                    data: {
+                        characters: '仮名',
+                        level: 12,
+                        hidden_at: '2024-03-01T00:00:00.000000Z',
+                        spaced_repetition_system_id: 2,
+                    },
+                })
+            )
+        ).toEqual({
+            profile,
+            track,
+            subjectId: 9,
+            data: {
+                characters: '仮名',
+                hidden_at: '2024-03-01T00:00:00.000000Z',
+                level: 12,
+                spaced_repetition_system_id: 2,
+            },
+        });
+    });
+
+    it('manages WaniKani build IDs, health checks, clearing, and progress expiration', async () => {
+        const key: [string, number] = [profile, track];
+        const statusUpdates = jest.fn();
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const dateNow = jest.spyOn(Date, 'now').mockReturnValue(2000);
+
+        await expect((dictionaryDB as any)._ensureBuildId(key, 'build-1', { buildTs: 1000 })).resolves.toBe(true);
+        await expect((dictionaryDB as any)._ensureBuildId(key, 'build-2', { buildTs: 2000 })).resolves.toBe(false);
+        await expect((dictionaryDB as any)._buildIdHealthCheck('build-1', [key])).resolves.toBeUndefined();
+        await expect((dictionaryDB as any)._buildIdHealthCheck('build-2', [key])).rejects.toThrow(
+            'WaniKani buildId was corrupted for track 1'
+        );
+        await expect((dictionaryDB as any)._ensureBuildId(key, 'build-2', { buildTs: 302000 })).resolves.toBe(true);
+        expect(consoleWarn).toHaveBeenCalledTimes(1);
+
+        await (dictionaryDB as any)._updateBuildWaniKaniCacheProgress(
+            'build-2',
+            [key],
+            track,
+            { current: 1, total: 3, startedAt: 1000 },
+            ['alpha'],
+            statusUpdates
+        );
+        await expect(privateDb(dictionaryDB).meta.get(key)).resolves.toMatchObject({
+            waniKaniMeta: {
+                buildId: 'build-2',
+                lastBuildExpiresAt: 302000,
+            },
+        });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildWaniKaniCacheStateType.progress,
+            body: { track, current: 1, total: 3, buildTimestamp: 1000, modifiedTokens: ['alpha'] },
+        });
+
+        await (dictionaryDB as any)._clearBuildId(key, 'wrong-build');
+        await expect(privateDb(dictionaryDB).meta.get(key)).resolves.toMatchObject({
+            waniKaniMeta: { buildId: 'build-2' },
+        });
+        await (dictionaryDB as any)._clearBuildIds([key], 'build-2');
+        await expect(privateDb(dictionaryDB).meta.get(key)).resolves.toMatchObject({
+            waniKaniMeta: { buildId: null },
+        });
+        dateNow.mockRestore();
+    });
+
+    it('clears WaniKani tokens and resources by profile and track while recording modified lemmas', async () => {
+        const modifiedTokensByTrack = new Map<number, Set<string>>();
+        await seedTokens(
+            makeTokenRecord({
+                token: 'cached',
+                track,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['cached-lemma'],
+                states: [TokenState.IGNORED],
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'anki',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['anki-lemma'],
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'other-track',
+                track: otherTrack,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['other-track-lemma'],
+                cardIds: [2],
+            }),
+            makeTokenRecord({
+                token: 'other-profile',
+                profile: otherProfile,
+                track,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['other-profile-lemma'],
+                cardIds: [3],
+            })
+        );
+        await seedWaniKaniSubjects(
+            makeWaniKaniSubjectRecord({ subjectId: 1 }),
+            makeWaniKaniSubjectRecord({ subjectId: 2, track: otherTrack }),
+            makeWaniKaniSubjectRecord({ subjectId: 3, profile: otherProfile })
+        );
+        await seedWaniKaniAssignments(
+            makeWaniKaniAssignmentRecord({ assignmentId: 1, subjectId: 1 }),
+            makeWaniKaniAssignmentRecord({ assignmentId: 2, subjectId: 2, track: otherTrack }),
+            makeWaniKaniAssignmentRecord({ assignmentId: 3, subjectId: 3, profile: otherProfile })
+        );
+
+        await (dictionaryDB as any)._deleteWaniKaniTokensForTracks(profile, [track], modifiedTokensByTrack);
+        await (dictionaryDB as any)._deleteWaniKaniResourcesForTracks(profile, [track]);
+
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('cached', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toBeUndefined();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('anki', DictionaryTokenSource.ANKI_WORD, track))
+        ).resolves.toBeDefined();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('other-track', DictionaryTokenSource.WANIKANI, otherTrack))
+        ).resolves.toBeDefined();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(
+                tokenKey('other-profile', DictionaryTokenSource.WANIKANI, track, otherProfile)
+            )
+        ).resolves.toBeDefined();
+        await expect(privateDb(dictionaryDB).waniKaniSubjects.get([1, track, profile])).resolves.toBeUndefined();
+        await expect(privateDb(dictionaryDB).waniKaniAssignments.get([1, track, profile])).resolves.toBeUndefined();
+        await expect(privateDb(dictionaryDB).waniKaniSubjects.get([2, otherTrack, profile])).resolves.toBeDefined();
+        await expect(privateDb(dictionaryDB).waniKaniSubjects.get([3, track, otherProfile])).resolves.toBeDefined();
+        expect(modifiedTokensByTrack).toEqual(new Map([[track, new Set(['cached', 'cached-lemma'])]]));
+    });
+
+    it('saves WaniKani token batches with subject, status, and state invariants', async () => {
+        const key: [string, number] = [profile, track];
+        const modifiedTokens = new Set<string>();
+        const staleRecord = makeTokenRecord({
+            token: 'stale',
+            track,
+            source: DictionaryTokenSource.WANIKANI,
+            status: null,
+            lemmas: ['stale-lemma'],
+            cardIds: [1],
+        });
+        await (dictionaryDB as any)._ensureBuildId(key, 'build', { buildTs: 1000 });
+        await seedTokens(staleRecord);
+
+        await (dictionaryDB as any)._saveWaniKaniTokenBatchForDB(
+            profile,
+            track,
+            [staleRecord],
+            [
+                makeTokenRecord({
+                    token: 'valid',
+                    track,
+                    source: DictionaryTokenSource.WANIKANI,
+                    status: TokenStatus.MATURE,
+                    lemmas: ['valid-lemma'],
+                    states: [TokenState.IGNORED],
+                    cardIds: [2],
+                }),
+                makeTokenRecord({
+                    token: 'empty',
+                    track,
+                    source: DictionaryTokenSource.WANIKANI,
+                    status: TokenStatus.MATURE,
+                    lemmas: ['empty-lemma'],
+                    states: [TokenState.IGNORED],
+                    cardIds: [],
+                }),
+            ],
+            'build',
+            [key],
+            modifiedTokens
+        );
+
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('valid', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toMatchObject({
+            status: null,
+            states: [],
+            cardIds: [2],
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('empty', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toBeUndefined();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('stale', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toBeUndefined();
+        expect(modifiedTokens).toEqual(
+            new Set(['valid', 'valid-lemma', 'empty', 'empty-lemma', 'stale', 'stale-lemma'])
+        );
+    });
+
+    it('returns without tokenization or progress when no WaniKani subjects are affected', async () => {
+        const yomitan = makeYomitan();
+        const statusUpdates = jest.fn();
+
+        await expect(
+            (dictionaryDB as any)._buildWaniKaniTokensForTrack(
+                profile,
+                track,
+                makeWaniKaniTrackState({ affectedSubjectIds: new Set<number>(), yomitan }),
+                'build',
+                [[profile, track]],
+                { current: 0, total: 0, startedAt: 1000 },
+                new Set<string>(),
+                statusUpdates
+            )
+        ).resolves.toEqual(new Set());
+
+        expect(yomitan.tokenizeBulk).not.toHaveBeenCalled();
+        expect(yomitan.tokenize).not.toHaveBeenCalled();
+        expect(yomitan.resetCache).not.toHaveBeenCalled();
+        expect(statusUpdates).not.toHaveBeenCalled();
+    });
+
+    it('builds WaniKani tokens in batches while preserving surviving subject IDs and deleting stale links', async () => {
+        const key: [string, number] = [profile, track];
+        const subjectIds = Array.from({ length: 101 }, (_, index) => index + 1);
+        const lemmatize = jest.fn<(token: string) => Promise<string[]>>((token) =>
+            Promise.resolve(token === 'word3' ? [] : [`${token}-lemma`])
+        );
+        const yomitan = makeYomitan({ lemmatize });
+        const statusUpdates = jest.fn();
+        const modifiedTokens = new Set<string>();
+
+        await (dictionaryDB as any)._ensureBuildId(key, 'build', { buildTs: 1000 });
+        await seedWaniKaniSubjects(
+            ...subjectIds.map((subjectId) =>
+                makeWaniKaniSubjectRecord({
+                    subjectId,
+                    data: {
+                        characters: `word${subjectId}`,
+                        hidden_at: subjectId === 4 ? '2024-03-01T00:00:00.000000Z' : null,
+                        level: 1,
+                        spaced_repetition_system_id: 1,
+                    },
+                })
+            )
+        );
+        await seedTokens(
+            makeTokenRecord({
+                token: 'word1',
+                track,
+                source: DictionaryTokenSource.WANIKANI,
+                status: TokenStatus.MATURE,
+                lemmas: ['old-word1'],
+                states: [TokenState.IGNORED],
+                cardIds: [1, 200],
+            }),
+            makeTokenRecord({
+                token: 'stale',
+                track,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['stale-lemma'],
+                cardIds: [2],
+            }),
+            makeTokenRecord({
+                token: 'other-profile-retain',
+                profile: otherProfile,
+                track,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['other-profile-retain-lemma'],
+                cardIds: [2],
+            }),
+            makeTokenRecord({
+                token: 'other-track-retain',
+                track: otherTrack,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['other-track-retain-lemma'],
+                cardIds: [2],
+            }),
+            makeTokenRecord({
+                token: 'local-retain',
+                track,
+                source: DictionaryTokenSource.LOCAL,
+                status: TokenStatus.UNKNOWN,
+                lemmas: ['local-retain-lemma'],
+                cardIds: [2],
+            })
+        );
+
+        const importedTokens = await (dictionaryDB as any)._buildWaniKaniTokensForTrack(
+            profile,
+            track,
+            makeWaniKaniTrackState({ affectedSubjectIds: new Set(subjectIds), yomitan }),
+            'build',
+            [key],
+            { current: 0, total: subjectIds.length, startedAt: 1000 },
+            modifiedTokens,
+            statusUpdates
+        );
+
+        expect(yomitan.tokenizeBulk.mock.calls.map(([texts]) => texts.length)).toEqual([99, 1]);
+        expect(yomitan.tokenize).toHaveBeenCalledTimes(100);
+        expect(lemmatize).toHaveBeenCalledWith('word3');
+        expect(yomitan.resetCache).toHaveBeenCalledTimes(2);
+        expect(importedTokens.size).toBe(99);
+        expect(importedTokens.has('word1')).toBe(true);
+        expect(importedTokens.has('word3')).toBe(false);
+        expect(importedTokens.has('word4')).toBe(false);
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('word1', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toMatchObject({
+            status: null,
+            states: [],
+            lemmas: ['word1-lemma'],
+            cardIds: [1, 200],
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('stale', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toBeUndefined();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('word3', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toBeUndefined();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('word4', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toBeUndefined();
+        await expect(
+            privateDb(dictionaryDB).tokens.get(
+                tokenKey('other-profile-retain', DictionaryTokenSource.WANIKANI, track, otherProfile)
+            )
+        ).resolves.toMatchObject({
+            cardIds: [2],
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(
+                tokenKey('other-track-retain', DictionaryTokenSource.WANIKANI, otherTrack)
+            )
+        ).resolves.toMatchObject({
+            cardIds: [2],
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('local-retain', DictionaryTokenSource.LOCAL, track))
+        ).resolves.toMatchObject({
+            cardIds: [2],
+        });
+        expect(statusUpdates.mock.calls.map(([state]) => (state as any).body.current)).toEqual([100, 101]);
+        expect(Array.from(modifiedTokens)).toEqual(
+            expect.arrayContaining(['word1', 'old-word1', 'word1-lemma', 'stale', 'stale-lemma'])
+        );
+    });
+
+    it('processes WaniKani tracks, saves metadata, clears build IDs, and publishes final stats', async () => {
+        const key: [string, number] = [profile, track];
+        const statusUpdates = jest.fn();
+        await (dictionaryDB as any)._ensureBuildId(key, 'build', { buildTs: 1000 });
+        await seedWaniKaniSubjects(
+            makeWaniKaniSubjectRecord({ data: { ...makeWaniKaniSubjectRecord().data, characters: 'alpha' } })
+        );
+
+        await (dictionaryDB as any)._processWaniKaniTracks(
+            profile,
+            'build',
+            new Map([
+                [
+                    track,
+                    makeWaniKaniTrackState({
+                        affectedSubjectIds: new Set([1]),
+                        settings: 'settings-v2',
+                        dataUpdatedAt: { subjects: 'new-subjects' },
+                        numFetchedSubjects: 1,
+                    }),
+                ],
+            ]),
+            [{ track, numFetchedSubjects: 1 }],
+            new Map(),
+            [key],
+            1000,
+            statusUpdates
+        );
+
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('alpha', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toMatchObject({
+            lemmas: ['alpha-lemma'],
+            cardIds: [1],
+        });
+        await expect(privateDb(dictionaryDB).meta.get(key)).resolves.toMatchObject({
+            waniKaniMeta: {
+                buildId: null,
+                settings: 'settings-v2',
+                dataUpdatedAt: { subjects: 'new-subjects' },
+            },
+        });
+        expect(statusUpdates).toHaveBeenLastCalledWith({
+            type: DictionaryBuildWaniKaniCacheStateType.stats,
+            body: expect.objectContaining({
+                track,
+                numFetchedSubjects: 1,
+                numImportedTokens: 1,
+                modifiedTokens: expect.arrayContaining(['alpha', 'alpha-lemma']),
+            }),
+        });
+    });
+
+    it('builds WaniKani tokens and resolves statuses from subjects and assignments', async () => {
+        const statusUpdates = jest.fn();
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryWaniKaniApiToken: 'wk-token',
+        });
+        mockWaniKaniOverrides.push({
+            spacedRepetitionSystems: jest.fn(async () => collection([makeWaniKaniSpacedRepetitionSystem()])),
+            assignments: jest.fn(async () => collection([makeWaniKaniAssignment()])),
+            subjects: jest.fn(async () => collection([makeWaniKaniSubject()])),
+        });
+
+        useSettings([dictionaryTrack]);
+        await dictionaryDB.buildWaniKaniCache(profile, statusUpdates);
+        await waitForWaniKaniBuildToFinish();
+
+        expect(mockWaniKaniInstances).toHaveLength(1);
+        expect(mockWaniKaniInstances[0].apiToken).toBe('wk-token');
+        expect(mockYomitanInstances[0].tokenizeBulk).toHaveBeenCalledWith(['単語']);
+        await expect(dictionaryDB.getBulk(profile, track, ['単語'])).resolves.toMatchObject({
+            単語: {
+                source: DictionaryTokenSource.WANIKANI,
+                statuses: [
+                    {
+                        status: TokenStatus.GRADUATED,
+                        suspended: false,
+                        waniKani: {
+                            subjectId: 1,
+                            subjectLevel: 3,
+                            assignmentId: 1,
+                            availableAt: '2024-02-01T00:00:00.000000Z',
+                        },
+                    },
+                ],
+                states: [],
+            },
+        });
+        await expect(dictionaryDB.getRecords(profile, track)).resolves.toMatchObject({
+            waniKaniSubjectRecords: { [track]: { 1: expect.objectContaining({ subjectId: 1 }) } },
+            waniKaniAssignmentRecords: {
+                [track]: { 1: expect.objectContaining({ assignmentId: 1, status: TokenStatus.GRADUATED }) },
+            },
+        });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildWaniKaniCacheStateType.stats,
+            body: expect.objectContaining({
+                track,
+                numFetchedAssignments: 1,
+                numFetchedSubjects: 1,
+                numImportedTokens: 1,
+                modifiedTokens: ['単語'],
+            }),
+        });
+    });
+
+    it('clears WaniKani cache records when an enabled track has no API token', async () => {
+        const statusUpdates = jest.fn();
+        await seedTokens(
+            makeTokenRecord({
+                token: 'cached',
+                track,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['cached-lemma'],
+                cardIds: [1],
+            })
+        );
+        await seedWaniKaniSubjects(makeWaniKaniSubjectRecord());
+        await seedWaniKaniAssignments(makeWaniKaniAssignmentRecord());
+        await privateDb(dictionaryDB).meta.put(
+            makeMetaRecord({
+                waniKaniMeta: {
+                    lastBuildStartedAt: 1,
+                    lastBuildExpiresAt: 2,
+                    buildId: null,
+                    settings: 'settings',
+                    dataUpdatedAt: { assignments: 'old' },
+                    spacedRepetitionSystems: [makeWaniKaniSpacedRepetitionSystem()],
+                },
+            })
+        );
+
+        useSettings([makeDictionaryTrack({ dictionaryColorizeSubtitles: true, dictionaryWaniKaniApiToken: '' })]);
+        await dictionaryDB.buildWaniKaniCache(profile, statusUpdates);
+
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('cached', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toBeUndefined();
+        await expect(privateDb(dictionaryDB).waniKaniSubjects.count()).resolves.toBe(0);
+        await expect(privateDb(dictionaryDB).waniKaniAssignments.count()).resolves.toBe(0);
+        await expect(privateDb(dictionaryDB).meta.get([profile, track])).resolves.toMatchObject({
+            waniKaniMeta: { buildId: null, settings: null, dataUpdatedAt: {}, spacedRepetitionSystems: [] },
+        });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildWaniKaniCacheStateType.stats,
+            body: expect.objectContaining({
+                track,
+                isTokensCleared: true,
+                modifiedTokens: expect.arrayContaining(['cached', 'cached-lemma']),
+            }),
+        });
+    });
+
+    it('uses incremental timestamps and removes stale WaniKani token links for hidden subjects', async () => {
+        const statusUpdates = jest.fn();
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryWaniKaniApiToken: ' wk-token ',
+        });
+        await seedTokens(
+            makeTokenRecord({
+                token: 'stale',
+                track,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['stale-lemma'],
+                cardIds: [1],
+            })
+        );
+        await seedWaniKaniSubjects(makeWaniKaniSubjectRecord());
+        await seedWaniKaniAssignments(makeWaniKaniAssignmentRecord());
+        await privateDb(dictionaryDB).meta.put(
+            makeMetaRecord({
+                waniKaniMeta: {
+                    lastBuildStartedAt: 0,
+                    lastBuildExpiresAt: 0,
+                    buildId: null,
+                    settings: waniKaniSettingsString(dictionaryTrack),
+                    dataUpdatedAt: {
+                        resets: 'old-resets',
+                        assignments: 'old-assignments',
+                        subjects: 'old-subjects',
+                        spacedRepetitionSystems: 'old-srs',
+                    },
+                    spacedRepetitionSystems: [makeWaniKaniSpacedRepetitionSystem()],
+                },
+            })
+        );
+        mockWaniKaniOverrides.push({
+            resets: jest.fn(async () => emptyCollection('new-resets')),
+            spacedRepetitionSystems: jest.fn(async () => emptyCollection('new-srs')),
+            assignments: jest.fn(async () => emptyCollection('new-assignments')),
+            subjects: jest.fn(async () =>
+                collection([
+                    makeWaniKaniSubject({
+                        data: {
+                            characters: 'stale',
+                            level: 3,
+                            hidden_at: '2024-02-01T00:00:00.000000Z',
+                            spaced_repetition_system_id: 1,
+                        },
+                    }),
+                ])
+            ),
+        });
+
+        useSettings([dictionaryTrack]);
+        await dictionaryDB.buildWaniKaniCache(profile, statusUpdates);
+        await waitForWaniKaniBuildToFinish();
+
+        expect(mockWaniKaniInstances[0].apiToken).toBe('wk-token');
+        expect(mockWaniKaniInstances[0].resets).toHaveBeenCalledWith({ updatedAfter: 'old-resets' });
+        expect(mockWaniKaniInstances[0].spacedRepetitionSystems).toHaveBeenCalledWith({ updatedAfter: 'old-srs' });
+        expect(mockWaniKaniInstances[0].assignments).toHaveBeenCalledWith({
+            subjectTypes: ['vocabulary', 'kana_vocabulary'],
+            updatedAfter: 'old-assignments',
+        });
+        expect(mockWaniKaniInstances[0].subjects).toHaveBeenCalledWith({
+            types: ['vocabulary', 'kana_vocabulary'],
+            updatedAfter: 'old-subjects',
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('stale', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toBeUndefined();
+        await expect(privateDb(dictionaryDB).meta.get([profile, track])).resolves.toMatchObject({
+            waniKaniMeta: {
+                settings: waniKaniSettingsString(dictionaryTrack),
+                dataUpdatedAt: {
+                    resets: 'new-resets',
+                    assignments: 'new-assignments',
+                    subjects: '2024-01-01T00:00:00.000000Z',
+                    spacedRepetitionSystems: 'new-srs',
+                },
+            },
+        });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildWaniKaniCacheStateType.stats,
+            body: expect.objectContaining({
+                track,
+                numImportedTokens: 0,
+                modifiedTokens: expect.arrayContaining(['stale', 'stale-lemma']),
+            }),
+        });
+    });
+
+    it('forces a full WaniKani resource rebuild after account resets', async () => {
+        const statusUpdates = jest.fn();
+        const dictionaryTrack = makeDictionaryTrack({
+            dictionaryColorizeSubtitles: true,
+            dictionaryWaniKaniApiToken: 'wk-token',
+        });
+        await seedTokens(
+            makeTokenRecord({
+                token: 'cached',
+                track,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['cached-lemma'],
+                cardIds: [1],
+            })
+        );
+        await seedWaniKaniSubjects(makeWaniKaniSubjectRecord());
+        await seedWaniKaniAssignments(makeWaniKaniAssignmentRecord());
+        await privateDb(dictionaryDB).meta.put(
+            makeMetaRecord({
+                waniKaniMeta: {
+                    lastBuildStartedAt: 0,
+                    lastBuildExpiresAt: 0,
+                    buildId: null,
+                    settings: waniKaniSettingsString(dictionaryTrack),
+                    dataUpdatedAt: {
+                        resets: 'old-resets',
+                        assignments: 'old-assignments',
+                        subjects: 'old-subjects',
+                        spacedRepetitionSystems: 'old-srs',
+                    },
+                    spacedRepetitionSystems: [makeWaniKaniSpacedRepetitionSystem()],
+                },
+            })
+        );
+        mockWaniKaniOverrides.push({
+            resets: jest.fn(async () => ({
+                data: [
+                    {
+                        id: 1,
+                        object: 'reset',
+                        url: 'https://api.wanikani.com/v2/resets/1',
+                        data_updated_at: '2024-01-02T00:00:00.000000Z',
+                        data: {
+                            created_at: '2024-01-02T00:00:00.000000Z',
+                            confirmed_at: null,
+                            original_level: 10,
+                            target_level: 1,
+                        },
+                    },
+                ],
+                dataUpdatedAt: 'new-resets',
+                totalCount: 1,
+            })),
+            spacedRepetitionSystems: jest.fn(async () => collection([makeWaniKaniSpacedRepetitionSystem()])),
+            assignments: jest.fn(async () => emptyCollection('new-assignments')),
+            subjects: jest.fn(async () => emptyCollection('new-subjects')),
+        });
+
+        useSettings([dictionaryTrack]);
+        await dictionaryDB.buildWaniKaniCache(profile, statusUpdates);
+        await waitForWaniKaniBuildToFinish();
+
+        expect(mockWaniKaniInstances[0].spacedRepetitionSystems).toHaveBeenCalledWith({ updatedAfter: undefined });
+        expect(mockWaniKaniInstances[0].assignments).toHaveBeenCalledWith({
+            subjectTypes: ['vocabulary', 'kana_vocabulary'],
+            updatedAfter: undefined,
+        });
+        expect(mockWaniKaniInstances[0].subjects).toHaveBeenCalledWith({
+            types: ['vocabulary', 'kana_vocabulary'],
+            updatedAfter: undefined,
+        });
+        await expect(
+            privateDb(dictionaryDB).tokens.get(tokenKey('cached', DictionaryTokenSource.WANIKANI, track))
+        ).resolves.toBeUndefined();
+        await expect(privateDb(dictionaryDB).waniKaniSubjects.count()).resolves.toBe(0);
+        await expect(privateDb(dictionaryDB).waniKaniAssignments.count()).resolves.toBe(0);
+        await expect(privateDb(dictionaryDB).meta.get([profile, track])).resolves.toMatchObject({
+            waniKaniMeta: {
+                dataUpdatedAt: {
+                    resets: 'new-resets',
+                    assignments: 'new-assignments',
+                    subjects: 'new-subjects',
+                    spacedRepetitionSystems: '2024-01-01T00:00:00.000000Z',
+                },
+            },
+        });
+    });
+
+    it('reports invalid WaniKani tokens and clears active build IDs', async () => {
+        const statusUpdates = jest.fn();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockWaniKaniOverrides.push({
+            resets: jest.fn(async () => {
+                throw new WaniKaniApiError(401, 'Unauthorized');
+            }),
+        });
+
+        useSettings([
+            makeDictionaryTrack({ dictionaryColorizeSubtitles: true, dictionaryWaniKaniApiToken: 'bad-token' }),
+        ]);
+        await dictionaryDB.buildWaniKaniCache(profile, statusUpdates);
+
+        expect(consoleError).toHaveBeenCalled();
+        await expect(privateDb(dictionaryDB).meta.get([profile, track])).resolves.toMatchObject({
+            waniKaniMeta: { buildId: null },
+        });
+        expect(statusUpdates).toHaveBeenCalledWith({
+            type: DictionaryBuildWaniKaniCacheStateType.error,
+            body: expect.objectContaining({
+                code: DictionaryBuildWaniKaniCacheStateErrorCode.invalidWaniKaniToken,
+                msg: 'Unauthorized',
+                track,
+            }),
+        });
+    });
+
+    it('prefers better-known WaniKani word records over lower-status Anki word records', async () => {
+        await seedTokens(
+            makeTokenRecord({
+                token: 'shared',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['shared'],
+                cardIds: [10],
+            }),
+            makeTokenRecord({
+                token: 'shared',
+                track,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['shared'],
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'other-profile',
+                profile: otherProfile,
+                track,
+                source: DictionaryTokenSource.WANIKANI,
+                status: null,
+                lemmas: ['other-profile'],
+                cardIds: [2],
+            })
+        );
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 10, status: TokenStatus.UNKNOWN }));
+        await seedWaniKaniSubjects(makeWaniKaniSubjectRecord());
+        await seedWaniKaniAssignments(
+            makeWaniKaniAssignmentRecord({ data: { srs_stage: 9, hidden: false, available_at: null } })
+        );
+        await privateDb(dictionaryDB).meta.put(
+            makeMetaRecord({
+                waniKaniMeta: {
+                    lastBuildStartedAt: 0,
+                    lastBuildExpiresAt: 0,
+                    buildId: null,
+                    settings: null,
+                    dataUpdatedAt: {},
+                    spacedRepetitionSystems: [makeWaniKaniSpacedRepetitionSystem()],
+                },
+            })
+        );
+
+        await expect(dictionaryDB.getBulk(profile, track, ['shared', 'other-profile'])).resolves.toMatchObject({
+            shared: {
+                source: DictionaryTokenSource.WANIKANI,
+                statuses: [
+                    {
+                        status: TokenStatus.MATURE,
+                        suspended: false,
+                        waniKani: expect.objectContaining({ subjectId: 1, assignmentId: 1 }),
+                    },
+                ],
+                externalCandidateStatuses: expect.arrayContaining([
+                    { cardId: 10, status: TokenStatus.UNKNOWN, suspended: false },
+                    expect.objectContaining({ status: TokenStatus.MATURE }),
+                ]),
+                states: [],
+            },
+        });
+    });
+});

--- a/common/dictionary-db/dictionary-db-wanikani.ts
+++ b/common/dictionary-db/dictionary-db-wanikani.ts
@@ -8,7 +8,12 @@ import {
     DictionaryBuildWaniKaniCacheStats,
     Progress,
 } from '@project/common';
-import { AsbplayerSettings, dictionaryStatusCollectionEnabled, DictionaryTokenSource } from '@project/common/settings';
+import {
+    AsbplayerSettings,
+    dictionaryStatusCollectionEnabled,
+    DictionaryTokenSource,
+    isWaniKaniSource,
+} from '@project/common/settings';
 import { HAS_LETTER_REGEX, inBatches } from '@project/common/util';
 import {
     WaniKani,
@@ -52,7 +57,7 @@ interface WaniKaniCacheSettingsDependencies {
     dictionaryWaniKaniApiToken: string;
 }
 
-interface WaniKaniTrackStateForDB extends TrackStateForDB {
+export interface WaniKaniTrackStateForDB extends TrackStateForDB {
     assignmentsToPut: DictionaryWaniKaniAssignmentRecord[];
     subjectsToPut: DictionaryWaniKaniSubjectRecord[];
     spacedRepetitionSystems: WaniKaniSpacedRepetitionSystem[];
@@ -65,7 +70,7 @@ interface WaniKaniTrackStateForDB extends TrackStateForDB {
     dataUpdatedAt: WaniKaniDataUpdatedAt;
 }
 
-interface WaniKaniTrackStats {
+export interface WaniKaniTrackStats {
     track: number;
     numFetchedAssignments?: number;
     numFetchedSubjects?: number;
@@ -73,8 +78,8 @@ interface WaniKaniTrackStats {
     isTokensCleared?: boolean;
 }
 
-type WaniKaniTrackStatesForDB = Map<number, WaniKaniTrackStateForDB>;
-type ModifiedTokensByTrack = Map<number, Set<string>>;
+export type WaniKaniTrackStatesForDB = Map<number, WaniKaniTrackStateForDB>;
+export type ModifiedTokensByTrack = Map<number, Set<string>>;
 
 function _modifiedTokensForTrack(modifiedTokensByTrack: ModifiedTokensByTrack, track: number): Set<string> {
     let modifiedTokens = modifiedTokensByTrack.get(track);
@@ -383,7 +388,7 @@ export async function buildWaniKaniCachePipeline(
     }
 }
 
-async function _deleteWaniKaniTokensForTracks(
+export async function _deleteWaniKaniTokensForTracks(
     db: _DictionaryDatabase,
     profile: string,
     tracks: Iterable<number>,
@@ -394,7 +399,7 @@ async function _deleteWaniKaniTokensForTracks(
     const existingRecords = await db.tokens
         .where('profile')
         .equals(profile)
-        .filter((record) => record.source === DictionaryTokenSource.WANIKANI && trackSet.has(record.track))
+        .filter((record) => isWaniKaniSource(record.source) && trackSet.has(record.track))
         .toArray();
     for (const record of existingRecords) {
         const modifiedTokens = _modifiedTokensForTrack(modifiedTokensByTrack, record.track);
@@ -406,7 +411,7 @@ async function _deleteWaniKaniTokensForTracks(
     );
 }
 
-async function _deleteWaniKaniResourcesForTracks(
+export async function _deleteWaniKaniResourcesForTracks(
     db: _DictionaryDatabase,
     profile: string,
     tracks: Iterable<number>
@@ -426,7 +431,7 @@ async function _deleteWaniKaniResourcesForTracks(
     await Promise.all([db.waniKaniSubjects.bulkDelete(subjectKeys), db.waniKaniAssignments.bulkDelete(assignmentKeys)]);
 }
 
-function _mergeWaniKaniSpaceRepetitionSystems(
+export function _mergeWaniKaniSpaceRepetitionSystems(
     existing: WaniKaniSpacedRepetitionSystem[],
     updated: WaniKaniSpacedRepetitionSystem[]
 ): WaniKaniSpacedRepetitionSystem[] {
@@ -435,7 +440,7 @@ function _mergeWaniKaniSpaceRepetitionSystems(
     return Array.from(systemsById.values()).sort((lhs, rhs) => lhs.id - rhs.id);
 }
 
-function _waniKaniAssignmentRecord(
+export function _waniKaniAssignmentRecord(
     profile: string,
     track: number,
     assignment: WaniKaniAssignment
@@ -453,7 +458,7 @@ function _waniKaniAssignmentRecord(
     };
 }
 
-function _waniKaniSubjectRecord(
+export function _waniKaniSubjectRecord(
     profile: string,
     track: number,
     subject: WaniKaniSubject
@@ -515,7 +520,7 @@ function _publishWaniKaniTrackErrors(
     }
 }
 
-async function _processWaniKaniTracks(
+export async function _processWaniKaniTracks(
     db: _DictionaryDatabase,
     profile: string,
     buildId: string,
@@ -571,7 +576,7 @@ async function _processWaniKaniTracks(
     }
 }
 
-async function _buildWaniKaniTokensForTrack(
+export async function _buildWaniKaniTokensForTrack(
     db: _DictionaryDatabase,
     profile: string,
     track: number,
@@ -602,10 +607,7 @@ async function _buildWaniKaniTokensForTrack(
                 .anyOf(batch)
                 .distinct()
                 .filter(
-                    (record) =>
-                        record.profile === profile &&
-                        record.track === track &&
-                        record.source === DictionaryTokenSource.WANIKANI
+                    (record) => record.profile === profile && record.track === track && isWaniKaniSource(record.source)
                 )
                 .toArray();
             const newSubjectIdsByToken = new Map<string, Set<number>>();
@@ -720,7 +722,7 @@ async function _buildWaniKaniTokensForTrack(
  * 4. A subject was hidden or its characters no longer tokenize the same way (handled by affectedSubjectIds)
  * 5. Based on track settings such as no WaniKani token (handled by tracksClearedWithoutBuild)
  */
-async function _saveWaniKaniTokenBatchForDB(
+export async function _saveWaniKaniTokenBatchForDB(
     db: _DictionaryDatabase,
     profile: string,
     track: number,
@@ -730,11 +732,21 @@ async function _saveWaniKaniTokenBatchForDB(
     activeTracks: DictionaryMetaKey[],
     modifiedTokens: Set<string>
 ): Promise<void> {
-    for (const record of existingRecords) {
+    for (let i = records.length - 1; i >= 0; i--) {
+        const record = records[i];
+
         modifiedTokens.add(record.token);
         for (const lemma of record.lemmas) modifiedTokens.add(lemma);
+
+        if (!isWaniKaniSource(record.source)) continue;
+        if (!record.cardIds.length) {
+            records.splice(i, 1); // WaniKani tokens must have at least one subject
+            continue;
+        }
+        record.status = null; // WaniKani status is derived from subject/assignments
+        record.states = []; // WaniKani tokens cannot have states (could change in the future)
     }
-    for (const record of records) {
+    for (const record of existingRecords) {
         modifiedTokens.add(record.token);
         for (const lemma of record.lemmas) modifiedTokens.add(lemma);
     }
@@ -775,7 +787,7 @@ async function _saveWaniKaniTrackMetadataForDB(
     });
 }
 
-async function _updateBuildWaniKaniCacheProgress(
+export async function _updateBuildWaniKaniCacheProgress(
     db: _DictionaryDatabase,
     buildId: string,
     activeTracks: DictionaryMetaKey[],

--- a/common/dictionary-db/dictionary-db.test.ts
+++ b/common/dictionary-db/dictionary-db.test.ts
@@ -1,0 +1,954 @@
+import 'core-js/stable/structured-clone';
+import 'fake-indexeddb/auto';
+import { Dexie } from 'dexie';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import {
+    ApplyStrategy,
+    AsbplayerSettings,
+    DictionaryTokenSource,
+    TokenState,
+    TokenStatus,
+} from '@project/common/settings';
+import {
+    DictionaryDB,
+    DictionaryTokenRecord,
+    LOCAL_TOKEN_TRACK,
+    _gatherModifiedTokens,
+    _getFromSourceBulk,
+    _saveRecordBulk,
+} from './dictionary-db';
+import {
+    makeAnkiCardRecord,
+    makeDictionaryTrack,
+    makeMetaRecord,
+    makeSettings,
+    makeTokenRecord,
+    otherProfile,
+    otherTrack,
+    privateDb,
+    profile,
+    tokenKey,
+    track,
+} from './dictionary-db-test-utils';
+
+describe('DictionaryDB', () => {
+    let dictionaryDB: DictionaryDB;
+    let settings: AsbplayerSettings;
+
+    beforeEach(async () => {
+        await Dexie.delete('DictionaryDatabase');
+        settings = makeSettings([makeDictionaryTrack()]);
+        dictionaryDB = new DictionaryDB({
+            getAll: jest.fn(async () => settings),
+            getSingle: jest.fn(async (key: keyof AsbplayerSettings) => settings[key]),
+        } as any);
+    });
+
+    afterEach(async () => {
+        jest.restoreAllMocks();
+        privateDb(dictionaryDB).close();
+        await Dexie.delete('DictionaryDatabase');
+    });
+
+    const seedTokens = async (...records: ReturnType<typeof makeTokenRecord>[]) => {
+        await privateDb(dictionaryDB).tokens.bulkPut(records);
+    };
+
+    const seedAnkiCards = async (...records: ReturnType<typeof makeAnkiCardRecord>[]) => {
+        await privateDb(dictionaryDB).ankiCards.bulkPut(records);
+    };
+
+    const allTokenRecords = async () => privateDb(dictionaryDB).tokens.toArray() as Promise<DictionaryTokenRecord[]>;
+
+    it('normalizes undefined profiles to Default and keeps explicit profile values unchanged', () => {
+        expect((dictionaryDB as any)._getProfile(undefined)).toBe('Default');
+        expect((dictionaryDB as any)._getProfile(profile)).toBe(profile);
+        expect((dictionaryDB as any)._getProfile('')).toBe('');
+    });
+
+    it('maps card statuses by unique card ID while respecting profile and track boundaries', async () => {
+        await seedAnkiCards(
+            makeAnkiCardRecord({ cardId: 1, status: TokenStatus.UNKNOWN }),
+            makeAnkiCardRecord({ cardId: 2, status: TokenStatus.MATURE, suspended: true }),
+            makeAnkiCardRecord({ cardId: 3, track: otherTrack, status: TokenStatus.GRADUATED }),
+            makeAnkiCardRecord({ cardId: 4, profile: otherProfile, status: TokenStatus.YOUNG })
+        );
+
+        await expect((dictionaryDB as any)._cardStatusMap(profile, track, [])).resolves.toEqual(new Map());
+        await expect((dictionaryDB as any)._cardStatusMap(profile, track, [1, 1, 2, 3, 4])).resolves.toEqual(
+            new Map([
+                [1, { cardId: 1, status: TokenStatus.UNKNOWN, suspended: false }],
+                [2, { cardId: 2, status: TokenStatus.MATURE, suspended: true }],
+            ])
+        );
+    });
+
+    it('maps statuses only from the record source', () => {
+        const ankiStatus = { cardId: 1, status: TokenStatus.MATURE, suspended: false };
+        const waniKaniStatus = {
+            waniKani: { subjectId: 1, subjectLevel: 2 },
+            status: TokenStatus.YOUNG,
+            suspended: false,
+        };
+        const cardStatusMap = new Map([[1, ankiStatus]]);
+        const waniKaniSubjectStatusMap = new Map([[1, waniKaniStatus]]);
+
+        expect(
+            (dictionaryDB as any)._statusesFromRecord(
+                makeTokenRecord({ source: DictionaryTokenSource.ANKI_WORD, cardIds: [1] }),
+                cardStatusMap,
+                waniKaniSubjectStatusMap
+            )
+        ).toEqual([ankiStatus]);
+        expect(
+            (dictionaryDB as any)._statusesFromRecord(
+                makeTokenRecord({ source: DictionaryTokenSource.WANIKANI, cardIds: [1] }),
+                cardStatusMap,
+                waniKaniSubjectStatusMap
+            )
+        ).toEqual([waniKaniStatus]);
+        expect(
+            (dictionaryDB as any)._statusesFromRecord(
+                makeTokenRecord({ source: DictionaryTokenSource.LOCAL, cardIds: [1] }),
+                cardStatusMap,
+                waniKaniSubjectStatusMap
+            )
+        ).toEqual([]);
+    });
+
+    it('converts token records to prioritized token results with ordered card statuses', async () => {
+        await seedAnkiCards(
+            makeAnkiCardRecord({ cardId: 1, status: TokenStatus.UNKNOWN }),
+            makeAnkiCardRecord({ cardId: 2, status: TokenStatus.MATURE, suspended: true }),
+            makeAnkiCardRecord({ cardId: 3, status: TokenStatus.GRADUATED })
+        );
+
+        await expect((dictionaryDB as any)._tokenResultsFromRecords(profile, track, [], settings)).resolves.toEqual({});
+        const results = await (dictionaryDB as any)._tokenResultsFromRecords(
+            profile,
+            track,
+            [
+                makeTokenRecord({ token: 'local', status: TokenStatus.LEARNING, states: [TokenState.IGNORED] }),
+                makeTokenRecord({
+                    token: 'local',
+                    track,
+                    source: DictionaryTokenSource.ANKI_WORD,
+                    status: null,
+                    cardIds: [1],
+                }),
+                makeTokenRecord({
+                    token: 'word',
+                    track,
+                    source: DictionaryTokenSource.ANKI_SENTENCE,
+                    status: null,
+                    lemmas: ['word'],
+                    cardIds: [3],
+                }),
+                makeTokenRecord({
+                    token: 'word',
+                    track,
+                    source: DictionaryTokenSource.ANKI_WORD,
+                    status: null,
+                    lemmas: ['word'],
+                    cardIds: [2, 1],
+                }),
+                makeTokenRecord({
+                    token: 'sentence',
+                    track,
+                    source: DictionaryTokenSource.ANKI_SENTENCE,
+                    status: null,
+                    lemmas: ['sentence'],
+                    cardIds: [],
+                }),
+            ],
+            settings
+        );
+        expect(results).toMatchObject({
+            local: {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.LEARNING, suspended: false }],
+                states: [TokenState.IGNORED],
+            },
+            word: {
+                source: DictionaryTokenSource.ANKI_WORD,
+                statuses: [
+                    { cardId: 2, status: TokenStatus.MATURE, suspended: true },
+                    { cardId: 1, status: TokenStatus.UNKNOWN, suspended: false },
+                ],
+                states: [],
+            },
+            sentence: {
+                source: DictionaryTokenSource.ANKI_SENTENCE,
+                statuses: [],
+                states: [],
+            },
+        });
+        expect(results.local.externalCandidateStatuses).toEqual([
+            { cardId: 1, status: TokenStatus.UNKNOWN, suspended: false },
+        ]);
+        expect(results.word.externalCandidateStatuses).toEqual([
+            { cardId: 3, status: TokenStatus.GRADUATED, suspended: false },
+            { cardId: 2, status: TokenStatus.MATURE, suspended: true },
+            { cardId: 1, status: TokenStatus.UNKNOWN, suspended: false },
+        ]);
+    });
+
+    it('returns empty results for empty bulk operations', async () => {
+        const profiles = [profile];
+
+        await expect(dictionaryDB.getBulk(profile, track, [])).resolves.toEqual({});
+        await expect(dictionaryDB.getByLemmaBulk(profile, track, [])).resolves.toEqual({});
+        await expect(dictionaryDB.saveRecordLocalBulk(profile, [], ApplyStrategy.ADD)).resolves.toEqual({
+            savedTokens: [],
+            deletedTokens: [],
+        });
+        await expect(dictionaryDB.deleteRecordLocalBulk(profile, [])).resolves.toEqual({ deletedTokens: [] });
+        await expect(dictionaryDB.importRecordLocalBulk([], profiles)).resolves.toEqual({ importedTokens: [] });
+        await expect(dictionaryDB.updateRecords(profile, [], ApplyStrategy.ADD)).resolves.toEqual({
+            savedTokens: [],
+            deletedTokens: [],
+        });
+        await expect(dictionaryDB.deleteRecords(profile, [])).resolves.toEqual({ deletedTokens: [] });
+        await expect(dictionaryDB.getRecords(profile, track)).resolves.toEqual({
+            tokenRecords: [],
+            ankiCardRecords: {},
+            waniKaniSubjectRecords: {},
+            waniKaniAssignmentRecords: {},
+        });
+        expect(profiles).toEqual([profile]);
+    });
+
+    it('saves one and two local token inputs while filtering invalid data', async () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const singleResult = await dictionaryDB.saveRecordLocalBulk(
+            undefined,
+            [{ token: 'alpha', status: TokenStatus.LEARNING, lemmas: ['alpha', '123'], states: [] }],
+            ApplyStrategy.ADD
+        );
+        expect(singleResult).toEqual({
+            savedTokens: [tokenKey('alpha', DictionaryTokenSource.LOCAL, LOCAL_TOKEN_TRACK, 'Default')],
+            deletedTokens: [],
+        });
+
+        const twoItemResult = await dictionaryDB.saveRecordLocalBulk(
+            profile,
+            [
+                { token: 'beta', status: TokenStatus.UNKNOWN, lemmas: ['beta'], states: [] },
+                { token: '123', status: TokenStatus.UNKNOWN, lemmas: ['123'], states: [] },
+            ],
+            ApplyStrategy.ADD
+        );
+        expect(twoItemResult).toEqual({ savedTokens: [tokenKey('beta')], deletedTokens: [] });
+        expect(consoleError).toHaveBeenCalledTimes(1);
+
+        await expect(dictionaryDB.getBulk(undefined, track, ['alpha'])).resolves.toMatchObject({
+            alpha: {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.LEARNING, suspended: false }],
+                states: [],
+            },
+        });
+        await expect(dictionaryDB.getBulk(profile, track, ['beta'])).resolves.toMatchObject({
+            beta: {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.UNKNOWN, suspended: false }],
+                states: [],
+            },
+        });
+        expect((await allTokenRecords()).find((record) => record.token === 'alpha')?.lemmas).toEqual(['alpha']);
+    });
+
+    it('applies state strategies and deletes local tokens that become uncollected with no states', async () => {
+        const ignored = TokenState.IGNORED;
+        const customState = 2 as TokenState;
+        const anotherState = 1 as TokenState;
+
+        await seedTokens(
+            makeTokenRecord({ token: 'alpha', states: [customState, ignored], status: TokenStatus.UNKNOWN }),
+            makeTokenRecord({ token: 'beta', states: [ignored], status: TokenStatus.UNKNOWN }),
+            makeTokenRecord({ token: 'gamma', states: [ignored], status: TokenStatus.UNKNOWN }),
+            makeTokenRecord({ token: 'delta', states: [ignored], status: TokenStatus.UNKNOWN })
+        );
+
+        await dictionaryDB.saveRecordLocalBulk(
+            profile,
+            [{ token: 'alpha', status: null, lemmas: ['alpha'], states: [anotherState, customState] }],
+            ApplyStrategy.ADD
+        );
+        await dictionaryDB.saveRecordLocalBulk(
+            profile,
+            [{ token: 'beta', status: TokenStatus.UNKNOWN, lemmas: ['beta'], states: [ignored] }],
+            ApplyStrategy.REMOVE
+        );
+        await dictionaryDB.saveRecordLocalBulk(
+            profile,
+            [{ token: 'gamma', status: TokenStatus.UNKNOWN, lemmas: ['gamma'], states: [customState, anotherState] }],
+            ApplyStrategy.REPLACE
+        );
+        await dictionaryDB.saveRecordLocalBulk(
+            profile,
+            [{ token: 'delta', status: TokenStatus.UNKNOWN, lemmas: ['delta'], states: [ignored, customState] }],
+            ApplyStrategy.TOGGLE
+        );
+
+        await expect(dictionaryDB.getBulk(profile, track, ['alpha', 'beta', 'gamma', 'delta'])).resolves.toMatchObject({
+            alpha: {
+                statuses: [{ status: TokenStatus.UNKNOWN, suspended: false }],
+                states: [ignored, anotherState, customState],
+            },
+            beta: { states: [] },
+            gamma: { states: [anotherState, customState] },
+            delta: { states: [customState] },
+        });
+
+        await expect(
+            dictionaryDB.saveRecordLocalBulk(
+                profile,
+                [{ token: 'beta', status: TokenStatus.UNCOLLECTED, lemmas: ['beta'], states: [] }],
+                ApplyStrategy.REPLACE
+            )
+        ).resolves.toEqual({ savedTokens: [], deletedTokens: [tokenKey('beta')] });
+        await expect(dictionaryDB.getBulk(profile, track, ['beta'])).resolves.toEqual({});
+    });
+
+    it('rejects unsupported apply strategies without modifying records', async () => {
+        await seedTokens(makeTokenRecord({ token: 'alpha', states: [TokenState.IGNORED] }));
+
+        await expect(
+            dictionaryDB.updateRecords(
+                profile,
+                [{ tokenKey: tokenKey('alpha'), status: TokenStatus.MATURE, states: [] }],
+                'UNKNOWN' as ApplyStrategy
+            )
+        ).rejects.toThrow('Unsupported applyStates value: "UNKNOWN"');
+        await expect(dictionaryDB.getBulk(profile, track, ['alpha'])).resolves.toMatchObject({
+            alpha: { statuses: [{ status: TokenStatus.UNKNOWN, suspended: false }], states: [TokenState.IGNORED] },
+        });
+    });
+
+    it('does not persist local records that violate token, lemma, or uncollected state invariants', async () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(
+            dictionaryDB.saveRecordLocalBulk(
+                profile,
+                [
+                    { token: '123', status: TokenStatus.UNKNOWN, lemmas: ['alpha'], states: [] },
+                    { token: 'alpha', status: TokenStatus.UNKNOWN, lemmas: ['123'], states: [] },
+                    { token: 'beta', status: TokenStatus.UNCOLLECTED, lemmas: ['beta'], states: [] },
+                ],
+                ApplyStrategy.ADD
+            )
+        ).resolves.toEqual({ savedTokens: [], deletedTokens: [] });
+        expect(consoleError).toHaveBeenCalledTimes(3);
+        await expect(allTokenRecords()).resolves.toEqual([]);
+    });
+
+    it('keeps persisted local records trackless with no card IDs and sorted states', async () => {
+        const customState = 2 as TokenState;
+        const anotherState = 1 as TokenState;
+
+        await dictionaryDB.saveRecordLocalBulk(
+            profile,
+            [{ token: 'alpha', status: TokenStatus.UNKNOWN, lemmas: ['alpha'], states: [customState, anotherState] }],
+            ApplyStrategy.REPLACE
+        );
+
+        await expect(allTokenRecords()).resolves.toEqual([
+            makeTokenRecord({
+                token: 'alpha',
+                track: LOCAL_TOKEN_TRACK,
+                source: DictionaryTokenSource.LOCAL,
+                cardIds: [],
+                states: [anotherState, customState],
+            }),
+        ]);
+    });
+
+    it('fetches and saves token records through source helpers', async () => {
+        const localRecord = makeTokenRecord({ token: 'alpha' });
+        const ankiRecord = makeTokenRecord({
+            token: 'alpha',
+            track,
+            source: DictionaryTokenSource.ANKI_WORD,
+            status: null,
+            cardIds: [1],
+        });
+        const secondRecord = makeTokenRecord({ token: 'beta' });
+
+        await expect(_saveRecordBulk(privateDb(dictionaryDB), [])).resolves.toEqual([]);
+        await expect(
+            _getFromSourceBulk(privateDb(dictionaryDB), profile, LOCAL_TOKEN_TRACK, DictionaryTokenSource.LOCAL, [])
+        ).resolves.toEqual(new Map());
+        await expect(
+            _saveRecordBulk(privateDb(dictionaryDB), [localRecord, ankiRecord, secondRecord])
+        ).resolves.toEqual([
+            tokenKey('alpha'),
+            tokenKey('alpha', DictionaryTokenSource.ANKI_WORD, track),
+            tokenKey('beta'),
+        ]);
+        await expect(
+            _getFromSourceBulk(privateDb(dictionaryDB), profile, LOCAL_TOKEN_TRACK, DictionaryTokenSource.LOCAL, [
+                'alpha',
+                'beta',
+            ])
+        ).resolves.toEqual(
+            new Map([
+                ['alpha', localRecord],
+                ['beta', secondRecord],
+            ])
+        );
+    });
+
+    it('gathers modified tokens through lemma relationships within the same profile', async () => {
+        const modifiedTokens = new Set(['alpha']);
+        await seedTokens(
+            makeTokenRecord({ token: 'related', lemmas: ['alpha', 'related-lemma'] }),
+            makeTokenRecord({ token: 'other-profile-related', profile: otherProfile, lemmas: ['alpha'] })
+        );
+
+        await _gatherModifiedTokens(privateDb(dictionaryDB), profile, modifiedTokens);
+
+        expect(modifiedTokens).toEqual(new Set(['alpha', 'related', 'related-lemma']));
+    });
+
+    it('prioritizes local, Anki word, then Anki sentence records for token lookups', async () => {
+        await seedTokens(
+            makeTokenRecord({ token: 'alpha', status: TokenStatus.LEARNING, states: [TokenState.IGNORED] }),
+            makeTokenRecord({
+                token: 'alpha',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'beta',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['beta'],
+                cardIds: [1, 2],
+            }),
+            makeTokenRecord({
+                token: 'beta',
+                track,
+                source: DictionaryTokenSource.ANKI_SENTENCE,
+                status: null,
+                lemmas: ['beta'],
+                cardIds: [3],
+            }),
+            makeTokenRecord({
+                token: 'gamma',
+                track,
+                source: DictionaryTokenSource.ANKI_SENTENCE,
+                status: null,
+                lemmas: ['gamma'],
+                cardIds: [3],
+            }),
+            makeTokenRecord({ token: 'wrong-track', track: otherTrack, source: DictionaryTokenSource.ANKI_WORD }),
+            makeTokenRecord({ token: 'wrong-profile', profile: otherProfile })
+        );
+        await seedAnkiCards(
+            makeAnkiCardRecord({ cardId: 1, status: TokenStatus.UNKNOWN }),
+            makeAnkiCardRecord({ cardId: 2, status: TokenStatus.MATURE, suspended: true }),
+            makeAnkiCardRecord({ cardId: 3, status: TokenStatus.GRADUATED })
+        );
+
+        await expect(
+            dictionaryDB.getBulk(profile, track, ['alpha', 'beta', 'gamma', 'wrong-track', 'wrong-profile'])
+        ).resolves.toMatchObject({
+            alpha: {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.LEARNING, suspended: false }],
+                states: [TokenState.IGNORED],
+            },
+            beta: {
+                source: DictionaryTokenSource.ANKI_WORD,
+                statuses: [
+                    { cardId: 1, status: TokenStatus.UNKNOWN, suspended: false },
+                    { cardId: 2, status: TokenStatus.MATURE, suspended: true },
+                ],
+                states: [],
+            },
+            gamma: {
+                source: DictionaryTokenSource.ANKI_SENTENCE,
+                statuses: [{ cardId: 3, status: TokenStatus.GRADUATED, suspended: false }],
+                states: [],
+            },
+        });
+    });
+
+    it('looks up tokens and lemmas case-insensitively while returning records under their stored keys', async () => {
+        await seedTokens(
+            makeTokenRecord({ token: 'Alpha', status: TokenStatus.LEARNING, lemmas: ['AlphaLemma'] }),
+            makeTokenRecord({
+                token: 'Beta',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['BetaLemma'],
+                cardIds: [1],
+            })
+        );
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 1, status: TokenStatus.MATURE }));
+
+        await expect(dictionaryDB.getBulk(profile, track, ['alpha', 'beta'])).resolves.toMatchObject({
+            Alpha: {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.LEARNING, suspended: false }],
+                states: [],
+            },
+            Beta: {
+                source: DictionaryTokenSource.ANKI_WORD,
+                statuses: [{ cardId: 1, status: TokenStatus.MATURE, suspended: false }],
+                states: [],
+            },
+        });
+
+        await expect(dictionaryDB.getByLemmaBulk(profile, track, ['alphalemma', 'betalemma'])).resolves.toMatchObject({
+            AlphaLemma: [
+                expect.objectContaining({
+                    token: 'Alpha',
+                    source: DictionaryTokenSource.LOCAL,
+                    statuses: [{ status: TokenStatus.LEARNING, suspended: false }],
+                }),
+            ],
+            BetaLemma: [
+                expect.objectContaining({
+                    token: 'Beta',
+                    source: DictionaryTokenSource.ANKI_WORD,
+                    statuses: [{ cardId: 1, status: TokenStatus.MATURE, suspended: false }],
+                }),
+            ],
+        });
+    });
+
+    it('returns all tokens for a profile and track with local tokens included across tracks', async () => {
+        await seedTokens(
+            makeTokenRecord({ token: 'local', status: TokenStatus.UNKNOWN }),
+            makeTokenRecord({
+                token: 'anki',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['anki'],
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'other-track',
+                track: otherTrack,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['other-track'],
+                cardIds: [2],
+            })
+        );
+        await seedAnkiCards(makeAnkiCardRecord({ cardId: 1, status: TokenStatus.YOUNG }));
+
+        await expect(dictionaryDB.getAllTokens(profile, track)).resolves.toMatchObject({
+            local: {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.UNKNOWN, suspended: false }],
+                states: [],
+            },
+            anki: {
+                source: DictionaryTokenSource.ANKI_WORD,
+                statuses: [{ cardId: 1, status: TokenStatus.YOUNG, suspended: false }],
+                states: [],
+            },
+        });
+    });
+
+    it('prioritizes sources and handles multiple results for lemma lookups', async () => {
+        await seedTokens(
+            makeTokenRecord({ token: 'local-token', status: TokenStatus.LEARNING, lemmas: ['shared'] }),
+            makeTokenRecord({
+                token: 'word-token',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['word-lemma', 'multi'],
+                cardIds: [1],
+            }),
+            makeTokenRecord({
+                token: 'word-token-2',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['multi'],
+                cardIds: [2],
+            }),
+            makeTokenRecord({
+                token: 'sentence-token',
+                track,
+                source: DictionaryTokenSource.ANKI_SENTENCE,
+                status: null,
+                lemmas: ['sentence-lemma', 'word-lemma'],
+                cardIds: [3],
+            }),
+            makeTokenRecord({
+                token: 'wrong-track',
+                track: otherTrack,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['word-lemma'],
+                cardIds: [4],
+            })
+        );
+        await seedAnkiCards(
+            makeAnkiCardRecord({ cardId: 1, status: TokenStatus.UNKNOWN }),
+            makeAnkiCardRecord({ cardId: 2, status: TokenStatus.MATURE }),
+            makeAnkiCardRecord({ cardId: 3, status: TokenStatus.GRADUATED })
+        );
+
+        const results = await dictionaryDB.getByLemmaBulk(profile, track, [
+            'shared',
+            'word-lemma',
+            'sentence-lemma',
+            'multi',
+        ]);
+        expect(results.shared).toEqual([
+            expect.objectContaining({
+                token: 'local-token',
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.LEARNING, suspended: false }],
+                states: [],
+            }),
+        ]);
+        expect(results['word-lemma']).toEqual([
+            expect.objectContaining({
+                token: 'word-token',
+                source: DictionaryTokenSource.ANKI_WORD,
+                statuses: [{ cardId: 1, status: TokenStatus.UNKNOWN, suspended: false }],
+                states: [],
+            }),
+        ]);
+        expect(results['sentence-lemma']).toEqual([
+            expect.objectContaining({
+                token: 'sentence-token',
+                source: DictionaryTokenSource.ANKI_SENTENCE,
+                statuses: [{ cardId: 3, status: TokenStatus.GRADUATED, suspended: false }],
+                states: [],
+            }),
+        ]);
+        expect(results.multi).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    token: 'word-token',
+                    source: DictionaryTokenSource.ANKI_WORD,
+                    statuses: [{ cardId: 1, status: TokenStatus.UNKNOWN, suspended: false }],
+                    states: [],
+                }),
+                expect.objectContaining({
+                    token: 'word-token-2',
+                    source: DictionaryTokenSource.ANKI_WORD,
+                    statuses: [{ cardId: 2, status: TokenStatus.MATURE, suspended: false }],
+                    states: [],
+                }),
+            ])
+        );
+        expect(results.multi).toHaveLength(2);
+    });
+
+    it('imports local records with profile, status, lemma, and existing-record invariants', async () => {
+        const customState = 2 as TokenState;
+
+        await seedTokens(
+            makeTokenRecord({
+                token: 'existing',
+                status: TokenStatus.GRADUATED,
+                lemmas: ['existing-lemma'],
+                states: [TokenState.IGNORED],
+            })
+        );
+
+        const result = await dictionaryDB.importRecordLocalBulk(
+            [
+                { profile, token: 'alpha', status: TokenStatus.UNKNOWN, lemmas: ['alpha', '123'], states: [] },
+                { profile: 'Default', token: 'beta', status: TokenStatus.MATURE + 1, lemmas: ['beta'], states: [] },
+                {
+                    profile,
+                    token: 'state-only',
+                    status: TokenStatus.UNCOLLECTED,
+                    lemmas: ['state-only'],
+                    states: [TokenState.IGNORED],
+                },
+                {
+                    profile,
+                    token: 'multi-state',
+                    status: TokenStatus.UNCOLLECTED,
+                    lemmas: ['multi-state'],
+                    states: [customState, TokenState.IGNORED],
+                },
+                { profile, token: 'existing', status: TokenStatus.UNKNOWN, lemmas: [], states: [] },
+                { profile, token: 'no-state', status: TokenStatus.UNCOLLECTED, lemmas: ['no-state'], states: [] },
+                {
+                    profile: otherProfile,
+                    token: 'wrong-profile',
+                    status: TokenStatus.UNKNOWN,
+                    lemmas: ['wrong-profile'],
+                },
+                { profile, token: '123', status: TokenStatus.UNKNOWN, lemmas: ['alpha'] },
+            ],
+            [profile]
+        );
+
+        expect(result.importedTokens).toEqual([
+            tokenKey('alpha'),
+            tokenKey('beta', DictionaryTokenSource.LOCAL, LOCAL_TOKEN_TRACK, 'Default'),
+            tokenKey('state-only'),
+            tokenKey('multi-state'),
+            tokenKey('existing'),
+        ]);
+        await expect(
+            dictionaryDB.getBulk(profile, track, ['alpha', 'state-only', 'multi-state', 'existing', 'no-state'])
+        ).resolves.toMatchObject({
+            alpha: {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.UNKNOWN, suspended: false }],
+                states: [],
+            },
+            'state-only': {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.UNCOLLECTED, suspended: false }],
+                states: [TokenState.IGNORED],
+            },
+            'multi-state': {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.UNCOLLECTED, suspended: false }],
+                states: [TokenState.IGNORED, customState],
+            },
+            existing: {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.GRADUATED, suspended: false }],
+                states: [TokenState.IGNORED],
+            },
+        });
+        await expect(dictionaryDB.getBulk(undefined, track, ['beta'])).resolves.toMatchObject({
+            beta: {
+                source: DictionaryTokenSource.LOCAL,
+                statuses: [{ status: TokenStatus.MATURE, suspended: false }],
+                states: [],
+            },
+        });
+        expect((await allTokenRecords()).find((record) => record.token === 'alpha')?.lemmas).toEqual(['alpha']);
+    });
+
+    it('exports only local records and omits empty optional arrays', async () => {
+        await seedTokens(
+            makeTokenRecord({ token: 'alpha', states: [TokenState.IGNORED] }),
+            makeTokenRecord({ token: 'beta', lemmas: [], states: [] }),
+            makeTokenRecord({
+                token: 'anki',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['anki'],
+                cardIds: [1],
+            })
+        );
+
+        await expect(dictionaryDB.exportRecordLocalBulk()).resolves.toEqual({
+            exportedRecords: [
+                {
+                    profile,
+                    token: 'alpha',
+                    status: TokenStatus.UNKNOWN,
+                    lemmas: ['alpha'],
+                    states: [TokenState.IGNORED],
+                },
+                { profile, token: 'beta', status: TokenStatus.UNKNOWN, lemmas: undefined, states: undefined },
+            ],
+        });
+    });
+
+    it('updates and deletes only matching local records', async () => {
+        const customState = 2 as TokenState;
+        await seedTokens(
+            makeTokenRecord({ token: 'alpha', states: [TokenState.IGNORED] }),
+            makeTokenRecord({ token: 'beta', states: [] }),
+            makeTokenRecord({ token: 'other-profile', profile: otherProfile }),
+            makeTokenRecord({
+                token: 'anki',
+                track,
+                source: DictionaryTokenSource.ANKI_WORD,
+                status: null,
+                lemmas: ['anki'],
+                cardIds: [1],
+            })
+        );
+
+        await expect(
+            dictionaryDB.updateRecords(
+                profile,
+                [
+                    { tokenKey: tokenKey('alpha'), status: TokenStatus.MATURE, states: [customState] },
+                    { tokenKey: tokenKey('beta'), status: TokenStatus.UNCOLLECTED, states: [] },
+                    {
+                        tokenKey: tokenKey(
+                            'other-profile',
+                            DictionaryTokenSource.LOCAL,
+                            LOCAL_TOKEN_TRACK,
+                            otherProfile
+                        ),
+                        status: TokenStatus.MATURE,
+                        states: [],
+                    },
+                    {
+                        tokenKey: tokenKey('anki', DictionaryTokenSource.ANKI_WORD, track),
+                        status: TokenStatus.MATURE,
+                        states: [],
+                    },
+                    { tokenKey: tokenKey('missing'), status: TokenStatus.MATURE, states: [] },
+                ],
+                ApplyStrategy.ADD
+            )
+        ).resolves.toEqual({ savedTokens: [tokenKey('alpha')], deletedTokens: [tokenKey('beta')] });
+
+        await expect(
+            dictionaryDB.getBulk(profile, track, ['alpha', 'beta', 'other-profile', 'anki'])
+        ).resolves.toMatchObject({
+            alpha: {
+                statuses: [{ status: TokenStatus.MATURE, suspended: false }],
+                states: [TokenState.IGNORED, customState],
+            },
+            anki: { source: DictionaryTokenSource.ANKI_WORD },
+        });
+
+        await expect(
+            dictionaryDB.deleteRecords(profile, [
+                tokenKey('alpha'),
+                tokenKey('anki', DictionaryTokenSource.ANKI_WORD, track),
+            ])
+        ).resolves.toEqual({
+            deletedTokens: [tokenKey('alpha')],
+        });
+        await expect(dictionaryDB.deleteRecordLocalBulk(profile, ['missing', 'other-profile'])).resolves.toEqual({
+            deletedTokens: [],
+        });
+        await expect(dictionaryDB.getBulk(profile, track, ['alpha'])).resolves.toEqual({});
+        await expect(dictionaryDB.getBulk(otherProfile, track, ['other-profile'])).resolves.toHaveProperty(
+            'other-profile'
+        );
+    });
+
+    it('returns raw records with unique Anki cards for the requested profile and track', async () => {
+        const localRecord = makeTokenRecord({ token: 'local' });
+        const ankiRecord = makeTokenRecord({
+            token: 'anki',
+            track,
+            source: DictionaryTokenSource.ANKI_WORD,
+            status: null,
+            lemmas: ['anki'],
+            cardIds: [1, 2, 1],
+        });
+        await seedTokens(
+            localRecord,
+            ankiRecord,
+            makeTokenRecord({
+                token: 'other-track',
+                track: otherTrack,
+                source: DictionaryTokenSource.ANKI_WORD,
+                cardIds: [3],
+            })
+        );
+        const firstCard = makeAnkiCardRecord({ cardId: 1, status: TokenStatus.UNKNOWN });
+        const secondCard = makeAnkiCardRecord({ cardId: 2, status: TokenStatus.MATURE });
+        await seedAnkiCards(firstCard, secondCard, makeAnkiCardRecord({ cardId: 3, track: otherTrack }));
+
+        const records = await dictionaryDB.getRecords(profile, track);
+        expect(records.tokenRecords).toEqual(expect.arrayContaining([localRecord, ankiRecord]));
+        expect(records.tokenRecords).toHaveLength(2);
+        expect(records.ankiCardRecords).toEqual({
+            [track]: {
+                [firstCard.cardId]: firstCard,
+                [secondCard.cardId]: secondCard,
+            },
+        });
+    });
+
+    it('returns raw records for all tracks when no track is requested', async () => {
+        const localRecord = makeTokenRecord({ token: 'local' });
+        const trackRecord = makeTokenRecord({
+            token: 'track-zero',
+            track,
+            source: DictionaryTokenSource.ANKI_WORD,
+            status: null,
+            lemmas: ['track-zero'],
+            cardIds: [1],
+        });
+        const otherTrackRecord = makeTokenRecord({
+            token: 'track-one',
+            track: otherTrack,
+            source: DictionaryTokenSource.ANKI_SENTENCE,
+            status: null,
+            lemmas: ['track-one'],
+            cardIds: [2],
+        });
+        await seedTokens(
+            localRecord,
+            trackRecord,
+            otherTrackRecord,
+            makeTokenRecord({ token: 'other-profile', profile: otherProfile })
+        );
+        const firstCard = makeAnkiCardRecord({ cardId: 1, status: TokenStatus.UNKNOWN });
+        const secondCard = makeAnkiCardRecord({ cardId: 2, track: otherTrack, status: TokenStatus.MATURE });
+        await seedAnkiCards(firstCard, secondCard, makeAnkiCardRecord({ cardId: 3, profile: otherProfile }));
+
+        const records = await dictionaryDB.getRecords(profile, undefined);
+
+        expect(records.tokenRecords).toEqual(expect.arrayContaining([localRecord, trackRecord, otherTrackRecord]));
+        expect(records.tokenRecords).toHaveLength(3);
+        expect(records.ankiCardRecords).toEqual({
+            [track]: { [firstCard.cardId]: firstCard },
+            [otherTrack]: { [secondCard.cardId]: secondCard },
+        });
+    });
+
+    it('deletes all dictionary data for one profile only', async () => {
+        await seedTokens(
+            makeTokenRecord({ token: 'alpha' }),
+            makeTokenRecord({ token: 'other-profile', profile: otherProfile })
+        );
+        await seedAnkiCards(
+            makeAnkiCardRecord({ cardId: 1 }),
+            makeAnkiCardRecord({ cardId: 2, profile: otherProfile })
+        );
+        await privateDb(dictionaryDB).meta.bulkPut([
+            makeMetaRecord({
+                ankiMeta: {
+                    lastBuildStartedAt: 1,
+                    lastBuildExpiresAt: 2,
+                    buildId: 'build',
+                    settings: 'settings',
+                },
+            }),
+            makeMetaRecord({
+                profile: otherProfile,
+                ankiMeta: {
+                    lastBuildStartedAt: 1,
+                    lastBuildExpiresAt: 2,
+                    buildId: 'build',
+                    settings: 'settings',
+                },
+            }),
+        ]);
+
+        await expect(dictionaryDB.deleteProfile(profile)).resolves.toEqual({
+            deletedMetas: [[profile, track]],
+            deletedTokens: [tokenKey('alpha')],
+            deletedAnkiCards: [[1, track, profile]],
+            deletedWaniKaniSubjects: [],
+            deletedWaniKaniAssignments: [],
+        });
+        await expect(dictionaryDB.getBulk(profile, track, ['alpha'])).resolves.toEqual({});
+        await expect(privateDb(dictionaryDB).ankiCards.get([1, track, profile])).resolves.toBeUndefined();
+        await expect(dictionaryDB.getBulk(otherProfile, track, ['other-profile'])).resolves.toHaveProperty(
+            'other-profile'
+        );
+        await expect(privateDb(dictionaryDB).ankiCards.count()).resolves.toBe(1);
+        await expect(privateDb(dictionaryDB).ankiCards.where('profile').equals(otherProfile).count()).resolves.toBe(1);
+    });
+});

--- a/common/dictionary-db/dictionary-db.ts
+++ b/common/dictionary-db/dictionary-db.ts
@@ -7,7 +7,9 @@ import {
     ExternalWordSource,
     externalWordSourcePriority,
     getFullyKnownTokenStatus,
+    isAnkiSource,
     isExternalWordSource,
+    isWaniKaniSource,
     SettingsProvider,
     TokenState,
     TokenStatus,
@@ -304,7 +306,7 @@ export class DictionaryDB {
     private async _cardStatusMap(
         profile: string,
         track: number,
-        cardIds: Iterable<number>
+        cardIds: number[]
     ): Promise<Map<number, TokenStatusInfo>> {
         const uniqueCardIds = Array.from(new Set(cardIds));
         if (!uniqueCardIds.length) return new Map();
@@ -329,7 +331,7 @@ export class DictionaryDB {
     private async _waniKaniSubjectStatusMap(
         profile: string,
         track: number,
-        subjectIds: Iterable<number>
+        subjectIds: number[]
     ): Promise<Map<number, TokenStatusInfo>> {
         const uniqueSubjectIds = Array.from(new Set(subjectIds));
         if (!uniqueSubjectIds.length) return new Map();
@@ -385,16 +387,19 @@ export class DictionaryDB {
         cardStatusMap: Map<number, TokenStatusInfo>,
         waniKaniSubjectStatusMap: Map<number, TokenStatusInfo>
     ): TokenStatusInfo[] {
-        if (record.source === DictionaryTokenSource.WANIKANI) {
+        if (isAnkiSource(record.source)) {
+            return record.cardIds.flatMap((cardId) => {
+                const status = cardStatusMap.get(cardId);
+                return status ? [status] : [];
+            });
+        }
+        if (isWaniKaniSource(record.source)) {
             return record.cardIds.flatMap((subjectId) => {
                 const status = waniKaniSubjectStatusMap.get(subjectId);
                 return status ? [status] : [];
             });
         }
-        return record.cardIds.flatMap((cardId) => {
-            const status = cardStatusMap.get(cardId);
-            return status ? [status] : [];
-        });
+        return [];
     }
 
     private _externalStatusesFromRecords(
@@ -461,16 +466,12 @@ export class DictionaryDB {
             this._cardStatusMap(
                 profile,
                 track,
-                flattenedRecords.flatMap((record) =>
-                    record.source === DictionaryTokenSource.WANIKANI ? [] : record.cardIds
-                )
+                flattenedRecords.flatMap((record) => (isAnkiSource(record.source) ? record.cardIds : []))
             ),
             this._waniKaniSubjectStatusMap(
                 profile,
                 track,
-                flattenedRecords.flatMap((record) =>
-                    record.source === DictionaryTokenSource.WANIKANI ? record.cardIds : []
-                )
+                flattenedRecords.flatMap((record) => (isWaniKaniSource(record.source) ? record.cardIds : []))
             ),
         ]);
 
@@ -545,15 +546,20 @@ export class DictionaryDB {
         if (!tokens.length) return {};
         const profile = this._getProfile(inputProfile);
         const settings = await this.settingsProvider.getAll();
+        const normalizedTokens = new Set(tokens.map(normalizeToken));
 
         return this.db.transaction(
             'r',
             [this.db.tokens, this.db.ankiCards, this.db.waniKaniAssignments, this.db.waniKaniSubjects, this.db.meta],
             async () => {
                 const records = await this.db.tokens
-                    .where('token')
-                    .anyOfIgnoreCase(tokens)
-                    .filter((r) => (r.track === track || r.track === LOCAL_TOKEN_TRACK) && r.profile === profile)
+                    .where('profile')
+                    .equals(profile)
+                    .filter(
+                        (r) =>
+                            normalizedTokens.has(normalizeToken(r.token)) &&
+                            (r.track === track || r.track === LOCAL_TOKEN_TRACK)
+                    )
                     .toArray();
                 return this._tokenResultsFromRecords(profile, track, records, settings);
             }
@@ -620,14 +626,14 @@ export class DictionaryDB {
                                 profile,
                                 track,
                                 flattenedRecords.flatMap((record) =>
-                                    record.source === DictionaryTokenSource.WANIKANI ? [] : record.cardIds
+                                    isAnkiSource(record.source) ? record.cardIds : []
                                 )
                             ),
                             this._waniKaniSubjectStatusMap(
                                 profile,
                                 track,
                                 flattenedRecords.flatMap((record) =>
-                                    record.source === DictionaryTokenSource.WANIKANI ? record.cardIds : []
+                                    isWaniKaniSource(record.source) ? record.cardIds : []
                                 )
                             ),
                         ]);
@@ -669,9 +675,7 @@ export class DictionaryDB {
                             const ankiWordRecords = records.filter(
                                 (record) => record.source === DictionaryTokenSource.ANKI_WORD
                             );
-                            const waniKaniRecords = records.filter(
-                                (record) => record.source === DictionaryTokenSource.WANIKANI
-                            );
+                            const waniKaniRecords = records.filter((record) => isWaniKaniSource(record.source));
                             const bestAnkiWordStatus = this._getBestKnownExternalWordToken(
                                 ankiWordRecords,
                                 cardStatusMap,
@@ -791,6 +795,7 @@ export class DictionaryDB {
                 } else if (localTokenInput.status == null) {
                     localTokenInput.status = TokenStatus.UNCOLLECTED;
                 }
+                localTokenInput.states = Array.from(new Set(localTokenInput.states)).sort((lhs, rhs) => lhs - rhs);
                 localTokenInput.lemmas = localTokenInput.lemmas.filter((lemma) => HAS_LETTER_REGEX.test(lemma));
                 if (!localTokenInput.lemmas.length) {
                     console.error(`Cannot save local token with no lemmas: ${JSON.stringify(localTokenInput)}`);
@@ -865,6 +870,7 @@ export class DictionaryDB {
         items: Partial<DictionaryTokenRecord>[],
         profiles: string[]
     ): Promise<DictionaryImportRecordLocalResult> {
+        if (!items.length) return { importedTokens: [] };
         const defaultProfile = this._getProfile(undefined);
         if (!profiles.includes(defaultProfile)) profiles.unshift(defaultProfile);
         const fullyKnownStatus = getFullyKnownTokenStatus();
@@ -900,6 +906,7 @@ export class DictionaryDB {
                     item.states = existingToken.states; // Treat the existing states as authoritative, TODO: expose ApplyStrategy for imports?
                 }
                 item.lemmas = item.lemmas.filter((lemma) => HAS_LETTER_REGEX.test(lemma));
+                item.states = Array.from(new Set(item.states)).sort((lhs, rhs) => lhs - rhs);
                 if (!item.lemmas.length) continue; // Cannot import tokens with no lemmas, require a different method where a tokenizer is available
                 let status = item.status;
                 if (item.status == null || item.status < TokenStatus.UNKNOWN) {

--- a/common/dictionary-statistics/dictionary-statistics.test.ts
+++ b/common/dictionary-statistics/dictionary-statistics.test.ts
@@ -1,0 +1,1405 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { DictionaryProvider } from '@project/common/dictionary-db';
+import {
+    defaultSettings,
+    DictionaryTokenSource,
+    DictionaryTrack,
+    TokenFrequencyAnnotation,
+    TokenReadingAnnotation,
+    TokenState,
+    TokenStatus,
+} from '@project/common/settings';
+import {
+    averageDisplay,
+    clampPercent,
+    countPercentOccurrencesDisplay,
+    defaultDictionaryStatisticsSentenceSortDirection,
+    defaultDictionaryStatisticsSentenceSortState,
+    DictionaryStatistics,
+    DictionaryStatisticsSentence,
+    DictionaryStatisticsSentenceBucketEntry,
+    DictionaryStatisticsSentenceBuckets,
+    DictionaryStatisticsSnapshot,
+    dictionaryStatisticsComprehensionBandForPercent,
+    nextDictionaryStatisticsSentenceSortCategory,
+    nextDictionaryStatisticsSentenceSortDirection,
+    percent,
+    percentDisplay,
+    processDictionaryStatisticsAnkiTrackSnapshot,
+    processDictionaryStatisticsSnapshot,
+    processDictionaryStatisticsWaniKaniTrackSnapshot,
+    processSimplifiedDictionaryStatistics,
+    selectedRewatchSnapshotForTrack,
+    sentenceComprehensionPointLabel,
+    sentenceComprehensionXAxisLabels,
+    sentenceDialogBucketData,
+    statusSentenceBucketLabel,
+    sortDictionaryStatisticsSentenceBucketEntries,
+} from '@project/common/dictionary-statistics';
+
+const makeDictionaryTrack = (overrides: Partial<DictionaryTrack> = {}): DictionaryTrack => ({
+    ...defaultSettings.dictionaryTracks[0],
+    dictionaryAnkiDecks: [...defaultSettings.dictionaryTracks[0].dictionaryAnkiDecks],
+    dictionaryAnkiWordFields: [...defaultSettings.dictionaryTracks[0].dictionaryAnkiWordFields],
+    dictionaryAnkiSentenceFields: [...defaultSettings.dictionaryTracks[0].dictionaryAnkiSentenceFields],
+    dictionaryTokenStatusColors: [...defaultSettings.dictionaryTracks[0].dictionaryTokenStatusColors],
+    dictionaryTokenStatusConfig: defaultSettings.dictionaryTracks[0].dictionaryTokenStatusConfig.map((config) => ({
+        ...config,
+    })),
+    ...overrides,
+});
+
+const makeDisabledDictionaryTrack = (overrides: Partial<DictionaryTrack> = {}): DictionaryTrack =>
+    makeDictionaryTrack({
+        dictionaryColorizeSubtitles: false,
+        dictionaryAutoGenerateStatistics: false,
+        dictionaryTokenReadingAnnotation: TokenReadingAnnotation.NEVER,
+        dictionaryDisplayIgnoredTokenReadings: false,
+        dictionaryTokenFrequencyAnnotation: TokenFrequencyAnnotation.NEVER,
+        ...overrides,
+    });
+
+const makeSettings = (dictionaryTracks: DictionaryTrack[]) => ({
+    ...defaultSettings,
+    dictionaryTracks,
+});
+
+const makeToken = (overrides: Record<string, unknown> = {}) => ({
+    pos: [0, 5] as [number, number],
+    states: [] as TokenState[],
+    readings: [],
+    status: TokenStatus.UNKNOWN,
+    groupingKey: 'token:word',
+    frequency: 1,
+    ...overrides,
+});
+
+const makeSentence = (overrides: Partial<DictionaryStatisticsSentence> = {}): DictionaryStatisticsSentence => ({
+    text: 'word',
+    start: 0,
+    end: 1000,
+    track: 0,
+    index: 0,
+    tokenization: { tokens: [] },
+    ...overrides,
+});
+
+const makeStorage = () => ({
+    getAllTokens: jest.fn(async () => ({})),
+    publishStatisticsSnapshot: jest.fn(async () => undefined),
+});
+
+const makeSettingsProvider = (settings: ReturnType<typeof makeSettings>) =>
+    ({
+        getAll: jest.fn(async () => settings),
+        getSingle: jest.fn(async (key: keyof typeof settings) => settings[key]),
+    }) as any;
+
+const makeStatistics = (settings = makeSettings([makeDisabledDictionaryTrack()])) => {
+    const storage = makeStorage();
+    const provider = new DictionaryProvider(storage as any);
+    const settingsProvider = makeSettingsProvider(settings);
+    const statistics = new DictionaryStatistics(settingsProvider, provider, 'media-id');
+
+    return { statistics, settingsProvider, storage };
+};
+
+const deferred = <T>() => {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return { promise, resolve, reject };
+};
+
+const lastPublishedSnapshot = (storage: ReturnType<typeof makeStorage>) => {
+    const calls = storage.publishStatisticsSnapshot.mock.calls as any[][];
+    return calls[calls.length - 1]?.[1] as DictionaryStatisticsSnapshot | undefined;
+};
+
+const frequencyBucketCount = (trackSnapshot: { frequencyBuckets: { label: string; count: number }[] }, label: string) =>
+    trackSnapshot.frequencyBuckets.find((bucket) => bucket.label === label)?.count;
+
+const makeProcessingSnapshot = (): DictionaryStatisticsSnapshot => ({
+    mediaId: 'media-id',
+    settings: makeSettings([
+        makeDictionaryTrack({
+            dictionaryAutoGenerateStatistics: true,
+            dictionaryAnkiTreatSuspended: TokenStatus.UNKNOWN,
+        }),
+    ]),
+    anki: {
+        cardsInfo: {},
+        dueCards: {},
+    },
+    snapshots: [
+        {
+            track: 0,
+            progress: { current: 2, total: 2, startedAt: 1 },
+            statusColors: {
+                [TokenStatus.UNCOLLECTED]: '#000000FF',
+                [TokenStatus.UNKNOWN]: '#111111FF',
+                [TokenStatus.LEARNING]: '#222222FF',
+                [TokenStatus.GRADUATED]: '#333333FF',
+                [TokenStatus.YOUNG]: '#444444FF',
+                [TokenStatus.MATURE]: '#555555FF',
+            },
+            stats: {
+                dictionary: {
+                    tokens: {
+                        alpha: {
+                            source: DictionaryTokenSource.LOCAL,
+                            statuses: [{ status: TokenStatus.LEARNING, suspended: false }],
+                            states: [],
+                        },
+                        beta: {
+                            source: DictionaryTokenSource.LOCAL,
+                            statuses: [],
+                            states: [],
+                        },
+                        gamma: {
+                            source: DictionaryTokenSource.LOCAL,
+                            statuses: [],
+                            states: [],
+                        },
+                        ignored: {
+                            source: DictionaryTokenSource.LOCAL,
+                            statuses: [{ status: TokenStatus.MATURE, suspended: false }],
+                            states: [TokenState.IGNORED],
+                        },
+                    },
+                },
+                sentences: {
+                    1: makeSentence({
+                        index: 1,
+                        text: 'beta gamma ignored skip 123',
+                        tokenization: {
+                            tokens: [
+                                makeToken({
+                                    pos: [0, 4],
+                                    groupingKey: 'token:beta',
+                                    status: TokenStatus.UNCOLLECTED,
+                                    frequency: 3000,
+                                }),
+                                makeToken({
+                                    pos: [5, 10],
+                                    groupingKey: 'token:gamma',
+                                    status: TokenStatus.UNCOLLECTED,
+                                    frequency: 25001,
+                                }),
+                                makeToken({
+                                    pos: [11, 18],
+                                    groupingKey: 'token:ignored',
+                                    status: TokenStatus.UNKNOWN,
+                                    states: [TokenState.IGNORED],
+                                    frequency: 400,
+                                }),
+                                makeToken({ pos: [19, 23], groupingKey: undefined, frequency: 900 }),
+                                makeToken({
+                                    pos: [24, 27],
+                                    groupingKey: 'token:number',
+                                    status: TokenStatus.MATURE,
+                                    frequency: 2,
+                                }),
+                            ],
+                        },
+                    }),
+                    0: makeSentence({
+                        index: 0,
+                        text: 'alpha beta alpha',
+                        tokenization: {
+                            tokens: [
+                                makeToken({
+                                    pos: [0, 5],
+                                    groupingKey: 'token:alpha',
+                                    status: TokenStatus.LEARNING,
+                                    frequency: 100,
+                                }),
+                                makeToken({
+                                    pos: [6, 10],
+                                    groupingKey: 'token:beta',
+                                    status: TokenStatus.UNCOLLECTED,
+                                    frequency: 3000,
+                                }),
+                                makeToken({
+                                    pos: [11, 16],
+                                    groupingKey: 'token:alpha',
+                                    status: TokenStatus.UNKNOWN,
+                                    frequency: 50,
+                                }),
+                            ],
+                        },
+                    }),
+                },
+            },
+        },
+    ],
+});
+
+const makeAnkiSnapshot = (): DictionaryStatisticsSnapshot => ({
+    mediaId: 'media-id',
+    settings: makeSettings([
+        makeDictionaryTrack({
+            dictionaryAutoGenerateStatistics: true,
+            dictionaryAnkiTreatSuspended: TokenStatus.UNKNOWN,
+        }),
+    ]),
+    anki: {
+        available: true,
+        progress: { current: 1, total: 2, startedAt: 10 },
+        dueCards: {
+            0: [10],
+            1: [11],
+            7: [11, 12],
+        },
+        cardsInfo: {
+            10: { cardId: 10, deckName: 'Deck B', modelName: 'Model Y' } as any,
+            11: { cardId: 11, deckName: 'Deck A', modelName: 'Model X' } as any,
+            12: { cardId: 12, deckName: 'Deck A', modelName: 'Model Y' } as any,
+        },
+    },
+    snapshots: [
+        {
+            track: 0,
+            progress: { current: 2, total: 2, startedAt: 1 },
+            statusColors: {
+                [TokenStatus.UNCOLLECTED]: '#000000FF',
+                [TokenStatus.UNKNOWN]: '#111111FF',
+                [TokenStatus.LEARNING]: '#222222FF',
+                [TokenStatus.GRADUATED]: '#333333FF',
+                [TokenStatus.YOUNG]: '#444444FF',
+                [TokenStatus.MATURE]: '#555555FF',
+            },
+            stats: {
+                dictionary: {
+                    tokens: {
+                        alpha: {
+                            source: DictionaryTokenSource.LOCAL,
+                            statuses: [
+                                { cardId: 10, status: TokenStatus.LEARNING, suspended: false },
+                                { cardId: 11, status: TokenStatus.GRADUATED, suspended: true },
+                            ],
+                            states: [],
+                        },
+                        beta: {
+                            source: DictionaryTokenSource.LOCAL,
+                            statuses: [{ cardId: 12, status: TokenStatus.MATURE, suspended: false }],
+                            states: [],
+                        },
+                        gamma: {
+                            source: DictionaryTokenSource.LOCAL,
+                            statuses: [{ cardId: 13, status: TokenStatus.LEARNING, suspended: false }],
+                            states: [TokenState.IGNORED],
+                        },
+                    },
+                },
+                sentences: {
+                    0: makeSentence({
+                        text: 'alpha beta',
+                        tokenization: {
+                            tokens: [
+                                makeToken({ pos: [0, 5], groupingKey: 'token:alpha', frequency: 100 }),
+                                makeToken({ pos: [6, 10], groupingKey: 'beta', frequency: 6000 }),
+                            ],
+                        },
+                    }),
+                    1: makeSentence({
+                        index: 1,
+                        text: 'alpha gamma',
+                        tokenization: {
+                            tokens: [
+                                makeToken({ pos: [0, 5], groupingKey: 'token:alpha', frequency: 100 }),
+                                makeToken({ pos: [6, 11], groupingKey: 'token:gamma', frequency: 50 }),
+                            ],
+                        },
+                    }),
+                },
+            },
+        },
+    ],
+});
+
+const makeUnknownFrequencySnapshot = (): DictionaryStatisticsSnapshot => ({
+    mediaId: 'media-id',
+    settings: makeSettings([makeDictionaryTrack({ dictionaryAutoGenerateStatistics: true })]),
+    anki: {
+        cardsInfo: {},
+        dueCards: {},
+    },
+    snapshots: [
+        {
+            track: 0,
+            progress: { current: 1, total: 1, startedAt: 1 },
+            statusColors: {
+                [TokenStatus.UNCOLLECTED]: '#000000FF',
+                [TokenStatus.UNKNOWN]: '#111111FF',
+                [TokenStatus.LEARNING]: '#222222FF',
+                [TokenStatus.GRADUATED]: '#333333FF',
+                [TokenStatus.YOUNG]: '#444444FF',
+                [TokenStatus.MATURE]: '#555555FF',
+            },
+            stats: {
+                dictionary: {
+                    tokens: {
+                        delta: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
+                        epsilon: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
+                    },
+                },
+                sentences: {
+                    0: makeSentence({
+                        text: 'delta epsilon',
+                        tokenization: {
+                            tokens: [
+                                makeToken({
+                                    pos: [0, 5],
+                                    groupingKey: 'token:delta',
+                                    status: TokenStatus.UNKNOWN,
+                                    frequency: null,
+                                }),
+                                makeToken({
+                                    pos: [6, 13],
+                                    groupingKey: 'token:epsilon',
+                                    status: TokenStatus.UNCOLLECTED,
+                                    frequency: 1500,
+                                }),
+                            ],
+                        },
+                    }),
+                },
+            },
+        },
+    ],
+});
+
+const makeEntry = (
+    index: number,
+    overrides: Partial<DictionaryStatisticsSentenceBucketEntry> = {}
+): DictionaryStatisticsSentenceBucketEntry => ({
+    sentence: makeSentence({ index, text: `sentence-${index}` }),
+    numConsideredTokens: 2,
+    numKnownTokens: 1,
+    numUnknownTokens: 0,
+    numUncollectedTokens: 1,
+    lowestFrequency: 100,
+    highestOccurrences: 1,
+    comprehensionPercent: 50,
+    comprehensionBandIndex: 0,
+    ...overrides,
+});
+
+beforeEach(() => {
+    let now = 1;
+    jest.spyOn(Date, 'now').mockImplementation(() => now++);
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+describe('DictionaryStatistics', () => {
+    it('publishes undefined before initialization, sorts snapshots, and resets state', () => {
+        const { statistics, storage } = makeStatistics();
+
+        expect(statistics.hasStatistics()).toBe(false);
+        statistics.publishSnapshot();
+        expect(storage.publishStatisticsSnapshot).toHaveBeenLastCalledWith('media-id', undefined);
+
+        statistics.init(2, 2);
+        statistics.init(0, 1);
+        statistics.ingest(makeSentence({ track: 2, index: 3, text: 'track-two' }));
+        statistics.ingest(makeSentence({ track: 0, index: 1, text: 'track-zero' }));
+        statistics.updateProgress(2, 1);
+        statistics.replaceAnkiSnapshot({
+            available: true,
+            cardsInfo: { 9: { cardId: 9 } as any },
+            dueCards: { 0: [9] },
+        });
+        statistics.publishSnapshot();
+
+        const snapshot = lastPublishedSnapshot(storage)!;
+        expect(statistics.hasStatistics()).toBe(true);
+        expect(snapshot.mediaId).toBe('media-id');
+        expect(snapshot.snapshots.map((trackSnapshot) => trackSnapshot.track)).toEqual([0, 2]);
+        expect(snapshot.snapshots[0].progress.total).toBe(1);
+        expect(snapshot.snapshots[1].progress.current).toBe(1);
+        expect(snapshot.snapshots[0].stats.sentences[1].text).toBe('track-zero');
+        expect(snapshot.snapshots[1].stats.sentences[3].text).toBe('track-two');
+        expect(snapshot.anki).toEqual({ available: true, cardsInfo: { 9: { cardId: 9 } }, dueCards: { 0: [9] } });
+
+        statistics.reset();
+        expect(statistics.hasStatistics()).toBe(false);
+        expect(storage.publishStatisticsSnapshot).toHaveBeenLastCalledWith('media-id', undefined);
+    });
+
+    it('throws for uninitialized track updates and ingestion', async () => {
+        const enabledTrack = makeDictionaryTrack({ dictionaryAutoGenerateStatistics: true });
+        const { statistics } = makeStatistics(makeSettings([enabledTrack]));
+
+        expect(() => statistics.updateProgress(0, 1)).toThrow('Track 0 not initialized');
+        expect(() => statistics.ingest(makeSentence({ track: 0 }))).toThrow('Track 0 not initialized');
+        await expect(statistics.refreshDictionaryTokens('profile')).rejects.toThrow('Track 0 not initialized');
+    });
+
+    it('stores replaced Anki snapshots and avoids publishing before stats exist', () => {
+        const { statistics, storage } = makeStatistics();
+
+        statistics.replaceAnkiSnapshot({
+            available: true,
+            progress: { current: 0, total: 2, startedAt: 77 },
+            cardsInfo: { 1: { cardId: 1 } as any },
+            dueCards: {},
+        });
+        expect(storage.publishStatisticsSnapshot).not.toHaveBeenCalled();
+
+        statistics.init(0, 2);
+        statistics.replaceAnkiSnapshot({
+            progress: { current: 1, total: 2, startedAt: 999 },
+            cardsInfo: { 2: { cardId: 2 } as any },
+            dueCards: {},
+        });
+
+        expect(lastPublishedSnapshot(storage)?.anki).toEqual({
+            progress: { current: 1, total: 2, startedAt: 999 },
+            cardsInfo: { 2: { cardId: 2 } },
+            dueCards: {},
+        });
+    });
+
+    it('stores replaced anki snapshots before initialization and publishes availability-only updates afterward', () => {
+        const { statistics, storage } = makeStatistics();
+
+        statistics.replaceAnkiSnapshot({ available: false, cardsInfo: {}, dueCards: {} });
+        expect(storage.publishStatisticsSnapshot).not.toHaveBeenCalled();
+
+        statistics.init(0, 1);
+        statistics.replaceAnkiSnapshot({ available: false, cardsInfo: {}, dueCards: {} });
+
+        expect(lastPublishedSnapshot(storage)?.anki).toEqual({ available: false, cardsInfo: {}, dueCards: {} });
+    });
+
+    it('stores WaniKani snapshots before initialization and publishes a top-level copy afterward', () => {
+        const { statistics, storage } = makeStatistics();
+        const initial = {
+            0: { available: true, assignments: [{ id: 1 }], subjects: { 1: { id: 1 } } },
+        } as any;
+
+        statistics.replaceWaniKaniSnapshots(initial);
+        expect(storage.publishStatisticsSnapshot).not.toHaveBeenCalled();
+
+        initial[1] = { available: false, assignments: [], subjects: {} };
+        statistics.init(0, 1);
+        statistics.publishSnapshot();
+        expect(lastPublishedSnapshot(storage)?.waniKani).toEqual({
+            0: { available: true, assignments: [{ id: 1 }], subjects: { 1: { id: 1 } } },
+        });
+
+        statistics.replaceWaniKaniSnapshots({
+            1: { available: false, assignments: [], subjects: {} },
+        });
+        expect(lastPublishedSnapshot(storage)?.waniKani).toEqual({
+            1: { available: false, assignments: [], subjects: {} },
+        });
+    });
+
+    it('refreshes dictionary tokens for enabled tracks, skips disabled tracks, and fills default status colors', async () => {
+        const enabledWithPartialConfig = makeDictionaryTrack({
+            dictionaryAutoGenerateStatistics: true,
+            dictionaryTokenStatusConfig: [
+                { color: '#111111', alpha: 'AA', display: true },
+                { color: '#222222', alpha: 'BB', display: true },
+            ],
+        });
+        const disabledTrack = makeDisabledDictionaryTrack();
+        const enabledWithDefaults = makeDictionaryTrack({ dictionaryAutoGenerateStatistics: true });
+        const settings = makeSettings([enabledWithPartialConfig, disabledTrack, enabledWithDefaults]);
+        const { statistics, settingsProvider, storage } = makeStatistics(settings);
+
+        statistics.init(0, 1);
+        statistics.init(2, 2);
+
+        storage.getAllTokens
+            .mockResolvedValueOnce({ alpha: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] } })
+            .mockResolvedValueOnce({ beta: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] } });
+
+        await statistics.refreshDictionaryTokens('profile');
+
+        expect(settingsProvider.getSingle).toHaveBeenCalledWith('dictionaryTracks');
+        expect((storage.getAllTokens.mock.calls as any[][]).map((call) => call[1])).toEqual([0, 2]);
+
+        const snapshot = lastPublishedSnapshot(storage)!;
+        expect(snapshot.settings).toEqual({ dictionaryTracks: settings.dictionaryTracks });
+        expect(snapshot.snapshots[0].stats.dictionary.tokens).toEqual({
+            alpha: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
+        });
+        expect(snapshot.snapshots[1].stats.dictionary.tokens).toEqual({
+            beta: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
+        });
+        expect(snapshot.snapshots[0].statusColors[0]).toBe('#111111AA');
+        expect(snapshot.snapshots[0].statusColors[1]).toBe('#222222BB');
+        expect(snapshot.snapshots[0].statusColors[2]).toBe('#9E9E9EFF');
+        expect(snapshot.snapshots[1].statusColors[0]).toBe(
+            `${enabledWithDefaults.dictionaryTokenStatusConfig[0].color}${enabledWithDefaults.dictionaryTokenStatusConfig[0].alpha}`
+        );
+    });
+
+    it('blocks stale publishes that started before reset', async () => {
+        const settings = makeSettings([makeDictionaryTrack({ dictionaryAutoGenerateStatistics: true })]);
+        const { statistics, storage } = makeStatistics(settings);
+        const pendingTokens =
+            deferred<Record<string, { source: DictionaryTokenSource; statuses: never[]; states: never[] }>>();
+
+        statistics.init(0, 1);
+        storage.getAllTokens.mockReturnValueOnce(pendingTokens.promise);
+
+        const refreshPromise = statistics.refreshDictionaryTokens('profile');
+        await Promise.resolve();
+
+        statistics.reset();
+        pendingTokens.resolve({ alpha: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] } });
+        await refreshPromise;
+
+        expect(storage.publishStatisticsSnapshot).toHaveBeenCalledTimes(1);
+        expect(storage.publishStatisticsSnapshot).toHaveBeenCalledWith('media-id', undefined);
+    });
+
+    it('rejects refresh failures after publishing completed track snapshots', async () => {
+        const settings = makeSettings([
+            makeDictionaryTrack({ dictionaryAutoGenerateStatistics: true }),
+            makeDictionaryTrack({ dictionaryAutoGenerateStatistics: true }),
+        ]);
+        const { statistics, storage } = makeStatistics(settings);
+        const firstTrackTokens =
+            deferred<Record<string, { source: DictionaryTokenSource; statuses: never[]; states: never[] }>>();
+        const secondTrackTokens =
+            deferred<Record<string, { source: DictionaryTokenSource; statuses: never[]; states: never[] }>>();
+
+        statistics.init(0, 1);
+        statistics.init(1, 1);
+        storage.getAllTokens
+            .mockReturnValueOnce(firstTrackTokens.promise)
+            .mockReturnValueOnce(secondTrackTokens.promise);
+
+        const refreshPromise = statistics.refreshDictionaryTokens('profile');
+        await Promise.resolve();
+        firstTrackTokens.resolve({ alpha: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] } });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(lastPublishedSnapshot(storage)?.snapshots[0].stats.dictionary.tokens).toEqual({
+            alpha: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
+        });
+
+        secondTrackTokens.reject(new Error('track failed'));
+        await expect(refreshPromise).rejects.toThrow('track failed');
+    });
+});
+
+describe('dictionary-statistics view helpers', () => {
+    it('handles clamp, percent, and display helpers at key boundaries', () => {
+        expect(clampPercent(-10)).toBe(0);
+        expect(clampPercent(75)).toBe(75);
+        expect(clampPercent(120)).toBe(100);
+
+        expect(percent(0, 0)).toBe(0);
+        expect(percent(1, 2)).toBe(50);
+        expect(percentDisplay(100)).toBe('100%');
+        expect(percentDisplay(99.9994)).toBe('99.999%');
+        expect(percentDisplay(9.94)).toBe('9.9%');
+        expect(averageDisplay(1)).toBe('1.0');
+        expect(countPercentOccurrencesDisplay(1, 2, 3)).toBe('1 · 50.0% (3)');
+    });
+
+    it('maps comprehension bands and x-axis labels for 0, 1, 2, and many points', () => {
+        expect(dictionaryStatisticsComprehensionBandForPercent(-1).label).toBe('<60');
+        expect(dictionaryStatisticsComprehensionBandForPercent(60).label).toBe('60+');
+        expect(dictionaryStatisticsComprehensionBandForPercent(95).label).toBe('95+');
+        expect(dictionaryStatisticsComprehensionBandForPercent(120).label).toBe('95+');
+        expect(
+            sentenceComprehensionPointLabel({
+                sentence: makeSentence({ index: 1 }),
+                comprehensionPercent: 75,
+                comprehensionBandIndex: 1,
+            })
+        ).toBe('#2 · 75.0%');
+
+        expect(sentenceComprehensionXAxisLabels([])).toEqual([{ value: 1, position: 0 }]);
+        expect(
+            sentenceComprehensionXAxisLabels([
+                { sentence: makeSentence(), comprehensionPercent: 50, comprehensionBandIndex: 0 },
+            ])
+        ).toEqual([{ value: 1, position: 0 }]);
+        expect(
+            sentenceComprehensionXAxisLabels([
+                { sentence: makeSentence({ index: 0 }), comprehensionPercent: 50, comprehensionBandIndex: 0 },
+                { sentence: makeSentence({ index: 1 }), comprehensionPercent: 75, comprehensionBandIndex: 1 },
+            ])
+        ).toEqual([{ value: 1, position: 0 }]);
+
+        const manyLabels = sentenceComprehensionXAxisLabels(
+            Array.from({ length: 120 }, (_, index) => ({
+                sentence: makeSentence({ index }),
+                comprehensionPercent: 50,
+                comprehensionBandIndex: 0,
+            }))
+        );
+        expect(manyLabels.map((label) => label.value)).toEqual([1, 50, 100]);
+        expect(manyLabels[1].position).toBeCloseTo((49 / 119) * 100, 6);
+        expect(manyLabels[2].position).toBeCloseTo((99 / 119) * 100, 6);
+    });
+
+    it('cycles default sort helpers and toggles direction', () => {
+        expect(defaultDictionaryStatisticsSentenceSortDirection('index')).toBe('asc');
+        expect(defaultDictionaryStatisticsSentenceSortDirection('occurrences')).toBe('desc');
+        expect(defaultDictionaryStatisticsSentenceSortState()).toEqual({ sort: 'index', direction: 'asc' });
+        expect(defaultDictionaryStatisticsSentenceSortState('frequency')).toEqual({
+            sort: 'frequency',
+            direction: 'asc',
+        });
+
+        expect(nextDictionaryStatisticsSentenceSortCategory({ sort: 'index', direction: 'asc' })).toEqual({
+            sort: 'frequency',
+            direction: 'asc',
+        });
+        expect(nextDictionaryStatisticsSentenceSortCategory({ sort: 'comprehension', direction: 'desc' })).toEqual({
+            sort: 'index',
+            direction: 'desc',
+        });
+        expect(nextDictionaryStatisticsSentenceSortDirection({ sort: 'index', direction: 'asc' })).toEqual({
+            sort: 'index',
+            direction: 'desc',
+        });
+        expect(nextDictionaryStatisticsSentenceSortDirection({ sort: 'index', direction: 'desc' })).toEqual({
+            sort: 'index',
+            direction: 'asc',
+        });
+    });
+
+    it('returns sentence dialog data for all-known, uncollected, and unknown buckets', () => {
+        const sentenceBuckets: DictionaryStatisticsSentenceBuckets = {
+            allKnown: { count: 1, entries: [makeEntry(0)] },
+            uncollected: [
+                { tokenCount: 1, count: 1, entries: [makeEntry(1)] },
+                { tokenCount: 2, count: 1, entries: [makeEntry(2)] },
+            ],
+            unknown: [
+                { tokenCount: 1, count: 1, entries: [makeEntry(3)] },
+                { tokenCount: 2, count: 1, entries: [makeEntry(4)] },
+            ],
+        };
+
+        expect(
+            sentenceDialogBucketData({ kind: 'allKnown' }, sentenceBuckets, {
+                knownSentencesLabel: 'Known',
+                uncollectedLabel: 'Uncollected',
+                unknownLabel: 'Unknown',
+            })
+        ).toEqual({ label: 'Known', entries: [sentenceBuckets.allKnown.entries[0]] });
+
+        expect(
+            sentenceDialogBucketData({ kind: 'uncollected', groupIndex: 1 }, sentenceBuckets, {
+                knownSentencesLabel: 'Known',
+                uncollectedLabel: 'Uncollected',
+                unknownLabel: 'Unknown',
+            })
+        ).toEqual({ label: '2+ Uncollected', entries: [sentenceBuckets.uncollected[1].entries[0]] });
+        expect(statusSentenceBucketLabel(sentenceBuckets.uncollected[0], 'Uncollected')).toBe('1 Uncollected');
+        expect(
+            sentenceDialogBucketData({ kind: 'unknown', groupIndex: 0 }, sentenceBuckets, {
+                knownSentencesLabel: 'Known',
+                uncollectedLabel: 'Uncollected',
+                unknownLabel: 'Unknown',
+            })
+        ).toEqual({ label: '1 Unknown', entries: [sentenceBuckets.unknown[0].entries[0]] });
+        expect(
+            sentenceDialogBucketData({ kind: 'unknown', groupIndex: 1 }, sentenceBuckets, {
+                knownSentencesLabel: 'Known',
+                uncollectedLabel: 'Uncollected',
+                unknownLabel: 'Unknown',
+            })
+        ).toEqual({ label: '2+ Unknown', entries: [sentenceBuckets.unknown[1].entries[0]] });
+        expect(statusSentenceBucketLabel(sentenceBuckets.unknown[0], 'Unknown')).toBe('1 Unknown');
+
+        expect(
+            sentenceDialogBucketData({ kind: 'uncollected', groupIndex: 9 }, sentenceBuckets, {
+                knownSentencesLabel: 'Known',
+                uncollectedLabel: 'Uncollected',
+                unknownLabel: 'Unknown',
+            })
+        ).toBeUndefined();
+        expect(
+            sentenceDialogBucketData({ kind: 'unknown', groupIndex: 9 }, sentenceBuckets, {
+                knownSentencesLabel: 'Known',
+                uncollectedLabel: 'Uncollected',
+                unknownLabel: 'Unknown',
+            })
+        ).toBeUndefined();
+    });
+
+    it('selects and clamps rewatch snapshots by track', () => {
+        const trackSnapshot = processDictionaryStatisticsSnapshot(makeProcessingSnapshot())[0];
+
+        expect(selectedRewatchSnapshotForTrack({ ...trackSnapshot, rewatchSnapshots: [] }, {})).toBeUndefined();
+        expect(selectedRewatchSnapshotForTrack(trackSnapshot, {})?.rewatch).toBe(0);
+        expect(selectedRewatchSnapshotForTrack(trackSnapshot, { 0: 99 })?.rewatch).toBe(2);
+    });
+
+    it('sorts sentence bucket entries deterministically across categories and directions', () => {
+        const entries = [
+            makeEntry(2, { lowestFrequency: 100, highestOccurrences: 1, comprehensionPercent: 80 }),
+            makeEntry(0, { lowestFrequency: 50, highestOccurrences: 2, comprehensionPercent: 80 }),
+            makeEntry(1, { lowestFrequency: 50, highestOccurrences: 1, comprehensionPercent: 60 }),
+        ];
+
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(entries, { sort: 'comprehension', direction: 'desc' }).map(
+                (entry) => entry.sentence.index
+            )
+        ).toEqual([0, 2, 1]);
+
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(entries, { sort: 'frequency', direction: 'asc' }).map(
+                (entry) => entry.sentence.index
+            )
+        ).toEqual([0, 1, 2]);
+
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(entries, { sort: 'occurrences', direction: 'desc' }).map(
+                (entry) => entry.sentence.index
+            )
+        ).toEqual([0, 2, 1]);
+
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(entries, { sort: 'index', direction: 'desc' }).map(
+                (entry) => entry.sentence.index
+            )
+        ).toEqual([2, 1, 0]);
+    });
+
+    it('covers sort tie-break fallbacks for occurrences and index ordering', () => {
+        const sameOccurrenceEntries = [
+            makeEntry(2, { highestOccurrences: 1, lowestFrequency: 100, comprehensionPercent: 50 }),
+            makeEntry(1, { highestOccurrences: 1, lowestFrequency: 100, comprehensionPercent: 50 }),
+        ];
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(sameOccurrenceEntries, {
+                sort: 'occurrences',
+                direction: 'asc',
+            }).map((entry) => entry.sentence.index)
+        ).toEqual([1, 2]);
+
+        const sameOccurrenceDifferentFrequency = [
+            makeEntry(2, { highestOccurrences: 1, comprehensionPercent: 50, lowestFrequency: 300 }),
+            makeEntry(1, { highestOccurrences: 1, comprehensionPercent: 50, lowestFrequency: 100 }),
+        ];
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(sameOccurrenceDifferentFrequency, {
+                sort: 'occurrences',
+                direction: 'asc',
+            }).map((entry) => entry.lowestFrequency)
+        ).toEqual([300, 100]);
+
+        const sameIndexDifferentFrequency = [
+            makeEntry(0, { lowestFrequency: 200, highestOccurrences: 1, comprehensionPercent: 40 }),
+            makeEntry(0, { lowestFrequency: 100, highestOccurrences: 1, comprehensionPercent: 40 }),
+        ];
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(sameIndexDifferentFrequency, {
+                sort: 'index',
+                direction: 'asc',
+            }).map((entry) => entry.lowestFrequency)
+        ).toEqual([100, 200]);
+
+        const sameIndexDifferentOccurrences = [
+            makeEntry(0, { lowestFrequency: 100, highestOccurrences: 1, comprehensionPercent: 40 }),
+            makeEntry(0, { lowestFrequency: 100, highestOccurrences: 3, comprehensionPercent: 40 }),
+        ];
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(sameIndexDifferentOccurrences, {
+                sort: 'index',
+                direction: 'asc',
+            }).map((entry) => entry.highestOccurrences)
+        ).toEqual([3, 1]);
+
+        const sameIndexDifferentComprehension = [
+            makeEntry(0, { lowestFrequency: 100, highestOccurrences: 1, comprehensionPercent: 40 }),
+            makeEntry(0, { lowestFrequency: 100, highestOccurrences: 1, comprehensionPercent: 70 }),
+        ];
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(sameIndexDifferentComprehension, {
+                sort: 'index',
+                direction: 'asc',
+            }).map((entry) => entry.comprehensionPercent)
+        ).toEqual([70, 40]);
+
+        const identicalEntries = [
+            makeEntry(0, { lowestFrequency: 100, highestOccurrences: 1, comprehensionPercent: 40 }),
+            makeEntry(0, { lowestFrequency: 100, highestOccurrences: 1, comprehensionPercent: 40 }),
+        ];
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(identicalEntries, {
+                sort: 'index',
+                direction: 'asc',
+            })
+        ).toEqual(identicalEntries);
+    });
+
+    it('covers sort tie-break fallbacks for comprehension and frequency ordering', () => {
+        const sameComprehensionDifferentOccurrences = [
+            makeEntry(2, { comprehensionPercent: 80, lowestFrequency: 100, highestOccurrences: 1 }),
+            makeEntry(1, { comprehensionPercent: 80, lowestFrequency: 100, highestOccurrences: 3 }),
+        ];
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(sameComprehensionDifferentOccurrences, {
+                sort: 'comprehension',
+                direction: 'desc',
+            }).map((entry) => entry.highestOccurrences)
+        ).toEqual([3, 1]);
+
+        const sameComprehensionFullyTied = [
+            makeEntry(2, { comprehensionPercent: 80, lowestFrequency: 100, highestOccurrences: 1 }),
+            makeEntry(1, { comprehensionPercent: 80, lowestFrequency: 100, highestOccurrences: 1 }),
+        ];
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(sameComprehensionFullyTied, {
+                sort: 'comprehension',
+                direction: 'desc',
+            }).map((entry) => entry.sentence.index)
+        ).toEqual([1, 2]);
+
+        const sameFrequencyDifferentOccurrences = [
+            makeEntry(2, { lowestFrequency: 100, comprehensionPercent: 80, highestOccurrences: 1 }),
+            makeEntry(1, { lowestFrequency: 100, comprehensionPercent: 80, highestOccurrences: 3 }),
+        ];
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(sameFrequencyDifferentOccurrences, {
+                sort: 'frequency',
+                direction: 'asc',
+            }).map((entry) => entry.highestOccurrences)
+        ).toEqual([3, 1]);
+
+        const sameFrequencyFullyTied = [
+            makeEntry(2, { lowestFrequency: 100, comprehensionPercent: 80, highestOccurrences: 1 }),
+            makeEntry(1, { lowestFrequency: 100, comprehensionPercent: 80, highestOccurrences: 1 }),
+        ];
+        expect(
+            sortDictionaryStatisticsSentenceBucketEntries(sameFrequencyFullyTied, {
+                sort: 'frequency',
+                direction: 'asc',
+            }).map((entry) => entry.sentence.index)
+        ).toEqual([1, 2]);
+    });
+
+    it('processes simplified and full track snapshots with merged tokens, buckets, and rewatch projections', () => {
+        const snapshot = makeProcessingSnapshot();
+
+        const fullTrackSnapshot = processDictionaryStatisticsSnapshot(snapshot)[0];
+        expect(processDictionaryStatisticsSnapshot(undefined)).toEqual([]);
+        expect(fullTrackSnapshot.progressPercent).toBe(100);
+        expect(fullTrackSnapshot.numDictionaryKnownTokens).toBe(1);
+        expect(fullTrackSnapshot.numDictionaryIgnoredTokens).toBe(1);
+        expect(fullTrackSnapshot.numUniqueTokens).toBe(4);
+        expect(fullTrackSnapshot.consideredTokens).toBe(3);
+        expect(fullTrackSnapshot.numIgnoredTokens).toBe(1);
+        expect(fullTrackSnapshot.numIgnoredOccurrences).toBe(1);
+        expect(fullTrackSnapshot.numKnownTokens).toBe(1);
+        expect(fullTrackSnapshot.knownPercent).toBeCloseTo(100 / 3, 6);
+        expect(fullTrackSnapshot.comprehensionPercent).toBeCloseTo(10, 6);
+        expect(fullTrackSnapshot.averageWordsPerSentence).toBe(2);
+        expect(fullTrackSnapshot.averageKnownWordsPerSentence).toBe(0.5);
+        expect(fullTrackSnapshot.sentenceTotals.processedSentenceCount).toBe(2);
+        expect(fullTrackSnapshot.sentenceTotals.totalWords).toBe(4);
+        expect(fullTrackSnapshot.sentenceTotals.totalKnownWords).toBe(1);
+        expect(fullTrackSnapshot.sentenceComprehensionPoints.map((point) => point.sentence.index)).toEqual([0, 1]);
+        expect(fullTrackSnapshot.allSentenceEntries.map((entry) => entry.numUncollectedTokens)).toEqual([1, 2]);
+        expect(fullTrackSnapshot.sentenceBuckets.allKnown.count).toBe(0);
+        expect(fullTrackSnapshot.sentenceBuckets.uncollected[0].count).toBe(1);
+        expect(fullTrackSnapshot.sentenceBuckets.uncollected[1].count).toBe(1);
+        expect(frequencyBucketCount(fullTrackSnapshot, '1-1000')).toBe(1);
+        expect(frequencyBucketCount(fullTrackSnapshot, '2001-5000')).toBe(1);
+        expect(frequencyBucketCount(fullTrackSnapshot, '20000+')).toBe(1);
+        expect(frequencyBucketCount(fullTrackSnapshot, 'Unknown')).toBe(0);
+        expect(fullTrackSnapshot.rewatchSnapshots).toHaveLength(3);
+        expect(fullTrackSnapshot.rewatchSnapshots[0].rewatch).toBe(0);
+        expect(fullTrackSnapshot.rewatchSnapshots[1].rewatch).toBe(1);
+        expect(fullTrackSnapshot.rewatchSnapshots[1].numKnownTokens).toBe(2);
+        expect(fullTrackSnapshot.rewatchSnapshots[1].numDictionaryKnownTokens).toBe(2);
+        expect(fullTrackSnapshot.rewatchSnapshots[1].sentenceBuckets.allKnown.count).toBe(1);
+        expect(fullTrackSnapshot.rewatchSnapshots[2].rewatch).toBe(2);
+        expect(fullTrackSnapshot.rewatchSnapshots[2].numKnownTokens).toBe(3);
+        expect(fullTrackSnapshot.rewatchSnapshots[2].sentenceBuckets.allKnown.count).toBe(2);
+
+        const simplifiedTrackSnapshot = processSimplifiedDictionaryStatistics(snapshot)[0];
+        expect(processSimplifiedDictionaryStatistics(undefined)).toEqual([]);
+        expect(simplifiedTrackSnapshot.progress).toEqual(snapshot.snapshots[0].progress);
+        expect(simplifiedTrackSnapshot.comprehensionPercent).toBeCloseTo(10, 6);
+        expect(simplifiedTrackSnapshot.sentenceBuckets.uncollected[0].count).toBe(1);
+        expect(simplifiedTrackSnapshot.sentenceBuckets.uncollected[1].count).toBe(1);
+    });
+
+    it('processes anki track snapshots with due counts, deck grouping, suspended cards, and fallback grouping keys', () => {
+        const snapshot = makeAnkiSnapshot();
+        snapshot.anki.cardsInfo[20] = { cardId: 20, deckName: 'Deck C' } as any;
+        snapshot.anki.cardsInfo[21] = { cardId: 21, modelName: 'Model Z' } as any;
+        snapshot.snapshots[0].stats.dictionary.tokens.theta = {
+            source: DictionaryTokenSource.LOCAL,
+            statuses: [{ cardId: 20, status: TokenStatus.LEARNING, suspended: false }],
+            states: [],
+        };
+        snapshot.snapshots[0].stats.dictionary.tokens.nocard = {
+            source: DictionaryTokenSource.LOCAL,
+            statuses: [{ status: TokenStatus.LEARNING, suspended: false }],
+            states: [],
+        };
+        snapshot.snapshots[0].stats.dictionary.tokens.nodeck = {
+            source: DictionaryTokenSource.LOCAL,
+            statuses: [{ cardId: 21, status: TokenStatus.LEARNING, suspended: false }],
+            states: [],
+        };
+        snapshot.snapshots[0].stats.dictionary.tokens.skipped = {
+            source: DictionaryTokenSource.LOCAL,
+            statuses: [{ cardId: 22, status: TokenStatus.LEARNING, suspended: false }],
+            states: [],
+        };
+        snapshot.snapshots[0].stats.sentences[2] = makeSentence({
+            index: 2,
+            text: 'orphan theta nocard nodeck skipped',
+            tokenization: {
+                tokens: [
+                    makeToken({ pos: [0, 6], groupingKey: 'lemma:orphan', frequency: 10 }),
+                    makeToken({ pos: [7, 12], groupingKey: 'token:theta', frequency: 10 }),
+                    makeToken({ pos: [13, 19], groupingKey: 'token:nocard', frequency: 10 }),
+                    makeToken({ pos: [20, 26], groupingKey: 'token:nodeck', frequency: 10 }),
+                    makeToken({
+                        pos: [27, 34],
+                        groupingKey: 'token:skipped',
+                        frequency: 10,
+                        states: [TokenState.IGNORED],
+                    }),
+                ],
+            },
+        });
+
+        const empty = processDictionaryStatisticsAnkiTrackSnapshot(undefined, 0);
+        expect(empty).toEqual({
+            available: undefined,
+            progress: undefined,
+            progressPercent: 0,
+            dueCounts: { today: 0, tomorrow: 0, week: 0 },
+            deckSnapshots: [],
+        });
+
+        const trackSnapshot = processDictionaryStatisticsAnkiTrackSnapshot(snapshot, 0);
+        expect(trackSnapshot.available).toBe(true);
+        expect(trackSnapshot.progressPercent).toBe(50);
+        expect(trackSnapshot.dueCounts).toEqual({ today: 1, tomorrow: 1, week: 2 });
+        expect(trackSnapshot.deckSnapshots.map((deck) => deck.deckName)).toEqual(['Deck A', 'Deck B']);
+
+        expect(trackSnapshot.deckSnapshots[0]).toEqual(
+            expect.objectContaining({
+                deckName: 'Deck A',
+                dueCounts: { today: 0, tomorrow: 1, week: 2 },
+                suspendedCards: 1,
+            })
+        );
+        expect(trackSnapshot.deckSnapshots[0].modelSnapshots.map((model) => model.modelName)).toEqual([
+            'Model X',
+            'Model Y',
+        ]);
+        expect(trackSnapshot.deckSnapshots[0].modelSnapshots[0].uniqueWords).toBe(1);
+        expect(trackSnapshot.deckSnapshots[0].modelSnapshots[0].frequencyBuckets[0].count).toBe(1);
+        expect(trackSnapshot.deckSnapshots[0].modelSnapshots[1].frequencyBuckets[3].count).toBe(1);
+
+        expect(trackSnapshot.deckSnapshots[1]).toEqual(
+            expect.objectContaining({
+                deckName: 'Deck B',
+                dueCounts: { today: 1, tomorrow: 0, week: 0 },
+                suspendedCards: 0,
+            })
+        );
+        expect(trackSnapshot.deckSnapshots[1].modelSnapshots[0].modelName).toBe('Model Y');
+        expect(trackSnapshot.deckSnapshots[1].modelSnapshots[0].uniqueWords).toBe(1);
+
+        expect(processDictionaryStatisticsAnkiTrackSnapshot(snapshot, 99).deckSnapshots).toEqual([]);
+    });
+
+    it('projects unknown Anki cards by deck into rewatch and deck stats', () => {
+        const snapshot = makeUnknownFrequencySnapshot();
+        snapshot.anki = {
+            cardsStatus: {
+                10: TokenStatus.UNKNOWN,
+                20: TokenStatus.UNKNOWN,
+            },
+            cardsInfo: {
+                10: { cardId: 10, deckName: 'Deck A', due: 0 } as any,
+                20: { cardId: 20, deckName: 'Deck B', due: 1 } as any,
+            },
+            dueCards: {},
+        };
+        snapshot.snapshots[0].stats.dictionary.tokens.delta.statuses = [
+            { cardId: 10, status: TokenStatus.UNKNOWN, suspended: false },
+        ];
+        snapshot.snapshots[0].stats.dictionary.tokens.epsilon.statuses = [
+            { cardId: 20, status: TokenStatus.UNKNOWN, suspended: false },
+        ];
+
+        const currentTrackSnapshot = processDictionaryStatisticsSnapshot(snapshot)[0];
+        expect(currentTrackSnapshot.numKnownTokens).toBe(0);
+        expect(currentTrackSnapshot.ankiDeckStats).toEqual([
+            { deckName: 'Deck A', knownWords: 0, totalWords: 1 },
+            { deckName: 'Deck B', knownWords: 0, totalWords: 1 },
+        ]);
+
+        const projectedTrackSnapshot = processDictionaryStatisticsSnapshot(snapshot, {
+            0: { ankiUnknownCardsByDeck: { 'Deck A': 1 } },
+        })[0];
+
+        expect(projectedTrackSnapshot.totalUnknownAnkiCards).toBe(2);
+        expect(projectedTrackSnapshot.unknownAnkiCardsByDeck).toEqual([
+            { deckName: 'Deck A', totalUnknownCards: 1 },
+            { deckName: 'Deck B', totalUnknownCards: 1 },
+        ]);
+        expect(projectedTrackSnapshot.rewatchSnapshots[0].numKnownTokens).toBe(1);
+        expect(projectedTrackSnapshot.rewatchSnapshots[0].sentenceTotals.totalKnownWords).toBe(1);
+        expect(projectedTrackSnapshot.rewatchSnapshots[0].ankiDeckStats).toEqual([
+            { deckName: 'Deck A', knownWords: 1, totalWords: 1 },
+            { deckName: 'Deck B', knownWords: 0, totalWords: 1 },
+        ]);
+    });
+
+    it('defaults missing anki metadata when a raw track snapshot exists', () => {
+        const snapshot = makeAnkiSnapshot();
+        snapshot.settings = makeSettings([]);
+        snapshot.anki = { available: true } as any;
+
+        const trackSnapshot = processDictionaryStatisticsAnkiTrackSnapshot(snapshot, 0);
+        expect(trackSnapshot.available).toBe(true);
+        expect(trackSnapshot.progress).toBeUndefined();
+        expect(trackSnapshot.progressPercent).toBe(0);
+        expect(trackSnapshot.dueCounts).toEqual({ today: 0, tomorrow: 0, week: 0 });
+        expect(trackSnapshot.deckSnapshots).toEqual([]);
+    });
+
+    it('processes WaniKani track snapshots with due counts, frequency buckets, and level projections', () => {
+        const now = new Date();
+        const todayStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+        const availableToday = new Date(todayStart + 12 * 60 * 60 * 1000).toISOString();
+        const availableTomorrow = new Date(todayStart + 36 * 60 * 60 * 1000).toISOString();
+        const snapshot: DictionaryStatisticsSnapshot = {
+            mediaId: 'media-id',
+            settings: makeSettings([makeDictionaryTrack({ dictionaryAutoGenerateStatistics: true })]),
+            anki: {
+                cardsInfo: {},
+                dueCards: {},
+            },
+            waniKani: {
+                0: {
+                    available: true,
+                    assignments: [
+                        {
+                            profile: 'Profile',
+                            track: 0,
+                            assignmentId: 1,
+                            subjectId: 1,
+                            status: TokenStatus.UNKNOWN,
+                            data: { srs_stage: 1, hidden: false, available_at: availableToday },
+                        },
+                        {
+                            profile: 'Profile',
+                            track: 0,
+                            assignmentId: 2,
+                            subjectId: 2,
+                            status: TokenStatus.UNKNOWN,
+                            data: { srs_stage: 1, hidden: false, available_at: availableTomorrow },
+                        },
+                    ],
+                    subjects: {
+                        1: {
+                            profile: 'Profile',
+                            track: 0,
+                            subjectId: 1,
+                            data: {
+                                characters: 'alpha',
+                                hidden_at: null,
+                                level: 2,
+                                spaced_repetition_system_id: 1,
+                            },
+                        },
+                        2: {
+                            profile: 'Profile',
+                            track: 0,
+                            subjectId: 2,
+                            data: {
+                                characters: 'beta',
+                                hidden_at: null,
+                                level: 10,
+                                spaced_repetition_system_id: 1,
+                            },
+                        },
+                        3: {
+                            profile: 'Profile',
+                            track: 0,
+                            subjectId: 3,
+                            data: {
+                                characters: 'gamma',
+                                hidden_at: null,
+                                level: 3,
+                                spaced_repetition_system_id: 1,
+                            },
+                        },
+                    },
+                },
+            },
+            snapshots: [
+                {
+                    track: 0,
+                    progress: { current: 1, total: 1, startedAt: 1 },
+                    statusColors: makeProcessingSnapshot().snapshots[0].statusColors,
+                    stats: {
+                        dictionary: {
+                            tokens: {
+                                alpha: {
+                                    source: DictionaryTokenSource.WANIKANI,
+                                    statuses: [
+                                        {
+                                            status: TokenStatus.UNKNOWN,
+                                            suspended: false,
+                                            waniKani: {
+                                                subjectId: 1,
+                                                subjectLevel: 2,
+                                                assignmentId: 1,
+                                                availableAt: availableToday,
+                                            },
+                                        },
+                                    ],
+                                    states: [],
+                                },
+                                beta: {
+                                    source: DictionaryTokenSource.WANIKANI,
+                                    statuses: [
+                                        {
+                                            status: TokenStatus.UNKNOWN,
+                                            suspended: false,
+                                            waniKani: {
+                                                subjectId: 2,
+                                                subjectLevel: 10,
+                                                assignmentId: 2,
+                                                availableAt: availableTomorrow,
+                                            },
+                                        },
+                                    ],
+                                    states: [],
+                                },
+                                gamma: {
+                                    source: DictionaryTokenSource.WANIKANI,
+                                    statuses: [
+                                        {
+                                            status: TokenStatus.LEARNING,
+                                            suspended: false,
+                                            waniKani: {
+                                                subjectId: 3,
+                                                subjectLevel: 3,
+                                                assignmentId: undefined,
+                                                availableAt: undefined,
+                                            },
+                                        },
+                                    ],
+                                    states: [],
+                                },
+                                ignored: {
+                                    source: DictionaryTokenSource.WANIKANI,
+                                    statuses: [
+                                        {
+                                            status: TokenStatus.MATURE,
+                                            suspended: false,
+                                            waniKani: {
+                                                subjectId: 4,
+                                                subjectLevel: 1,
+                                                assignmentId: 4,
+                                                availableAt: availableToday,
+                                            },
+                                        },
+                                    ],
+                                    states: [TokenState.IGNORED],
+                                },
+                            },
+                        },
+                        sentences: {
+                            0: makeSentence({
+                                text: 'alpha beta gamma ignored',
+                                tokenization: {
+                                    tokens: [
+                                        makeToken({
+                                            pos: [0, 5],
+                                            groupingKey: 'token:alpha',
+                                            status: TokenStatus.UNKNOWN,
+                                            frequency: 100,
+                                        }),
+                                        makeToken({
+                                            pos: [6, 10],
+                                            groupingKey: 'token:beta',
+                                            status: TokenStatus.UNKNOWN,
+                                            frequency: 3000,
+                                        }),
+                                        makeToken({
+                                            pos: [11, 16],
+                                            groupingKey: 'token:gamma',
+                                            status: TokenStatus.LEARNING,
+                                            frequency: null,
+                                        }),
+                                        makeToken({
+                                            pos: [17, 24],
+                                            groupingKey: 'token:ignored',
+                                            status: TokenStatus.MATURE,
+                                            states: [TokenState.IGNORED],
+                                        }),
+                                    ],
+                                },
+                            }),
+                        },
+                    },
+                },
+            ],
+        };
+
+        const empty = processDictionaryStatisticsWaniKaniTrackSnapshot(undefined, 0);
+        expect(empty).toEqual({
+            available: undefined,
+            dueCounts: { today: 0, tomorrow: 0, week: 0 },
+            uniqueWords: 0,
+            frequencyBuckets: [],
+        });
+
+        const waniKaniTrackSnapshot = processDictionaryStatisticsWaniKaniTrackSnapshot(snapshot, 0);
+        expect(waniKaniTrackSnapshot.available).toBe(true);
+        expect(waniKaniTrackSnapshot.dueCounts).toEqual({ today: 1, tomorrow: 2, week: 2 });
+        expect(waniKaniTrackSnapshot.uniqueWords).toBe(3);
+        expect(frequencyBucketCount(waniKaniTrackSnapshot, '1-1000')).toBe(1);
+        expect(frequencyBucketCount(waniKaniTrackSnapshot, '2001-5000')).toBe(1);
+        expect(frequencyBucketCount(waniKaniTrackSnapshot, 'Unknown')).toBe(1);
+
+        const projectedTrackSnapshot = processDictionaryStatisticsSnapshot(snapshot, { 0: { waniKaniLevel: 3 } })[0];
+        expect(projectedTrackSnapshot.waniKaniStats).toEqual({ knownWords: 1, totalWords: 3 });
+        expect(projectedTrackSnapshot.rewatchSnapshots[0].waniKaniStats).toEqual({
+            level: 3,
+            knownWords: 2,
+            totalWords: 3,
+        });
+    });
+
+    it('counts unknown non-ignored tokens and unknown-frequency buckets', () => {
+        const trackSnapshot = processDictionaryStatisticsSnapshot(makeUnknownFrequencySnapshot())[0];
+
+        expect(trackSnapshot.allSentenceEntries[0].numUnknownTokens).toBe(1);
+        expect(trackSnapshot.allSentenceEntries[0].numUncollectedTokens).toBe(1);
+        expect(frequencyBucketCount(trackSnapshot, 'Unknown')).toBe(1);
+        expect(frequencyBucketCount(trackSnapshot, '1001-2000')).toBe(1);
+    });
+
+    it('assigns token frequencies at exact bucket boundaries', () => {
+        const snapshot = makeUnknownFrequencySnapshot();
+        const words = ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta', 'theta', 'iota', 'kappa'];
+        const frequencies = [1000, 1001, 2000, 2001, 5000, 5001, 10000, 10001, 20000, 20001];
+        const text = words.join(' ');
+        let pos = 0;
+        snapshot.snapshots[0].stats.sentences = {
+            0: makeSentence({
+                text,
+                tokenization: {
+                    tokens: words.map((word, index) => {
+                        const start = pos;
+                        pos += word.length + 1;
+                        return makeToken({
+                            pos: [start, start + word.length],
+                            groupingKey: `token:${word}`,
+                            frequency: frequencies[index],
+                        });
+                    }),
+                },
+            }),
+        };
+
+        const trackSnapshot = processDictionaryStatisticsSnapshot(snapshot)[0];
+
+        expect(frequencyBucketCount(trackSnapshot, '1-1000')).toBe(1);
+        expect(frequencyBucketCount(trackSnapshot, '1001-2000')).toBe(2);
+        expect(frequencyBucketCount(trackSnapshot, '2001-5000')).toBe(2);
+        expect(frequencyBucketCount(trackSnapshot, '5001-10000')).toBe(2);
+        expect(frequencyBucketCount(trackSnapshot, '10001-20000')).toBe(2);
+        expect(frequencyBucketCount(trackSnapshot, '20000+')).toBe(1);
+    });
+
+    it('groups one and multiple unknown-token sentences into unknown sentence buckets', () => {
+        const snapshot = makeUnknownFrequencySnapshot();
+        snapshot.snapshots[0].stats.dictionary.tokens = {
+            alpha: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
+            beta: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
+            delta: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
+            epsilon: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
+            gamma: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
+        };
+        snapshot.snapshots[0].stats.sentences = {
+            0: makeSentence({
+                text: 'alpha',
+                tokenization: {
+                    tokens: [
+                        makeToken({
+                            pos: [0, 5],
+                            groupingKey: 'token:alpha',
+                            status: TokenStatus.UNKNOWN,
+                        }),
+                    ],
+                },
+            }),
+            1: makeSentence({
+                index: 1,
+                text: 'beta gamma',
+                tokenization: {
+                    tokens: [
+                        makeToken({
+                            pos: [0, 4],
+                            groupingKey: 'token:beta',
+                            status: TokenStatus.UNKNOWN,
+                        }),
+                        makeToken({
+                            pos: [5, 10],
+                            groupingKey: 'token:gamma',
+                            status: TokenStatus.UNKNOWN,
+                        }),
+                    ],
+                },
+            }),
+            2: makeSentence({
+                index: 2,
+                text: 'delta epsilon',
+                tokenization: {
+                    tokens: [
+                        makeToken({
+                            pos: [0, 5],
+                            groupingKey: 'token:delta',
+                            status: TokenStatus.UNKNOWN,
+                        }),
+                        makeToken({
+                            pos: [6, 13],
+                            groupingKey: 'token:epsilon',
+                            status: TokenStatus.UNCOLLECTED,
+                        }),
+                    ],
+                },
+            }),
+        };
+
+        const trackSnapshot = processDictionaryStatisticsSnapshot(snapshot)[0];
+
+        expect(trackSnapshot.sentenceBuckets.unknown[0].count).toBe(1);
+        expect(trackSnapshot.sentenceBuckets.unknown[0].entries[0].sentence.index).toBe(0);
+        expect(trackSnapshot.sentenceBuckets.unknown[0].entries[0].numUnknownTokens).toBe(1);
+        expect(trackSnapshot.sentenceBuckets.unknown[1].count).toBe(1);
+        expect(trackSnapshot.sentenceBuckets.unknown[1].entries[0].sentence.index).toBe(1);
+        expect(trackSnapshot.sentenceBuckets.unknown[1].entries[0].numUnknownTokens).toBe(2);
+        expect(trackSnapshot.sentenceBuckets.uncollected[0].entries[0].sentence.index).toBe(2);
+        expect(trackSnapshot.sentenceBuckets.uncollected[0].entries[0].numUncollectedTokens).toBe(1);
+    });
+});

--- a/common/dictionary-statistics/dictionary-statistics.test.ts
+++ b/common/dictionary-statistics/dictionary-statistics.test.ts
@@ -4,11 +4,13 @@ import {
     defaultSettings,
     DictionaryTokenSource,
     DictionaryTrack,
+    SettingsProvider,
     TokenFrequencyAnnotation,
     TokenReadingAnnotation,
     TokenState,
     TokenStatus,
 } from '@project/common/settings';
+import { MockSettingsStorage } from '@project/common/settings/mock-settings-storage';
 import {
     averageDisplay,
     clampPercent,
@@ -89,16 +91,12 @@ const makeStorage = () => ({
     publishStatisticsSnapshot: jest.fn(async () => undefined),
 });
 
-const makeSettingsProvider = (settings: ReturnType<typeof makeSettings>) =>
-    ({
-        getAll: jest.fn(async () => settings),
-        getSingle: jest.fn(async (key: keyof typeof settings) => settings[key]),
-    }) as any;
-
 const makeStatistics = (settings = makeSettings([makeDisabledDictionaryTrack()])) => {
     const storage = makeStorage();
     const provider = new DictionaryProvider(storage as any);
-    const settingsProvider = makeSettingsProvider(settings);
+    const settingsStorage = new MockSettingsStorage();
+    settingsStorage.setData(settings);
+    const settingsProvider = new SettingsProvider(settingsStorage);
     const statistics = new DictionaryStatistics(settingsProvider, provider, 'media-id');
 
     return { statistics, settingsProvider, storage };
@@ -504,9 +502,14 @@ describe('DictionaryStatistics', () => {
         });
     });
 
-    it('refreshes dictionary tokens for enabled tracks, skips disabled tracks, and fills default status colors', async () => {
+    it('refreshes dictionary tokens for enabled tracks, skips disabled tracks, and normalizes status colors', async () => {
         const enabledWithPartialConfig = makeDictionaryTrack({
             dictionaryAutoGenerateStatistics: true,
+            dictionaryTokenStatusColors: [
+                '#111111',
+                '#222222',
+                ...defaultSettings.dictionaryTracks[0].dictionaryTokenStatusColors.slice(2),
+            ],
             dictionaryTokenStatusConfig: [
                 { color: '#111111', alpha: 'AA', display: true },
                 { color: '#222222', alpha: 'BB', display: true },
@@ -526,11 +529,12 @@ describe('DictionaryStatistics', () => {
 
         await statistics.refreshDictionaryTokens('profile');
 
-        expect(settingsProvider.getSingle).toHaveBeenCalledWith('dictionaryTracks');
         expect((storage.getAllTokens.mock.calls as any[][]).map((call) => call[1])).toEqual([0, 2]);
 
         const snapshot = lastPublishedSnapshot(storage)!;
-        expect(snapshot.settings).toEqual({ dictionaryTracks: settings.dictionaryTracks });
+        expect(snapshot.settings).toEqual({
+            dictionaryTracks: await settingsProvider.getSingle('dictionaryTracks'),
+        });
         expect(snapshot.snapshots[0].stats.dictionary.tokens).toEqual({
             alpha: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },
         });
@@ -539,7 +543,9 @@ describe('DictionaryStatistics', () => {
         });
         expect(snapshot.snapshots[0].statusColors[0]).toBe('#111111AA');
         expect(snapshot.snapshots[0].statusColors[1]).toBe('#222222BB');
-        expect(snapshot.snapshots[0].statusColors[2]).toBe('#9E9E9EFF');
+        expect(snapshot.snapshots[0].statusColors[2]).toBe(
+            `${defaultSettings.dictionaryTracks[0].dictionaryTokenStatusConfig[2].color}${defaultSettings.dictionaryTracks[0].dictionaryTokenStatusConfig[2].alpha}`
+        );
         expect(snapshot.snapshots[1].statusColors[0]).toBe(
             `${enabledWithDefaults.dictionaryTokenStatusConfig[0].color}${enabledWithDefaults.dictionaryTokenStatusConfig[0].alpha}`
         );
@@ -552,10 +558,14 @@ describe('DictionaryStatistics', () => {
             deferred<Record<string, { source: DictionaryTokenSource; statuses: never[]; states: never[] }>>();
 
         statistics.init(0, 1);
-        storage.getAllTokens.mockReturnValueOnce(pendingTokens.promise);
+        const tokenRequestStarted = deferred<void>();
+        storage.getAllTokens.mockImplementationOnce(() => {
+            tokenRequestStarted.resolve();
+            return pendingTokens.promise;
+        });
 
         const refreshPromise = statistics.refreshDictionaryTokens('profile');
-        await Promise.resolve();
+        await tokenRequestStarted.promise;
 
         statistics.reset();
         pendingTokens.resolve({ alpha: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] } });
@@ -575,18 +585,29 @@ describe('DictionaryStatistics', () => {
             deferred<Record<string, { source: DictionaryTokenSource; statuses: never[]; states: never[] }>>();
         const secondTrackTokens =
             deferred<Record<string, { source: DictionaryTokenSource; statuses: never[]; states: never[] }>>();
+        const firstTrackRequestStarted = deferred<void>();
+        const secondTrackRequestStarted = deferred<void>();
+        const firstTrackPublished = deferred<void>();
 
         statistics.init(0, 1);
         statistics.init(1, 1);
         storage.getAllTokens
-            .mockReturnValueOnce(firstTrackTokens.promise)
-            .mockReturnValueOnce(secondTrackTokens.promise);
+            .mockImplementationOnce(() => {
+                firstTrackRequestStarted.resolve();
+                return firstTrackTokens.promise;
+            })
+            .mockImplementationOnce(() => {
+                secondTrackRequestStarted.resolve();
+                return secondTrackTokens.promise;
+            });
+        storage.publishStatisticsSnapshot.mockImplementationOnce(async () => {
+            firstTrackPublished.resolve();
+        });
 
         const refreshPromise = statistics.refreshDictionaryTokens('profile');
-        await Promise.resolve();
+        await Promise.all([firstTrackRequestStarted.promise, secondTrackRequestStarted.promise]);
         firstTrackTokens.resolve({ alpha: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] } });
-        await Promise.resolve();
-        await Promise.resolve();
+        await firstTrackPublished.promise;
 
         expect(lastPublishedSnapshot(storage)?.snapshots[0].stats.dictionary.tokens).toEqual({
             alpha: { source: DictionaryTokenSource.LOCAL, statuses: [], states: [] },

--- a/common/jest.config.js
+++ b/common/jest.config.js
@@ -1,8 +1,11 @@
-/* global module */
+/* global module, require */
 module.exports = {
     verbose: true,
     transform: {
         '^.+\\.ts?$': 'ts-jest',
+    },
+    moduleNameMapper: {
+        '^uuid$': require.resolve('uuid'),
     },
     testEnvironment: 'jsdom',
 };

--- a/common/pages/index.test.ts
+++ b/common/pages/index.test.ts
@@ -1,4 +1,5 @@
 import { pageMetadata } from '.';
+import { expect, it } from '@jest/globals';
 
 it('page csp rule ids are distinct', () => {
     const seenRuleIds: { [ruleId: number]: boolean } = {};

--- a/common/settings/mock-settings-storage.ts
+++ b/common/settings/mock-settings-storage.ts
@@ -1,0 +1,75 @@
+import type { AsbplayerSettings } from './settings';
+import {
+    prefixedSettings,
+    type AsbplayerSettingsProfile,
+    type Profile,
+    type SettingsStorage,
+    unprefixedSettings,
+} from './settings-provider';
+
+export class MockSettingsStorage implements SettingsStorage {
+    private _activeProfile?: string;
+    private _profiles: Profile[] = [];
+    private _data: any = {};
+
+    async get(keysAndDefaults: Partial<AsbplayerSettings>) {
+        const settings: any = {};
+
+        const actualKeysAndDefaults =
+            this._activeProfile === undefined
+                ? keysAndDefaults
+                : prefixedSettings(keysAndDefaults, this._activeProfile);
+
+        for (const [key, defaultValue] of Object.entries(actualKeysAndDefaults)) {
+            // Simulate retrieval from actual storage - object references should change
+            settings[key] = JSON.parse(JSON.stringify(this._data[key] ?? defaultValue));
+        }
+
+        return this._activeProfile === undefined
+            ? (settings as Partial<AsbplayerSettings>)
+            : unprefixedSettings(settings as Partial<AsbplayerSettingsProfile<string>>, this._activeProfile);
+    }
+
+    async set(settings: Partial<AsbplayerSettings>) {
+        const actualSettings =
+            this._activeProfile === undefined ? settings : prefixedSettings(settings, this._activeProfile);
+
+        for (const [key, value] of Object.entries(actualSettings)) {
+            this._data[key] = value;
+        }
+    }
+
+    async activeProfile(): Promise<Profile | undefined> {
+        return this._activeProfile === undefined
+            ? undefined
+            : this._profiles.find((p) => p.name === this._activeProfile);
+    }
+
+    async setActiveProfile(name: string | undefined): Promise<void> {
+        this._activeProfile = name;
+    }
+
+    async profiles(): Promise<Profile[]> {
+        return this._profiles;
+    }
+
+    async addProfile(name: string): Promise<void> {
+        const existing = this._profiles.find((p) => p.name === name);
+
+        if (existing === undefined) {
+            this._profiles.push({ name });
+        }
+    }
+
+    async removeProfile(name: string): Promise<void> {
+        if (this._activeProfile === name) {
+            throw new Error('Cannot remove active profile');
+        }
+
+        this._profiles = this._profiles.filter((p) => p.name !== name);
+    }
+
+    setData(data: any) {
+        this._data = data;
+    }
+}

--- a/common/settings/settings-import-export.test.ts
+++ b/common/settings/settings-import-export.test.ts
@@ -9,6 +9,7 @@ import {
 } from './settings';
 import { validateSettings } from './settings-import-export';
 import { defaultSettings } from './settings-provider';
+import { expect, it } from '@jest/globals';
 
 it('validates the default settings', () => {
     validateSettings(defaultSettings);

--- a/common/settings/settings-provider.test.ts
+++ b/common/settings/settings-provider.test.ts
@@ -1,85 +1,13 @@
 import {
-    AsbplayerSettings,
-    AsbplayerSettingsProfile,
-    Profile,
     SettingsProvider,
-    SettingsStorage,
     SubtitleAlignment,
     VideoSubtitleSplitBehavior,
     changeForTextSubtitleSetting,
     defaultSettings,
-    prefixedSettings,
     textSubtitleSettingsForTrack,
-    unprefixedSettings,
 } from '@project/common/settings';
 import { expect, it } from '@jest/globals';
-
-export class MockSettingsStorage implements SettingsStorage {
-    private _activeProfile?: string;
-    private _profiles: Profile[] = [];
-    private _data: any = {};
-
-    async get(keysAndDefaults: Partial<AsbplayerSettings>) {
-        const settings: any = {};
-
-        const actualKeysAndDefaults =
-            this._activeProfile === undefined
-                ? keysAndDefaults
-                : prefixedSettings(keysAndDefaults, this._activeProfile);
-
-        for (const [key, defaultValue] of Object.entries(actualKeysAndDefaults)) {
-            // Simulate retrieval from actual storage - object references should change
-            settings[key] = JSON.parse(JSON.stringify(this._data[key] ?? defaultValue));
-        }
-
-        return this._activeProfile === undefined
-            ? (settings as Partial<AsbplayerSettings>)
-            : unprefixedSettings(settings as Partial<AsbplayerSettingsProfile<string>>, this._activeProfile);
-    }
-
-    async set(settings: Partial<AsbplayerSettings>) {
-        const actualSettings =
-            this._activeProfile === undefined ? settings : prefixedSettings(settings, this._activeProfile);
-
-        for (const [key, value] of Object.entries(actualSettings)) {
-            this._data[key] = value;
-        }
-    }
-
-    async activeProfile(): Promise<Profile | undefined> {
-        return this._activeProfile === undefined
-            ? undefined
-            : this._profiles.find((p) => p.name === this._activeProfile);
-    }
-
-    async setActiveProfile(name: string | undefined): Promise<void> {
-        this._activeProfile = name;
-    }
-
-    async profiles(): Promise<Profile[]> {
-        return this._profiles;
-    }
-
-    async addProfile(name: string): Promise<void> {
-        const existing = this._profiles.find((p) => p.name === name);
-
-        if (existing === undefined) {
-            this._profiles.push({ name });
-        }
-    }
-
-    async removeProfile(name: string): Promise<void> {
-        if (this._activeProfile === name) {
-            throw new Error('Cannot remove active profile');
-        }
-
-        this._profiles = this._profiles.filter((p) => p.name !== name);
-    }
-
-    setData(data: any) {
-        this._data = data;
-    }
-}
+import { MockSettingsStorage } from './mock-settings-storage';
 
 it('starts at default settings', async () => {
     const provider = new SettingsProvider(new MockSettingsStorage());

--- a/common/settings/settings-provider.test.ts
+++ b/common/settings/settings-provider.test.ts
@@ -12,6 +12,7 @@ import {
     textSubtitleSettingsForTrack,
     unprefixedSettings,
 } from '@project/common/settings';
+import { expect, it } from '@jest/globals';
 
 export class MockSettingsStorage implements SettingsStorage {
     private _activeProfile?: string;

--- a/common/settings/settings.test.ts
+++ b/common/settings/settings.test.ts
@@ -1,4 +1,5 @@
 import { calculateSeekableTracksValue, isTrackSeekable, updateSeekableTracksValue } from '.';
+import { expect, it } from '@jest/globals';
 
 it('can determine seekable tracks correctly', () => {
     expect(isTrackSeekable(0, 0)).toBe(false);

--- a/common/settings/settings.ts
+++ b/common/settings/settings.ts
@@ -103,6 +103,11 @@ export function isAnkiSource(source: DictionaryTokenSource): source is AnkiSourc
     return source === DictionaryTokenSource.ANKI_WORD || source === DictionaryTokenSource.ANKI_SENTENCE;
 }
 
+export type WaniKaniSource = DictionaryTokenSource.WANIKANI;
+export function isWaniKaniSource(source: DictionaryTokenSource): source is WaniKaniSource {
+    return source === DictionaryTokenSource.WANIKANI;
+}
+
 export type ExternalWordSource = DictionaryTokenSource.ANKI_WORD | DictionaryTokenSource.WANIKANI;
 export function isExternalWordSource(source: DictionaryTokenSource): source is ExternalWordSource {
     return source === DictionaryTokenSource.ANKI_WORD || source === DictionaryTokenSource.WANIKANI;

--- a/common/src/auto-pause-context.test.ts
+++ b/common/src/auto-pause-context.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import AutoPauseContext from '@project/common/src/auto-pause-context';
+import { type SubtitleModel } from '@project/common/src/model';
+
+const makeSubtitle = (overrides: Partial<SubtitleModel> = {}): SubtitleModel => ({
+    text: 'subtitle',
+    start: 0,
+    end: 1000,
+    originalStart: 0,
+    originalEnd: 1000,
+    track: 0,
+    ...overrides,
+});
+
+describe('AutoPauseContext', () => {
+    it('tolerates 0 registered callbacks', async () => {
+        const context = new AutoPauseContext();
+
+        expect(() => context.startedShowing(makeSubtitle())).not.toThrow();
+        await expect(context.willStopShowing(makeSubtitle())).resolves.toBeUndefined();
+        expect(() => context.clear()).not.toThrow();
+    });
+
+    it('deduplicates repeated startedShowing events for the same start time', () => {
+        const context = new AutoPauseContext();
+        const onStartedShowing = jest.fn();
+        context.onStartedShowing = onStartedShowing;
+
+        context.startedShowing(makeSubtitle({ start: 0, end: 1000 }));
+        context.startedShowing(makeSubtitle({ start: 0, end: 2000 }));
+
+        expect(onStartedShowing).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires startedShowing again after clear for the same subtitle', () => {
+        const context = new AutoPauseContext();
+        const onStartedShowing = jest.fn();
+        context.onStartedShowing = onStartedShowing;
+        const subtitle = makeSubtitle({ start: 100, end: 500 });
+
+        context.startedShowing(subtitle);
+        context.clear();
+        context.startedShowing(subtitle);
+
+        expect(onStartedShowing).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates repeated willStopShowing events for the same end time', async () => {
+        const context = new AutoPauseContext();
+        const onWillStopShowing = jest.fn<(subtitle: SubtitleModel) => Promise<void>>().mockResolvedValue(undefined);
+        context.onWillStopShowing = onWillStopShowing;
+
+        await context.willStopShowing(makeSubtitle({ start: 0, end: 1000 }));
+        await context.willStopShowing(makeSubtitle({ start: 200, end: 1000 }));
+
+        expect(onWillStopShowing).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes distinct subtitles through for 2 different end times', async () => {
+        const context = new AutoPauseContext();
+        const onWillStopShowing = jest.fn<(subtitle: SubtitleModel) => Promise<void>>().mockResolvedValue(undefined);
+        context.onWillStopShowing = onWillStopShowing;
+        const first = makeSubtitle({ start: 0, end: 1000 });
+        const second = makeSubtitle({ start: 1100, end: 2000 });
+
+        await context.willStopShowing(first);
+        await context.willStopShowing(second);
+
+        expect(onWillStopShowing).toHaveBeenNthCalledWith(1, first);
+        expect(onWillStopShowing).toHaveBeenNthCalledWith(2, second);
+    });
+
+    it('tracks startedShowing and willStopShowing independently', async () => {
+        const context = new AutoPauseContext();
+        const onStartedShowing = jest.fn();
+        const onWillStopShowing = jest.fn<(subtitle: SubtitleModel) => Promise<void>>().mockResolvedValue(undefined);
+        context.onStartedShowing = onStartedShowing;
+        context.onWillStopShowing = onWillStopShowing;
+
+        context.startedShowing(makeSubtitle({ start: 0, end: 1000 }));
+        await context.willStopShowing(makeSubtitle({ start: 0, end: 1000 }));
+        context.startedShowing(makeSubtitle({ start: 1001, end: 2000 }));
+        await context.willStopShowing(makeSubtitle({ start: 1001, end: 2000 }));
+
+        expect(onStartedShowing).toHaveBeenCalledTimes(2);
+        expect(onWillStopShowing).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps clear idempotent for later start and stop notifications', async () => {
+        const context = new AutoPauseContext();
+        const onStartedShowing = jest.fn();
+        const onWillStopShowing = jest.fn<(subtitle: SubtitleModel) => Promise<void>>().mockResolvedValue(undefined);
+        const subtitle = makeSubtitle({ start: 100, end: 500 });
+        context.onStartedShowing = onStartedShowing;
+        context.onWillStopShowing = onWillStopShowing;
+
+        context.startedShowing(subtitle);
+        await context.willStopShowing(subtitle);
+        context.clear();
+        context.clear();
+        context.startedShowing(subtitle);
+        await context.willStopShowing(subtitle);
+
+        expect(onStartedShowing).toHaveBeenCalledTimes(2);
+        expect(onWillStopShowing).toHaveBeenCalledTimes(2);
+    });
+});

--- a/common/src/fetcher.ts
+++ b/common/src/fetcher.ts
@@ -1,5 +1,5 @@
-export interface Fetcher {
-    fetch: (url: string, body: any) => Promise<any>;
+export interface Fetcher<TRequest = any, TResponse = any> {
+    fetch: (url: string, request: TRequest) => Promise<TResponse>;
 }
 
 export class HttpFetcher implements Fetcher {

--- a/common/src/jpeg-file-media-fragment-data.test.ts
+++ b/common/src/jpeg-file-media-fragment-data.test.ts
@@ -1,9 +1,10 @@
 import { JpegFileMediaFragmentData } from './jpeg-file-media-fragment-data';
 import { CancelledMediaFragmentDataRenderingError, createVideoElement } from './media-fragment';
 import { FileModel } from './model';
+import { afterEach, expect, it, jest } from '@jest/globals';
 
 jest.mock('./media-fragment', () => {
-    const actual = jest.requireActual('./media-fragment');
+    const actual: object = jest.requireActual('./media-fragment');
     return {
         ...actual,
         createVideoElement: jest.fn(),

--- a/common/src/media-fragment.test.ts
+++ b/common/src/media-fragment.test.ts
@@ -6,6 +6,7 @@ import {
     resolveWebmMediaFragmentRange,
 } from './media-fragment';
 import { CardModel } from './model';
+import { afterEach, expect, it } from '@jest/globals';
 
 const originalMediaRecorder = (globalThis as any).MediaRecorder;
 const originalCaptureStream = (HTMLCanvasElement.prototype as any).captureStream;

--- a/common/src/webm-file-media-fragment-data.test.ts
+++ b/common/src/webm-file-media-fragment-data.test.ts
@@ -1,5 +1,6 @@
 import { WebmFileMediaFragmentData } from './webm-file-media-fragment-data';
 import { FileModel } from './model';
+import { afterEach, beforeEach, expect, it, jest } from '@jest/globals';
 
 type Listener = (event: Event) => void;
 type VideoFrameCallback = (now: number, metadata: { mediaTime: number }) => void;

--- a/common/subtitle-collection/subtitle-collection.test.ts
+++ b/common/subtitle-collection/subtitle-collection.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from '@jest/globals';
+import { SubtitleCollection } from '@project/common/subtitle-collection';
+import { type SubtitleModel } from '@project/common/src/model';
+
+const makeSubtitle = (overrides: Partial<SubtitleModel> = {}): SubtitleModel => ({
+    text: 'subtitle',
+    start: 0,
+    end: 1000,
+    originalStart: 0,
+    originalEnd: 1000,
+    track: 0,
+    index: 0,
+    ...overrides,
+});
+
+describe('SubtitleCollection', () => {
+    it('returns an empty slice for 0 subtitles', () => {
+        const collection = new SubtitleCollection<SubtitleModel>({ returnLastShown: true, returnNextToShow: true });
+        collection.setSubtitles([]);
+
+        expect(collection.subtitlesAt(0)).toEqual({
+            showing: [],
+            lastShown: [],
+            nextToShow: undefined,
+            startedShowing: undefined,
+            willStopShowing: undefined,
+        });
+    });
+
+    it('returns the next subtitle before a 1-item collection begins', () => {
+        const collection = new SubtitleCollection<SubtitleModel>({ returnLastShown: true, returnNextToShow: true });
+        const subtitle = makeSubtitle({ start: 500, end: 1000, index: 0 });
+        collection.setSubtitles([subtitle]);
+
+        const slice = collection.subtitlesAt(100);
+
+        expect(slice.showing).toEqual([]);
+        expect(slice.nextToShow).toEqual([subtitle]);
+        expect(slice.lastShown).toEqual([]);
+    });
+
+    it('reports start and end proximity for a single showing subtitle', () => {
+        const collection = new SubtitleCollection<SubtitleModel>({ showingCheckRadiusMs: 150 });
+        const subtitle = makeSubtitle({ start: 100, end: 1000, index: 0 });
+        collection.setSubtitles([subtitle]);
+
+        const nearStart = collection.subtitlesAt(200);
+        const nearEnd = collection.subtitlesAt(900);
+
+        expect(nearStart.showing).toEqual([subtitle]);
+        expect(nearStart.startedShowing).toBe(subtitle);
+        expect(nearStart.willStopShowing).toBeUndefined();
+        expect(nearEnd.showing).toEqual([subtitle]);
+        expect(nearEnd.startedShowing).toBeUndefined();
+        expect(nearEnd.willStopShowing).toBe(subtitle);
+    });
+
+    it('returns lastShown and nextToShow across a 2-item gap', () => {
+        const collection = new SubtitleCollection<SubtitleModel>({ returnLastShown: true, returnNextToShow: true });
+        const first = makeSubtitle({ start: 0, end: 1000, index: 0 });
+        const second = makeSubtitle({ start: 2500, end: 3500, index: 1 });
+        collection.setSubtitles([first, second]);
+
+        const slice = collection.subtitlesAt(1500);
+
+        expect(slice.showing).toEqual([]);
+        expect(slice.lastShown).toEqual([first]);
+        expect(slice.nextToShow).toEqual([second]);
+    });
+
+    it('supports lastShown and nextToShow independently across a gap', () => {
+        const first = makeSubtitle({ start: 0, end: 1000, index: 0 });
+        const second = makeSubtitle({ start: 2500, end: 3500, index: 1 });
+        const lastOnly = new SubtitleCollection<SubtitleModel>({ returnLastShown: true });
+        const nextOnly = new SubtitleCollection<SubtitleModel>({ returnNextToShow: true });
+
+        lastOnly.setSubtitles([first, second]);
+        nextOnly.setSubtitles([first, second]);
+
+        expect(lastOnly.subtitlesAt(1500)).toMatchObject({
+            showing: [],
+            lastShown: [first],
+            nextToShow: undefined,
+        });
+        expect(nextOnly.subtitlesAt(1500)).toMatchObject({
+            showing: [],
+            lastShown: [first],
+            nextToShow: [second],
+        });
+    });
+
+    it('returns 2 showing subtitles when their ranges overlap', () => {
+        const collection = new SubtitleCollection<SubtitleModel>({ showingCheckRadiusMs: 150 });
+        const first = makeSubtitle({ start: 0, end: 1000, index: 0 });
+        const second = makeSubtitle({ start: 500, end: 1500, index: 1 });
+        collection.setSubtitles([first, second]);
+
+        const slice = collection.subtitlesAt(750);
+
+        expect(slice.showing).toEqual([first, second]);
+        expect(slice.startedShowing).toBeUndefined();
+        expect(slice.willStopShowing).toBeUndefined();
+    });
+
+    it('treats start and end minus 1 as inclusive and end as outside', () => {
+        const collection = new SubtitleCollection<SubtitleModel>({ returnLastShown: true, returnNextToShow: true });
+        const first = makeSubtitle({ start: 100, end: 200, index: 0 });
+        const second = makeSubtitle({ start: 300, end: 400, index: 1 });
+        collection.setSubtitles([first, second]);
+
+        expect(collection.subtitlesAt(100).showing).toEqual([first]);
+        expect(collection.subtitlesAt(199).showing).toEqual([first]);
+        expect(collection.subtitlesAt(200)).toMatchObject({
+            showing: [],
+            lastShown: [first],
+            nextToShow: [second],
+        });
+    });
+
+    it('skips invalid ranges and replaces old subtitles on repeated setSubtitles calls', () => {
+        const collection = new SubtitleCollection<SubtitleModel>({ returnLastShown: true, returnNextToShow: true });
+        const oldSubtitle = makeSubtitle({ start: 0, end: 100, index: 0 });
+        const zeroDuration = makeSubtitle({ start: 100, end: 100, index: 1 });
+        const inverted = makeSubtitle({ start: 300, end: 200, index: 2 });
+        const replacement = makeSubtitle({ start: 500, end: 600, index: 3 });
+
+        collection.setSubtitles([oldSubtitle]);
+        collection.setSubtitles([zeroDuration, inverted, replacement]);
+
+        expect(collection.subtitlesAt(50).showing).toEqual([]);
+        expect(collection.subtitlesAt(100).showing).toEqual([]);
+        expect(collection.subtitlesAt(250).showing).toEqual([]);
+        expect(collection.subtitlesAt(500).showing).toEqual([replacement]);
+    });
+});

--- a/common/subtitle-collection/subtitle-collection.test.ts
+++ b/common/subtitle-collection/subtitle-collection.test.ts
@@ -48,11 +48,11 @@ describe('SubtitleCollection', () => {
         const nearEnd = collection.subtitlesAt(900);
 
         expect(nearStart.showing).toEqual([subtitle]);
-        expect(nearStart.startedShowing).toBe(subtitle);
+        expect(nearStart.startedShowing).toEqual(subtitle);
         expect(nearStart.willStopShowing).toBeUndefined();
         expect(nearEnd.showing).toEqual([subtitle]);
         expect(nearEnd.startedShowing).toBeUndefined();
-        expect(nearEnd.willStopShowing).toBe(subtitle);
+        expect(nearEnd.willStopShowing).toEqual(subtitle);
     });
 
     it('returns lastShown and nextToShow across a 2-item gap', () => {

--- a/common/subtitle-collection/subtitle-collection.ts
+++ b/common/subtitle-collection/subtitle-collection.ts
@@ -15,14 +15,18 @@ export interface SubtitleCollectionOptions {
     showingCheckRadiusMs?: number;
 }
 
+interface SubtitleGap<T> {
+    lastShown?: T;
+}
+
 export class SubtitleCollection<T extends SubtitleModel> {
     static emptySubtitleCollection = new SubtitleCollection({});
 
     private options: SubtitleCollectionOptions;
     // Tree for subtitles
     private tree: IntervalTree<T>;
-    // Tree for gaps between subtitles. The gaps are populated with the last subtitle before the gap.
-    private gapsTree?: IntervalTree<T>;
+    // Tree for gaps between subtitles. A gap has no last shown subtitle when it precedes the first subtitle.
+    private gapsTree?: IntervalTree<SubtitleGap<T>>;
 
     constructor(options: SubtitleCollectionOptions) {
         this.options = options;
@@ -34,10 +38,10 @@ export class SubtitleCollection<T extends SubtitleModel> {
 
         if (this.options.returnLastShown || this.options.returnNextToShow) {
             let last: T | undefined;
-            this.gapsTree = new IntervalTree<T>();
+            this.gapsTree = new IntervalTree<SubtitleGap<T>>();
 
             if (subtitles.length > 0 && subtitles[0].start > 0) {
-                this.gapsTree.insert([0, subtitles[0].start - 1], subtitles[0]);
+                this.gapsTree.insert([0, subtitles[0].start - 1], {});
             }
 
             for (const s of subtitles) {
@@ -46,7 +50,7 @@ export class SubtitleCollection<T extends SubtitleModel> {
                 }
 
                 if (last !== undefined && last.end < s.start) {
-                    this.gapsTree.insert([last.end, s.start - 1], last);
+                    this.gapsTree.insert([last.end, s.start - 1], { lastShown: last });
                 }
 
                 last = s;
@@ -74,12 +78,13 @@ export class SubtitleCollection<T extends SubtitleModel> {
             if (this.gapsTree !== undefined) {
                 // One of returnLastShown or returnNextToShow is true due to constructor
                 const gapIntervals: Interval[] = [];
-                lastShown = this.gapsTree.search(interval, (s, i) => {
+                const gaps = this.gapsTree.search(interval, (gap, i) => {
                     gapIntervals.push(i);
-                    return s;
-                }) as T[];
+                    return gap;
+                }) as SubtitleGap<T>[];
+                lastShown = gaps.flatMap((gap) => (gap.lastShown === undefined ? [] : [gap.lastShown]));
 
-                if (lastShown.length > 0 && this.options.returnNextToShow) {
+                if (gaps.length > 0 && this.options.returnNextToShow) {
                     const nextStart = gapIntervals[0].high + 1;
                     nextToShow = this.tree.search([nextStart, nextStart]) as T[];
                 }

--- a/common/subtitle-reader/subtitle-reader.test.ts
+++ b/common/subtitle-reader/subtitle-reader.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 // These deps ship as ESM that the repo's ts-jest setup does not transform, and the
 // IMSC path under test never uses them (they back the srt/ass/vtt branches).
 jest.mock('@qgustavor/srt-parser', () => ({ __esModule: true, default: class {} }));

--- a/common/subtitle-sources/subtitle-sources.test.ts
+++ b/common/subtitle-sources/subtitle-sources.test.ts
@@ -1,5 +1,7 @@
 import { JimakuClient } from './subtitle-sources';
-import { describe, expect, it, jest } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+const originalFetch = globalThis.fetch;
 
 const createResponse = ({
     ok = true,
@@ -27,13 +29,19 @@ const createResponse = ({
     } as unknown as Response;
 };
 
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+});
+
 describe('JimakuClient', () => {
     it('validates api key at construction', () => {
         expect(() => new JimakuClient({ apiKey: '   ' })).toThrow('Jimaku API key cannot be empty or whitespace-only');
     });
 
     it('searches entries with authorization header', async () => {
-        const fetchMock = jest.fn().mockResolvedValue(
+        const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
             createResponse({
                 jsonData: [{ id: 729, name: 'Sousou no Frieren' }],
                 headers: {
@@ -59,7 +67,7 @@ describe('JimakuClient', () => {
     });
 
     it('searches entries with anime parameter', async () => {
-        const fetchMock = jest.fn().mockResolvedValue(
+        const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
             createResponse({
                 jsonData: [{ id: 999, name: 'Some Drama', flags: 2 }],
                 headers: {
@@ -81,7 +89,7 @@ describe('JimakuClient', () => {
     });
 
     it('requests files with optional filters', async () => {
-        const fetchMock = jest.fn().mockResolvedValue(createResponse({ jsonData: [] }));
+        const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(createResponse({ jsonData: [] }));
         global.fetch = fetchMock;
         const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
 
@@ -92,9 +100,131 @@ describe('JimakuClient', () => {
         });
     });
 
+    it('waits for server rate-limit reset before the next request', async () => {
+        jest.useFakeTimers();
+        try {
+            const fetchMock = jest
+                .fn<typeof fetch>()
+                .mockResolvedValueOnce(
+                    createResponse({
+                        jsonData: [],
+                        headers: {
+                            'x-ratelimit-remaining': '0',
+                            'x-ratelimit-reset-after': '0.25',
+                        },
+                    })
+                )
+                .mockResolvedValueOnce(createResponse({ jsonData: [] }));
+            global.fetch = fetchMock;
+            const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 10000 });
+
+            await client.searchEntries('first');
+            const secondRequest = client.searchEntries('second');
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            await jest.advanceTimersByTimeAsync(249);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            await jest.advanceTimersByTimeAsync(1);
+            await secondRequest;
+
+            expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://jimaku.cc/api/entries/search?query=second', {
+                headers: { Authorization: 'test-key' },
+            });
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it('does not wait when server rate-limit headers report remaining quota', async () => {
+        jest.useFakeTimers();
+        try {
+            const fetchMock = jest
+                .fn<typeof fetch>()
+                .mockResolvedValueOnce(
+                    createResponse({
+                        jsonData: [],
+                        headers: {
+                            'x-ratelimit-remaining': '2',
+                            'x-ratelimit-reset-after': '10',
+                        },
+                    })
+                )
+                .mockResolvedValueOnce(createResponse({ jsonData: [] }));
+            global.fetch = fetchMock;
+            const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 10000 });
+
+            await client.searchEntries('first');
+            const secondRequest = client.searchEntries('second');
+            await Promise.resolve();
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            await secondRequest;
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it('falls back to the minimum request interval without server quota headers', async () => {
+        jest.useFakeTimers();
+        try {
+            const fetchMock = jest
+                .fn<typeof fetch>()
+                .mockResolvedValueOnce(createResponse({ jsonData: [] }))
+                .mockResolvedValueOnce(createResponse({ jsonData: [] }));
+            global.fetch = fetchMock;
+            const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 100 });
+
+            await client.searchEntries('first');
+            await jest.advanceTimersByTimeAsync(40);
+            const secondRequest = client.searchEntries('second');
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            await jest.advanceTimersByTimeAsync(59);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            await jest.advanceTimersByTimeAsync(1);
+            await secondRequest;
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it('falls back to the minimum request interval when quota is exhausted without reset timing', async () => {
+        jest.useFakeTimers();
+        try {
+            const fetchMock = jest
+                .fn<typeof fetch>()
+                .mockResolvedValueOnce(
+                    createResponse({
+                        jsonData: [],
+                        headers: {
+                            'x-ratelimit-remaining': '0',
+                        },
+                    })
+                )
+                .mockResolvedValueOnce(createResponse({ jsonData: [] }));
+            global.fetch = fetchMock;
+            const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 100 });
+
+            await client.searchEntries('first');
+            const secondRequest = client.searchEntries('second');
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            await jest.advanceTimersByTimeAsync(99);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            await jest.advanceTimersByTimeAsync(1);
+            await secondRequest;
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
     it('throws parsed error message on failed request', async () => {
         const fetchMock = jest
-            .fn()
+            .fn<typeof fetch>()
             .mockResolvedValue(createResponse({ ok: false, status: 401, jsonData: { error: 'Unauthorized' } }));
         global.fetch = fetchMock;
         const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
@@ -103,7 +233,9 @@ describe('JimakuClient', () => {
     });
 
     it('falls back to status-based error when response is not json', async () => {
-        const fetchMock = jest.fn().mockResolvedValue(createResponse({ ok: false, status: 503, textData: '<html/>' }));
+        const fetchMock = jest
+            .fn<typeof fetch>()
+            .mockResolvedValue(createResponse({ ok: false, status: 503, textData: '<html/>' }));
         global.fetch = fetchMock;
         const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
 
@@ -111,7 +243,9 @@ describe('JimakuClient', () => {
     });
 
     it('throws when successful response does not contain valid json', async () => {
-        const fetchMock = jest.fn().mockResolvedValue(createResponse({ ok: true, status: 200, textData: '<html/>' }));
+        const fetchMock = jest
+            .fn<typeof fetch>()
+            .mockResolvedValue(createResponse({ ok: true, status: 200, textData: '<html/>' }));
         global.fetch = fetchMock;
         const client = new JimakuClient({ apiKey: 'test-key', minRequestIntervalMs: 0 });
 

--- a/common/subtitle-sources/subtitle-sources.test.ts
+++ b/common/subtitle-sources/subtitle-sources.test.ts
@@ -1,4 +1,5 @@
 import { JimakuClient } from './subtitle-sources';
+import { describe, expect, it, jest } from '@jest/globals';
 
 const createResponse = ({
     ok = true,

--- a/common/util/util.test.ts
+++ b/common/util/util.test.ts
@@ -40,6 +40,7 @@ import {
     clampMediaTimestamp,
 } from '@project/common/util';
 import { TextSubtitleSettings } from '@project/common/settings';
+import { Progress } from '@project/common';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 function subtitle(text: string, start: number, end: number, track = 0, index = 0) {
@@ -128,14 +129,7 @@ describe('humanReadableTime', () => {
     });
 
     it('formats localized dates with hour, minute, and second fields', () => {
-        const toLocaleTimeString = jest.spyOn(Date.prototype, 'toLocaleTimeString').mockReturnValue('01:02:03 PM');
-
-        expect(localizedDate(123456)).toBe('01:02:03 PM');
-        expect(toLocaleTimeString).toHaveBeenCalledWith([], {
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-        });
+        expect(localizedDate(Date.UTC(2026, 0, 1, 13, 2, 3), 'en-US', 'UTC')).toBe('01:02:03 PM');
     });
 
     it('formats 0 milliseconds', () => {
@@ -166,18 +160,32 @@ describe('humanReadableTime', () => {
 describe('download', () => {
     it('downloads a sanitized filename and cleans up the temporary object URL and element', () => {
         const blob = new Blob(['content'], { type: 'text/plain' });
-        const createElement = jest.spyOn(document, 'createElement');
         const originalCreateObjectURL = window.URL.createObjectURL;
         const originalRevokeObjectURL = window.URL.revokeObjectURL;
-        const createObjectURL = jest.fn(() => 'blob:test-url');
-        const revokeObjectURL = jest.fn();
-        const click = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
-        Object.defineProperty(window.URL, 'createObjectURL', { configurable: true, value: createObjectURL });
-        Object.defineProperty(window.URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+        const createdBlobs: Blob[] = [];
+        const revokedUrls: string[] = [];
+        let clickedAnchor: HTMLAnchorElement | undefined;
+        const onClick = (event: Event) => {
+            event.preventDefault();
+            clickedAnchor = event.target as HTMLAnchorElement;
+        };
+        document.addEventListener('click', onClick);
+        Object.defineProperty(window.URL, 'createObjectURL', {
+            configurable: true,
+            value: (value: Blob) => {
+                createdBlobs.push(value);
+                return 'blob:test-url';
+            },
+        });
+        Object.defineProperty(window.URL, 'revokeObjectURL', {
+            configurable: true,
+            value: (value: string) => revokedUrls.push(value),
+        });
 
         try {
             download(blob, '../bad:name?.txt');
         } finally {
+            document.removeEventListener('click', onClick);
             Object.defineProperty(window.URL, 'createObjectURL', {
                 configurable: true,
                 value: originalCreateObjectURL,
@@ -188,12 +196,10 @@ describe('download', () => {
             });
         }
 
-        expect(createObjectURL).toHaveBeenCalledWith(blob);
-        expect(click).toHaveBeenCalledTimes(1);
-        expect(revokeObjectURL).toHaveBeenCalledWith('blob:test-url');
+        expect(createdBlobs).toEqual([blob]);
+        expect(revokedUrls).toEqual(['blob:test-url']);
         expect(document.querySelectorAll('a')).toHaveLength(0);
-        const anchor = createElement.mock.results[0].value as HTMLAnchorElement;
-        expect(anchor.download).toBe('..badname.txt');
+        expect(clickedAnchor).toMatchObject({ download: '..badname.txt', href: 'blob:test-url' });
     });
 });
 
@@ -671,24 +677,28 @@ describe('batch helpers', () => {
     });
 
     it('filterAsync preserves input order while filtering through async batches', async () => {
-        const progress = jest.fn(async () => undefined);
+        const progress: Progress[] = [];
 
         await expect(
-            filterAsync([1, 2, 3, 4], async (value) => value % 2 === 0, { batchSize: 2, statusUpdates: progress })
+            filterAsync([1, 2, 3, 4], async (value) => value % 2 === 0, {
+                batchSize: 2,
+                statusUpdates: async (update) => {
+                    progress.push(update);
+                },
+            })
         ).resolves.toEqual([2, 4]);
-        expect(progress).toHaveBeenCalledTimes(2);
+        expect(progress.map(({ current, total }) => ({ current, total }))).toEqual([
+            { current: 2, total: 4 },
+            { current: 4, total: 4 },
+        ]);
     });
 });
 
 describe('ensureStoragePersisted', () => {
     const originalStorage = navigator.storage;
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-
-    beforeEach(() => {
-        warn.mockClear();
-    });
 
     afterEach(() => {
+        jest.restoreAllMocks();
         Object.defineProperty(navigator, 'storage', {
             configurable: true,
             value: originalStorage,
@@ -702,7 +712,6 @@ describe('ensureStoragePersisted', () => {
         });
 
         await expect(ensureStoragePersisted()).resolves.toBeUndefined();
-        expect(warn).not.toHaveBeenCalled();
     });
 
     it('returns early when storage is already persisted', async () => {
@@ -714,11 +723,11 @@ describe('ensureStoragePersisted', () => {
             },
         });
 
-        await ensureStoragePersisted();
-        expect(warn).not.toHaveBeenCalled();
+        await expect(ensureStoragePersisted()).resolves.toBe(true);
     });
 
     it('warns when requesting persistence fails', async () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
         Object.defineProperty(navigator, 'storage', {
             configurable: true,
             value: {
@@ -727,7 +736,7 @@ describe('ensureStoragePersisted', () => {
             },
         });
 
-        await ensureStoragePersisted();
+        await expect(ensureStoragePersisted()).resolves.toBe(false);
         expect(warn).toHaveBeenCalledWith('Storage could not be persisted, data may be cleared by the browser');
     });
 });

--- a/common/util/util.test.ts
+++ b/common/util/util.test.ts
@@ -1,118 +1,935 @@
 import {
-    clampMediaTimestamp,
+    areTokenizationsEqual,
+    arrayEquals,
+    AsyncSemaphore,
+    buildSubtitleTracks,
     compareSubtitlesForDisplay,
+    computeStyles,
+    computeStyleString,
+    download,
+    ensureStoragePersisted,
+    extractText,
+    filterAsync,
+    fromBatches,
+    getCurrentTimeString,
+    getKanaMoras,
+    hex2ToPercent,
+    hexToRgb,
+    humanReadableTime,
+    inBatches,
+    isKanaOnly,
+    isKanaMoraPitchHigh,
+    isAttachedParticlePitchHigh,
+    isKatakanaOnly,
+    isNumeric,
+    iterateOverStringInBlocks,
+    joinSubtitles,
+    localizedDate,
+    mapAsync,
+    mockSurroundingSubtitles,
+    normalizeForSearch,
+    normalizedLookupTerms,
+    percentToHex2,
     seekWithNudge,
+    sourceString,
+    subtitleIntersectsTimeInterval,
     subtitleTimestampWithDelay,
+    surroundingSubtitles,
     surroundingSubtitlesAroundInterval,
     timeDurationDisplay,
-} from './util';
+    clampMediaTimestamp,
+} from '@project/common/util';
+import { TextSubtitleSettings } from '@project/common/settings';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-it('correctly displays timestamps less than 100 ms', () => {
-    expect(timeDurationDisplay(50, 100, true)).toEqual('00:00.050');
-});
-
-it('correctly displays timestamps less than 100 ms (2)', () => {
-    expect(timeDurationDisplay(1, 100, true)).toEqual('00:00.001');
-});
-
-it('correctly displays timestamps less than 100 ms (3)', () => {
-    expect(timeDurationDisplay(99, 99, true)).toEqual('00:00.099');
-});
-
-it('correctly displays timestamps', () => {
-    expect(timeDurationDisplay(999, 1000, true)).toEqual('00:00.999');
-});
-
-it('correctly displays timestamps (2)', () => {
-    expect(timeDurationDisplay(1250, 1250, true)).toEqual('00:01.250');
-});
-
-it('displays negative timestamps with a leading minus sign', () => {
-    expect(timeDurationDisplay(-1250, 1250, true)).toEqual('-00:01.250');
-    expect(timeDurationDisplay(-1250, 1250, false)).toEqual('-00:01');
-});
-
-it('displays negative timestamps with hours when the media is at least one hour long', () => {
-    expect(timeDurationDisplay(-3_723_004, 3_723_004, true)).toEqual('-01:02:03.004');
-});
-
-it('displays negative timestamps with hours when their magnitude exceeds the adjusted media length', () => {
-    expect(timeDurationDisplay(-5_400_000, 1_800_000, true)).toEqual('-01:30:00.000');
-});
-
-it('clamps negative media timestamps to zero', () => {
-    expect(clampMediaTimestamp(-1)).toBe(0);
-    expect(clampMediaTimestamp(0)).toBe(0);
-    expect(clampMediaTimestamp(1)).toBe(1);
-});
-
-it('clamps media timestamps to an optional media length', () => {
-    expect(clampMediaTimestamp(-1, 100)).toBe(0);
-    expect(clampMediaTimestamp(50, 100)).toBe(50);
-    expect(clampMediaTimestamp(100, 100)).toBe(100);
-    expect(clampMediaTimestamp(101, 100)).toBe(100);
-});
-
-it('does not apply an unavailable or invalid media length', () => {
-    expect(clampMediaTimestamp(100, 0)).toBe(100);
-    expect(clampMediaTimestamp(100, -1)).toBe(100);
-    expect(clampMediaTimestamp(100, Number.NaN)).toBe(100);
-    expect(clampMediaTimestamp(100, Number.POSITIVE_INFINITY)).toBe(100);
-});
-
-it('clamps negative seeks before updating the media element', () => {
-    const media = { currentTime: 10, duration: 100 } as HTMLMediaElement;
-
-    expect(seekWithNudge(media, -1)).toBe(0);
-    expect(media.currentTime).toBe(0);
-});
-
-it('clamps seeks past the media duration before updating the media element', () => {
-    const media = { currentTime: 10, duration: 100 } as HTMLMediaElement;
-
-    expect(seekWithNudge(media, 101)).toBe(100);
-    expect(media.currentTime).toBe(100);
-});
-
-function subtitle(text: string, start: number, end: number) {
-    return { text, start, end, originalStart: start, originalEnd: end, track: 0 };
+function subtitle(text: string, start: number, end: number, track = 0, index = 0) {
+    return { text, start, end, originalStart: start, originalEnd: end, track, index };
 }
 
-it('calculates surrounding subtitles around interval in middle when radius is 0', () => {
-    const surrounding = surroundingSubtitlesAroundInterval(
-        [subtitle('1', 0, 1), subtitle('2', 10, 20), subtitle('3', 25, 26), subtitle('4', 26, 30)],
-        9,
-        27,
-        0,
-        0
-    );
-    expect(surrounding.subtitle).toEqual(subtitle('2', 10, 20));
-    expect(surrounding.surroundingSubtitles).toEqual([
-        subtitle('2', 10, 20),
-        subtitle('3', 25, 26),
-        subtitle('4', 26, 30),
-    ]);
+function textSubtitleSettings(overrides: Partial<TextSubtitleSettings> = {}): TextSubtitleSettings {
+    return {
+        subtitleColor: '#FFFFFF',
+        subtitleSize: 32,
+        subtitleThickness: 700,
+        subtitleOutlineThickness: 0,
+        subtitleOutlineColor: '#000000',
+        subtitleShadowThickness: 0,
+        subtitleShadowColor: '#111111',
+        subtitleBackgroundOpacity: 0,
+        subtitleBackgroundColor: '#000000',
+        subtitleFontFamily: '',
+        subtitleCustomStyles: [],
+        subtitleBlur: false,
+        subtitleAlignment: 'bottom',
+        ...overrides,
+    };
+}
+
+describe('arrayEquals', () => {
+    it('returns true for 0 items', () => {
+        expect(arrayEquals([], [])).toBe(true);
+    });
+
+    it('returns true for 1 equal item and false for mismatched lengths', () => {
+        expect(arrayEquals([1], [1])).toBe(true);
+        expect(arrayEquals([1], [1, 2])).toBe(false);
+    });
+
+    it('supports custom comparators for 2 items', () => {
+        expect(
+            arrayEquals(
+                [{ value: 1 }, { value: 2 }],
+                [{ value: 1 }, { value: 2 }],
+                (lhs, rhs) => lhs.value === rhs.value
+            )
+        ).toBe(true);
+        expect(
+            arrayEquals(
+                [{ value: 1 }, { value: 2 }],
+                [{ value: 1 }, { value: 3 }],
+                (lhs, rhs) => lhs.value === rhs.value
+            )
+        ).toBe(false);
+    });
 });
 
-it('calculates surrounding subtitles around interval in middle when radius is 0 and subtitles overlap', () => {
-    const surrounding = surroundingSubtitlesAroundInterval(
-        [subtitle('1', 0, 1), subtitle('2', 10, 20), subtitle('3', 15, 26), subtitle('4', 26, 30)],
-        9,
-        25,
-        0,
-        0
-    );
-    expect(surrounding.subtitle).toEqual(subtitle('2', 10, 20));
-    expect(surrounding.surroundingSubtitles).toEqual([subtitle('2', 10, 20), subtitle('3', 15, 26)]);
+describe('lookup and pitch helpers', () => {
+    it('normalizes, expands, and deduplicates lookup terms while dropping empty values', () => {
+        expect(normalizedLookupTerms('Café', 'cafe', null, undefined, '')).toEqual(['café', 'cafe']);
+    });
+
+    it('groups small kana into moras and evaluates numeric and explicit pitch patterns', () => {
+        expect(getKanaMoras('きょう')).toEqual(['きょ', 'う']);
+        expect(getKanaMoras('か\u3099')).toEqual(['が']);
+        expect(isKanaMoraPitchHigh(0, 0)).toBe(false);
+        expect(isKanaMoraPitchHigh(1, 0)).toBe(true);
+        expect(isKanaMoraPitchHigh(1, 2)).toBe(true);
+        expect(isKanaMoraPitchHigh(2, 'LHL')).toBe(false);
+    });
+
+    it('derives attached-particle pitch and rejects invalid candidates or context', () => {
+        expect(isAttachedParticlePitchHigh('は', { prevMoras: ['に', 'ほ', 'ん'], prevPitchAccent: 0 })).toBe(true);
+        expect(isAttachedParticlePitchHigh('は', { prevMoras: ['に', 'ほ', 'ん'], prevPitchAccent: 'LHH' })).toBe(true);
+        expect(isAttachedParticlePitchHigh('word', { prevMoras: ['に'], prevPitchAccent: 0 })).toBeNull();
+        expect(isAttachedParticlePitchHigh('は', {})).toBeNull();
+    });
+
+    it('builds sorted subtitle tracks once per used track and tolerates missing filenames', () => {
+        expect(buildSubtitleTracks([{ track: 2 }, { track: 0 }, { track: 2 }], ['first.ass'])).toEqual([
+            { trackNumber: 0, fileName: 'first.ass' },
+            { trackNumber: 2, fileName: '' },
+        ]);
+    });
 });
 
-it('computes subtitle timestamp with delay and clamps to subtitle interval', () => {
-    const sample = subtitle('text', 1000, 2000);
+describe('humanReadableTime', () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
 
-    expect(subtitleTimestampWithDelay(sample, 300)).toBe(1300);
-    expect(subtitleTimestampWithDelay(sample, 1500)).toBe(2000);
-    expect(subtitleTimestampWithDelay(sample, -300)).toBe(1700);
-    expect(subtitleTimestampWithDelay(sample, -1500)).toBe(1000);
+    it('formats localized dates with hour, minute, and second fields', () => {
+        const toLocaleTimeString = jest.spyOn(Date.prototype, 'toLocaleTimeString').mockReturnValue('01:02:03 PM');
+
+        expect(localizedDate(123456)).toBe('01:02:03 PM');
+        expect(toLocaleTimeString).toHaveBeenCalledWith([], {
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+        });
+    });
+
+    it('formats 0 milliseconds', () => {
+        expect(humanReadableTime(0)).toBe('0m00s');
+    });
+
+    it('formats nearest tenths for sub-minute timestamps', () => {
+        expect(humanReadableTime(8250, true)).toBe('0m8.3s');
+    });
+
+    it('formats fully padded timestamps with hours', () => {
+        expect(humanReadableTime(3_661_000, false, true)).toBe('01h01m01s');
+        expect(humanReadableTime(3_668_200, true, true)).toBe('01h01m08.2s');
+    });
+
+    it('carries minute and hour boundaries with integer formatting', () => {
+        expect(humanReadableTime(60_000)).toBe('1m00s');
+        expect(humanReadableTime(3_600_000)).toBe('1h00m00s');
+    });
+
+    it('formats the current timestamp with date and clock components', () => {
+        jest.useFakeTimers().setSystemTime(new Date(2026, 4, 1, 2, 3, 4));
+
+        expect(getCurrentTimeString()).toBe('2026-5-1-2-3-4');
+    });
+});
+
+describe('download', () => {
+    it('downloads a sanitized filename and cleans up the temporary object URL and element', () => {
+        const blob = new Blob(['content'], { type: 'text/plain' });
+        const createElement = jest.spyOn(document, 'createElement');
+        const originalCreateObjectURL = window.URL.createObjectURL;
+        const originalRevokeObjectURL = window.URL.revokeObjectURL;
+        const createObjectURL = jest.fn(() => 'blob:test-url');
+        const revokeObjectURL = jest.fn();
+        const click = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+        Object.defineProperty(window.URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+        Object.defineProperty(window.URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+
+        try {
+            download(blob, '../bad:name?.txt');
+        } finally {
+            Object.defineProperty(window.URL, 'createObjectURL', {
+                configurable: true,
+                value: originalCreateObjectURL,
+            });
+            Object.defineProperty(window.URL, 'revokeObjectURL', {
+                configurable: true,
+                value: originalRevokeObjectURL,
+            });
+        }
+
+        expect(createObjectURL).toHaveBeenCalledWith(blob);
+        expect(click).toHaveBeenCalledTimes(1);
+        expect(revokeObjectURL).toHaveBeenCalledWith('blob:test-url');
+        expect(document.querySelectorAll('a')).toHaveLength(0);
+        const anchor = createElement.mock.results[0].value as HTMLAnchorElement;
+        expect(anchor.download).toBe('..badname.txt');
+    });
+});
+
+describe('timeDurationDisplay', () => {
+    it.each([
+        { timestamp: 1, length: 100, expected: '00:00.001' },
+        { timestamp: 50, length: 100, expected: '00:00.050' },
+        { timestamp: 99, length: 99, expected: '00:00.099' },
+        { timestamp: 999, length: 1000, expected: '00:00.999' },
+        { timestamp: 1250, length: 1250, expected: '00:01.250' },
+    ])('zero-pads millisecond precision for $timestamp ms', ({ timestamp, length, expected }) => {
+        expect(timeDurationDisplay(timestamp, length, true)).toBe(expected);
+    });
+
+    it('can omit milliseconds and display hour-long durations', () => {
+        expect(timeDurationDisplay(3_661_250, 4_000_000, false)).toEqual('01:01:01');
+    });
+
+    it('displays negative timestamps with a leading minus sign', () => {
+        expect(timeDurationDisplay(-1250, 1250, true)).toEqual('-00:01.250');
+        expect(timeDurationDisplay(-1250, 1250, false)).toEqual('-00:01');
+    });
+
+    it('displays negative timestamps with hours when the media is at least one hour long', () => {
+        expect(timeDurationDisplay(-3_723_004, 3_723_004, true)).toEqual('-01:02:03.004');
+    });
+
+    it('displays negative timestamps with hours when their magnitude exceeds the adjusted media length', () => {
+        expect(timeDurationDisplay(-5_400_000, 1_800_000, true)).toEqual('-01:30:00.000');
+    });
+});
+
+describe('clampMediaTimestamp', () => {
+    it('clamps negative media timestamps to zero', () => {
+        expect(clampMediaTimestamp(-1)).toBe(0);
+        expect(clampMediaTimestamp(0)).toBe(0);
+        expect(clampMediaTimestamp(1)).toBe(1);
+    });
+
+    it('clamps media timestamps to an optional media length', () => {
+        expect(clampMediaTimestamp(-1, 100)).toBe(0);
+        expect(clampMediaTimestamp(50, 100)).toBe(50);
+        expect(clampMediaTimestamp(100, 100)).toBe(100);
+        expect(clampMediaTimestamp(101, 100)).toBe(100);
+    });
+
+    it('does not apply an unavailable or invalid media length', () => {
+        expect(clampMediaTimestamp(100, 0)).toBe(100);
+        expect(clampMediaTimestamp(100, -1)).toBe(100);
+        expect(clampMediaTimestamp(100, Number.NaN)).toBe(100);
+        expect(clampMediaTimestamp(100, Number.POSITIVE_INFINITY)).toBe(100);
+    });
+});
+
+describe('surroundingSubtitles', () => {
+    it('returns 0 items when subtitles are empty', () => {
+        expect(surroundingSubtitles([], 0, 0, 0)).toEqual([]);
+    });
+
+    it('returns the only subtitle for 1 item', () => {
+        const subtitles = [subtitle('1', 10, 20)];
+        expect(surroundingSubtitles(subtitles, 0, 0, 0)).toEqual(subtitles);
+    });
+
+    it('returns 2 items when count radius reaches the neighbor', () => {
+        const subtitles = [subtitle('1', 0, 5), subtitle('2', 10, 15)];
+        expect(surroundingSubtitles(subtitles, 0, 1, 0)).toEqual(subtitles);
+    });
+
+    it('uses time radius to include overlapping neighbors when count radius is 0', () => {
+        const subtitles = [subtitle('1', 0, 5), subtitle('2', 4, 9), subtitle('3', 30, 35)];
+        expect(surroundingSubtitles(subtitles, 1, 0, 5)).toEqual([subtitle('1', 0, 5), subtitle('2', 4, 9)]);
+    });
+});
+
+describe('surroundingSubtitlesAroundInterval', () => {
+    it('calculates surrounding subtitles around interval in middle when radius is 0', () => {
+        const surrounding = surroundingSubtitlesAroundInterval(
+            [subtitle('1', 0, 1), subtitle('2', 10, 20), subtitle('3', 25, 26), subtitle('4', 26, 30)],
+            9,
+            27,
+            0,
+            0
+        );
+        expect(surrounding.subtitle).toEqual(subtitle('2', 10, 20));
+        expect(surrounding.surroundingSubtitles).toEqual([
+            subtitle('2', 10, 20),
+            subtitle('3', 25, 26),
+            subtitle('4', 26, 30),
+        ]);
+    });
+
+    it('calculates surrounding subtitles around interval in middle when radius is 0 and subtitles overlap', () => {
+        const surrounding = surroundingSubtitlesAroundInterval(
+            [subtitle('1', 0, 1), subtitle('2', 10, 20), subtitle('3', 15, 26), subtitle('4', 26, 30)],
+            9,
+            25,
+            0,
+            0
+        );
+        expect(surrounding.subtitle).toEqual(subtitle('2', 10, 20));
+        expect(surrounding.surroundingSubtitles).toEqual([subtitle('2', 10, 20), subtitle('3', 15, 26)]);
+    });
+
+    it('returns an empty object for 0 items around an interval', () => {
+        expect(surroundingSubtitlesAroundInterval([], 0, 10, 0, 0)).toEqual({});
+    });
+
+    it('returns an empty object when a single subtitle collapses both interval boundaries', () => {
+        const only = subtitle('1', 10, 20);
+        expect(surroundingSubtitlesAroundInterval([only], 11, 19, 0, 0)).toEqual({});
+    });
+
+    it('returns 2 items when count radius covers both interval neighbors', () => {
+        const first = subtitle('1', 10, 20);
+        const second = subtitle('2', 30, 40);
+        expect(surroundingSubtitlesAroundInterval([first, second], 15, 35, 1, 0)).toEqual({
+            surroundingSubtitles: [first, second],
+            subtitle: second,
+        });
+    });
+});
+
+describe('mockSurroundingSubtitles', () => {
+    it('returns 1 item when the subtitle already spans the whole media', () => {
+        const middle = subtitle('1', 0, 100);
+        expect(mockSurroundingSubtitles(middle, 100, 10)).toEqual([middle]);
+    });
+
+    it('returns 2 items with a trailing filler when only the end has space', () => {
+        const middle = subtitle('1', 0, 40);
+        expect(mockSurroundingSubtitles(middle, 100, 10)).toEqual([
+            middle,
+            {
+                text: '',
+                start: 40,
+                end: 50,
+                originalStart: 40,
+                originalEnd: 50,
+                track: 0,
+                index: 0,
+                richText: undefined,
+            },
+        ]);
+    });
+
+    it('returns 3 items when space exists on both sides and preserves subtitle offset', () => {
+        const middle = { ...subtitle('1', 20, 30), originalStart: 10, originalEnd: 20 };
+        expect(mockSurroundingSubtitles(middle, 100, 10)).toEqual([
+            {
+                text: '',
+                start: 10,
+                end: 20,
+                originalStart: 0,
+                originalEnd: 10,
+                track: 0,
+                index: 0,
+                richText: undefined,
+            },
+            middle,
+            {
+                text: '',
+                start: 30,
+                end: 40,
+                originalStart: 20,
+                originalEnd: 30,
+                track: 0,
+                index: 0,
+                richText: undefined,
+            },
+        ]);
+    });
+});
+
+describe('subtitleTimestampWithDelay', () => {
+    it('computes subtitle timestamp with delay and clamps to subtitle interval', () => {
+        const sample = subtitle('text', 1000, 2000);
+
+        expect(subtitleTimestampWithDelay(sample, 300)).toBe(1300);
+        expect(subtitleTimestampWithDelay(sample, 1500)).toBe(2000);
+        expect(subtitleTimestampWithDelay(sample, -300)).toBe(1700);
+        expect(subtitleTimestampWithDelay(sample, -1500)).toBe(1000);
+    });
+
+    it('computes subtitle timestamp correctly for reversed intervals and zero-length subtitles', () => {
+        expect(subtitleTimestampWithDelay(subtitle('text', 2000, 1000), 300)).toBe(1300);
+        expect(subtitleTimestampWithDelay(subtitle('text', 1500, 1500), 999)).toBe(1500);
+    });
+});
+
+describe('subtitleIntersectsTimeInterval', () => {
+    it('returns false for 0-length subtitles', () => {
+        expect(subtitleIntersectsTimeInterval(subtitle('1', 10, 10), [0, 100])).toBe(false);
+    });
+
+    it('returns true when overlap is exactly half of the subtitle length', () => {
+        expect(subtitleIntersectsTimeInterval(subtitle('1', 10, 20), [0, 15])).toBe(true);
+    });
+
+    it('returns false when overlap is less than half of the subtitle length', () => {
+        expect(subtitleIntersectsTimeInterval(subtitle('1', 10, 20), [0, 14])).toBe(false);
+    });
+});
+
+describe('joinSubtitles', () => {
+    it('returns an empty string for 0 items', () => {
+        expect(joinSubtitles([])).toBe('');
+    });
+
+    it('joins 1 and 2 non-empty subtitles while filtering whitespace-only text', () => {
+        expect(joinSubtitles([subtitle('one', 0, 1)])).toBe('one');
+        expect(joinSubtitles([subtitle('one', 0, 1), subtitle('two', 1, 2)])).toBe('one\ntwo');
+        expect(joinSubtitles([subtitle('one', 0, 1), subtitle('   ', 1, 2), subtitle('two', 2, 3)])).toBe('one\ntwo');
+    });
+});
+
+describe('extractText', () => {
+    it('returns the subtitle text when surrounding subtitles are empty', () => {
+        const current = subtitle('current', 10, 20);
+        expect(extractText(current, [])).toBe('current');
+    });
+
+    it('extracts 1 matching subtitle and filters by track when requested', () => {
+        const current = subtitle('current', 10, 20, 0);
+        const surrounding = [subtitle('track0', 10, 20, 0), subtitle('track1', 10, 20, 1)];
+        expect(extractText(current, surrounding, 0)).toBe('track0');
+        expect(extractText(current, surrounding, 1)).toBe('track1');
+    });
+
+    it('extracts 2 overlapping subtitles and excludes non-intersecting ones', () => {
+        const current = subtitle('current', 10, 20);
+        const surrounding = [subtitle('one', 5, 15), subtitle('two', 15, 25), subtitle('three', 30, 40)];
+        expect(extractText(current, surrounding)).toBe('one\ntwo');
+    });
+});
+
+describe('computeStyles and computeStyleString', () => {
+    it('returns base styles when optional decorations are disabled', () => {
+        expect(computeStyles(textSubtitleSettings())).toEqual({
+            color: '#FFFFFF',
+            fontSize: '32px',
+            fontWeight: '700',
+        });
+    });
+
+    it('applies outline, shadow, background, font family, and custom styles while ignoring numeric keys', () => {
+        const styles = computeStyles(
+            textSubtitleSettings({
+                subtitleOutlineThickness: 2,
+                subtitleShadowThickness: 3,
+                subtitleBackgroundOpacity: 0.5,
+                subtitleBackgroundColor: '#112233',
+                subtitleFontFamily: 'Noto Sans JP',
+                subtitleCustomStyles: [
+                    { key: 'webkitTextFillColor', value: '#ABCDEF' },
+                    { key: 'letterSpacing', value: '0.1em' },
+                    { key: '0', value: 'invalid' },
+                ],
+            })
+        );
+
+        expect(styles).toEqual({
+            color: '#FFFFFF',
+            fontSize: '32px',
+            fontWeight: '700',
+            WebkitTextStroke: '#000000 2px',
+            paintOrder: 'stroke fill',
+            textShadow: '0 0 3px #111111, 0 0 3px #111111, 0 0 3px #111111, 0 0 3px #111111',
+            backgroundColor: 'rgba(17, 34, 51, 0.5)',
+            fontFamily: "'Noto Sans JP'",
+            WebkitTextFillColor: '#ABCDEF',
+            letterSpacing: '0.1em',
+        });
+    });
+
+    it('builds a kebab-cased style string with important declarations', () => {
+        const styleString = computeStyleString(
+            textSubtitleSettings({
+                subtitleOutlineThickness: 1,
+                subtitleCustomStyles: [
+                    { key: 'webkitTextFillColor', value: '#ABCDEF' },
+                    { key: 'letterSpacing', value: '0.1em' },
+                ],
+            })
+        );
+
+        expect(styleString).toContain('color: #FFFFFF !important');
+        expect(styleString).toContain('-webkit-text-stroke: #000000 1px !important');
+        expect(styleString).toContain('-webkit-text-fill-color: #ABCDEF !important');
+        expect(styleString).toContain('letter-spacing: 0.1em !important');
+    });
+});
+
+describe('kana detection and normalization', () => {
+    it('detects kana-only strings after NFC normalization', () => {
+        expect(isKanaOnly('かな')).toBe(true);
+        expect(isKanaOnly('ガ')).toBe(true);
+        expect(isKanaOnly('仮名')).toBe(false);
+        expect(isKanaOnly('')).toBe(false);
+    });
+
+    it('detects katakana-only strings and rejects hiragana and latin text', () => {
+        expect(isKatakanaOnly('カタカナ')).toBe(true);
+        expect(isKatakanaOnly('ガ')).toBe(true);
+        expect(isKatakanaOnly('かな')).toBe(false);
+        expect(isKatakanaOnly('abc')).toBe(false);
+    });
+
+    it('normalizes text for search across accent and ligature variants', () => {
+        expect(normalizeForSearch('Crème Brûlée')).toBe('Creme Brulee');
+        expect(normalizeForSearch('straße STRAẞE æ Æ œ Œ ø Ø đ Đ ł Ł')).toBe('strasse STRASSE ae AE oe OE o O d D l L');
+    });
+
+    it('normalizes decomposed input, preserves plain text, and is idempotent', () => {
+        expect(normalizeForSearch('Cafe\u0301')).toBe('Cafe');
+        expect(normalizeForSearch('plain ASCII 123')).toBe('plain ASCII 123');
+        expect(normalizeForSearch(normalizeForSearch('Crème straße'))).toBe('Creme strasse');
+    });
+
+    it('removes combining marks without otherwise transliterating non-Latin text', () => {
+        expect(normalizeForSearch('かな カナ 漢字')).toBe('かな カナ 漢字');
+        expect(normalizeForSearch('क़')).toBe('क');
+    });
+});
+
+describe('isNumeric', () => {
+    it('returns true for integer, decimal, negative, and empty strings', () => {
+        // Number('') === 0, so the implementation treats '' as numeric — pin this invariant
+        expect(isNumeric('0')).toBe(true);
+        expect(isNumeric('1')).toBe(true);
+        expect(isNumeric('-1')).toBe(true);
+        expect(isNumeric('1.5')).toBe(true);
+        expect(isNumeric('')).toBe(true);
+    });
+
+    it('returns false for non-numeric strings used as style keys', () => {
+        expect(isNumeric('a')).toBe(false);
+        expect(isNumeric('letterSpacing')).toBe(false);
+        expect(isNumeric('NaN')).toBe(false);
+    });
+});
+
+describe('color and source helpers', () => {
+    it('parses hex colors and falls back to white on invalid input', () => {
+        expect(hexToRgb('#112233')).toEqual({ r: 17, g: 34, b: 51 });
+        expect(hexToRgb('invalid')).toEqual({ r: 255, g: 255, b: 255 });
+    });
+
+    it('converts alpha hex values to percents and back with clamping', () => {
+        expect(hex2ToPercent('#00')).toBe(0);
+        expect(hex2ToPercent('#FF')).toBe(1);
+        expect(hex2ToPercent('invalid')).toBe(1);
+        expect(percentToHex2(0)).toBe('00');
+        expect(percentToHex2(0.5)).toBe('80');
+        expect(percentToHex2(1.5)).toBe('FF');
+    });
+
+    it('omits the timestamp from source strings when the timestamp is 0', () => {
+        expect(sourceString('episode.ass', 0)).toBe('episode.ass');
+        expect(sourceString('episode.ass', 8_250)).toBe('episode.ass (00h00m08.3s)');
+    });
+});
+
+describe('seekWithNudge', () => {
+    it('returns the exact target timestamp when the media lands on it', () => {
+        const media = { currentTime: 0, duration: 100 } as HTMLMediaElement;
+        expect(seekWithNudge(media, 5)).toBe(5);
+    });
+
+    it('nudges forward when the media lands short', () => {
+        let storedTime = 0;
+        let writes = 0;
+        const media = {
+            duration: 10,
+            get currentTime() {
+                return storedTime;
+            },
+            set currentTime(value: number) {
+                writes += 1;
+                storedTime = writes === 1 ? 4.995 : value;
+            },
+        } as HTMLMediaElement;
+
+        expect(seekWithNudge(media, 6)).toBeCloseTo(5.005, 5);
+    });
+
+    it('caps a forward nudge at the media duration', () => {
+        let storedTime = 0;
+        let writes = 0;
+        const media = {
+            duration: 10,
+            get currentTime() {
+                return storedTime;
+            },
+            set currentTime(value: number) {
+                writes += 1;
+                storedTime = writes === 1 ? 9.995 : value;
+            },
+        } as HTMLMediaElement;
+
+        expect(seekWithNudge(media, 10)).toBe(10);
+    });
+
+    it('clamps negative seeks before updating the media element', () => {
+        const media = { currentTime: 10, duration: 100 } as HTMLMediaElement;
+
+        expect(seekWithNudge(media, -1)).toBe(0);
+        expect(media.currentTime).toBe(0);
+    });
+
+    it('clamps seeks past the media duration before updating the media element', () => {
+        const media = { currentTime: 10, duration: 100 } as HTMLMediaElement;
+
+        expect(seekWithNudge(media, 101)).toBe(100);
+        expect(media.currentTime).toBe(100);
+    });
+});
+
+describe('batch helpers', () => {
+    it('inBatches handles 0, 1, and 2 items in order and reports progress', async () => {
+        const seen: number[][] = [];
+        const progress: Array<{ current: number; total: number }> = [];
+
+        await inBatches([], async (batch) => {
+            seen.push(batch);
+        });
+        await inBatches(
+            [1],
+            async (batch) => {
+                seen.push(batch);
+            },
+            { batchSize: 1 }
+        );
+        await inBatches(
+            [1, 2],
+            async (batch) => {
+                seen.push(batch);
+            },
+            {
+                batchSize: 0,
+                statusUpdates: async ({ current, total }) => {
+                    progress.push({ current, total });
+                },
+            }
+        );
+
+        expect(seen).toEqual([[1], [1], [2]]);
+        expect(progress).toEqual([
+            { current: 1, total: 2 },
+            { current: 2, total: 2 },
+        ]);
+    });
+
+    it('fromBatches handles 0, 1, and 2 items while flattening results in order', async () => {
+        expect(await fromBatches([], async (batch) => batch.map(String), { batchSize: 2 })).toEqual([]);
+        expect(await fromBatches([1], async (batch) => batch.map(String), { batchSize: 1 })).toEqual(['1']);
+        expect(await fromBatches([1, 2], async (batch) => batch.map((value) => value * 10), { batchSize: 1 })).toEqual([
+            10, 20,
+        ]);
+    });
+
+    it('mapAsync preserves input order for 0, 1, and 2 items', async () => {
+        expect(await mapAsync([], async (value: number) => value, { batchSize: 2 })).toEqual([]);
+        expect(await mapAsync([1], async (value) => value + 1, { batchSize: 1 })).toEqual([2]);
+        expect(
+            await mapAsync(
+                [1, 2],
+                async (value) => {
+                    await Promise.resolve();
+                    return value * 2;
+                },
+                { batchSize: 2 }
+            )
+        ).toEqual([2, 4]);
+    });
+
+    it('filterAsync preserves input order while filtering through async batches', async () => {
+        const progress = jest.fn(async () => undefined);
+
+        await expect(
+            filterAsync([1, 2, 3, 4], async (value) => value % 2 === 0, { batchSize: 2, statusUpdates: progress })
+        ).resolves.toEqual([2, 4]);
+        expect(progress).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('ensureStoragePersisted', () => {
+    const originalStorage = navigator.storage;
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    beforeEach(() => {
+        warn.mockClear();
+    });
+
+    afterEach(() => {
+        Object.defineProperty(navigator, 'storage', {
+            configurable: true,
+            value: originalStorage,
+        });
+    });
+
+    it('returns early when the storage API is unavailable', async () => {
+        Object.defineProperty(navigator, 'storage', {
+            configurable: true,
+            value: undefined,
+        });
+
+        await expect(ensureStoragePersisted()).resolves.toBeUndefined();
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('returns early when storage is already persisted', async () => {
+        Object.defineProperty(navigator, 'storage', {
+            configurable: true,
+            value: {
+                persist: async () => true,
+                persisted: async () => true,
+            },
+        });
+
+        await ensureStoragePersisted();
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('warns when requesting persistence fails', async () => {
+        Object.defineProperty(navigator, 'storage', {
+            configurable: true,
+            value: {
+                persist: async () => false,
+                persisted: async () => false,
+            },
+        });
+
+        await ensureStoragePersisted();
+        expect(warn).toHaveBeenCalledWith('Storage could not be persisted, data may be cleared by the browser');
+    });
+});
+
+describe('iterateOverStringInBlocks', () => {
+    it('iterates over a full gap when there are 0 blocks', () => {
+        const calls: Array<[number, number, boolean]> = [];
+
+        iterateOverStringInBlocks(
+            'abcd',
+            () => undefined,
+            (left, right, block) => {
+                calls.push([left, right, block !== undefined]);
+            }
+        );
+
+        expect(calls).toEqual([[0, 4, false]]);
+    });
+
+    it('iterates over 1 block and surrounding gaps', () => {
+        const calls: Array<[number, number, string | undefined]> = [];
+
+        iterateOverStringInBlocks(
+            'abcdef',
+            (_, index) => (index === 0 ? { pos: [2, 4], label: 'block' } : undefined),
+            (left, right, block) => {
+                calls.push([left, right, block?.label]);
+            }
+        );
+
+        expect(calls).toEqual([
+            [0, 2, undefined],
+            [2, 4, 'block'],
+            [4, 6, undefined],
+        ]);
+    });
+
+    it('iterates over 2 adjacent blocks without inventing extra gaps', () => {
+        const calls: Array<[number, number, string | undefined]> = [];
+
+        iterateOverStringInBlocks(
+            'abcdef',
+            (_, index) => {
+                if (index === 0) return { pos: [0, 2], label: 'a' };
+                if (index === 1) return { pos: [2, 4], label: 'b' };
+                return undefined;
+            },
+            (left, right, block) => {
+                calls.push([left, right, block?.label]);
+            }
+        );
+
+        expect(calls).toEqual([
+            [0, 2, 'a'],
+            [2, 4, 'b'],
+            [4, 6, undefined],
+        ]);
+    });
+});
+
+describe('areTokenizationsEqual', () => {
+    const tokenization = {
+        error: false,
+        tokens: [
+            {
+                pos: [0, 1],
+                status: 'known',
+                states: ['ignored'],
+                readings: [{ pos: [0, 1], reading: 'a' }],
+                frequency: 1,
+                groupingKey: 'group-a',
+            },
+        ],
+    } as any;
+
+    it('handles undefined values', () => {
+        expect(areTokenizationsEqual(undefined, undefined)).toBe(true);
+        expect(areTokenizationsEqual(tokenization, undefined)).toBe(false);
+    });
+
+    it('returns true for structurally equal tokenizations', () => {
+        expect(
+            areTokenizationsEqual(tokenization, {
+                ...tokenization,
+                tokens: tokenization.tokens.map((token: any) => ({
+                    ...token,
+                    pos: [...token.pos],
+                    states: [...token.states],
+                    readings: token.readings.map((reading: any) => ({ ...reading, pos: [...reading.pos] })),
+                })),
+            })
+        ).toBe(true);
+    });
+
+    it('detects differences in tokenization error state', () => {
+        expect(areTokenizationsEqual(tokenization, { ...tokenization, error: true })).toBe(false);
+    });
+
+    it('detects differences in token grouping keys', () => {
+        expect(
+            areTokenizationsEqual(tokenization, {
+                ...tokenization,
+                tokens: [{ ...tokenization.tokens[0], groupingKey: 'group-b' }],
+            })
+        ).toBe(false);
+    });
+
+    it('detects differences in token readings', () => {
+        expect(
+            areTokenizationsEqual(tokenization, {
+                ...tokenization,
+                tokens: [{ ...tokenization.tokens[0], readings: [{ pos: [0, 1], reading: 'b' }] }],
+            })
+        ).toBe(false);
+    });
+});
+
+describe('AsyncSemaphore', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('validates constructor options', () => {
+        expect(() => new AsyncSemaphore({ permits: 0 })).toThrow('Permits count must be positive');
+        expect(() => new AsyncSemaphore({ permits: 1, lifetimeMs: -1 })).toThrow('Lifetime must be positive');
+    });
+
+    it('acquires immediately when permits are available', async () => {
+        const semaphore = new AsyncSemaphore({ permits: 1 });
+        await expect(semaphore.acquire()).resolves.toBe(1);
+    });
+
+    it('preserves FIFO order within the same priority', async () => {
+        const semaphore = new AsyncSemaphore({ permits: 1 });
+        const first = await semaphore.acquire();
+        const secondPromise = semaphore.acquire();
+        const thirdPromise = semaphore.acquire();
+
+        semaphore.release(first);
+        const second = await secondPromise;
+        semaphore.release(second);
+        const third = await thirdPromise;
+
+        expect([second, third]).toEqual([2, 3]);
+    });
+
+    it('favors higher priorities when releasing permits', async () => {
+        const semaphore = new AsyncSemaphore({ permits: 1 });
+        const first = await semaphore.acquire();
+        const lowPriorityPromise = semaphore.acquire(0);
+        const highPriorityPromise = semaphore.acquire(2);
+
+        semaphore.release(first);
+        const highPriority = await highPriorityPromise;
+        semaphore.release(highPriority);
+        const lowPriority = await lowPriorityPromise;
+
+        expect(highPriority).toBe(2);
+        expect(lowPriority).toBe(3);
+    });
+
+    it('ignores duplicate releases without granting an extra permit', async () => {
+        const semaphore = new AsyncSemaphore({ permits: 1 });
+        const first = await semaphore.acquire();
+        const queued = semaphore.acquire();
+
+        semaphore.release(first);
+        semaphore.release(first);
+        const second = await queued;
+        const next = semaphore.acquire();
+
+        let nextAcquired = false;
+        void next.then(() => {
+            nextAcquired = true;
+        });
+        await Promise.resolve();
+
+        expect(nextAcquired).toBe(false);
+        semaphore.release(second);
+        await expect(next).resolves.toBe(3);
+        expect(second).toBe(2);
+    });
+
+    it('auto-releases an acquired permit after its lifetime expires', async () => {
+        const semaphore = new AsyncSemaphore({ permits: 1, lifetimeMs: 1000 });
+        await semaphore.acquire();
+        const queued = semaphore.acquire();
+
+        let queuedAcquired = false;
+        void queued.then(() => {
+            queuedAcquired = true;
+        });
+        await jest.advanceTimersByTimeAsync(999);
+        expect(queuedAcquired).toBe(false);
+
+        await jest.advanceTimersByTimeAsync(1);
+        await expect(queued).resolves.toBe(2);
+    });
 });
 
 // Regression test for https://github.com/asbplayer/asbplayer/issues/1064:

--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -29,11 +29,12 @@ export function arrayEquals<T>(
     return true;
 }
 
-export const localizedDate = (timestamp: number) => {
-    return new Date(timestamp).toLocaleTimeString([], {
+export const localizedDate = (timestamp: number, locales: Intl.LocalesArgument = [], timeZone?: string) => {
+    return new Date(timestamp).toLocaleTimeString(locales, {
         hour: '2-digit',
         minute: '2-digit',
         second: '2-digit',
+        timeZone,
     });
 };
 
@@ -693,11 +694,12 @@ export async function filterAsync<T>(
     return arr.filter((_, index) => results[index]);
 }
 
-export async function ensureStoragePersisted(): Promise<void> {
+export async function ensureStoragePersisted(): Promise<boolean | undefined> {
     if (!navigator.storage?.persist) return;
-    if (await navigator.storage.persisted()) return;
+    if (await navigator.storage.persisted()) return true;
     const persisted = await navigator.storage.persist();
     if (!persisted) console.warn('Storage could not be persisted, data may be cleared by the browser');
+    return persisted;
 }
 
 type Block = {

--- a/common/wanikani/wanikani.test.ts
+++ b/common/wanikani/wanikani.test.ts
@@ -1,7 +1,6 @@
-import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
+import type { Fetcher } from '@project/common';
 import { WaniKani, WaniKaniApiError, WaniKaniAssignment, WaniKaniSubject } from './wanikani';
-
-const originalFetch = globalThis.fetch;
 
 const collection = <T>(
     data: T[],
@@ -27,7 +26,7 @@ const response = (body: unknown, status = 200, statusText = 'OK', headers = new 
         status,
         statusText,
         headers,
-        json: jest.fn(async () => body),
+        json: async () => body,
     }) as unknown as Response;
 
 const responseWithInvalidJson = (status: number, statusText: string) =>
@@ -36,10 +35,23 @@ const responseWithInvalidJson = (status: number, statusText: string) =>
         status,
         statusText,
         headers: new Headers(),
-        json: jest.fn(async () => {
+        json: async () => {
             throw new Error('invalid json');
-        }),
+        },
     }) as unknown as Response;
+
+class TestTransport implements Fetcher<RequestInit, Response> {
+    requests: Array<{ url: string; init: RequestInit }> = [];
+
+    constructor(private readonly responses: Response[]) {}
+
+    fetch = async (url: string, init: RequestInit) => {
+        this.requests.push({ url, init });
+        const response = this.responses.shift();
+        if (response === undefined) throw new Error('Unexpected WaniKani request');
+        return response;
+    };
+}
 
 const makeAssignment = (id: number): WaniKaniAssignment => ({
     id,
@@ -68,22 +80,15 @@ const makeSubject = (id: number): WaniKaniSubject => ({
     },
 });
 
-afterEach(() => {
-    globalThis.fetch = originalFetch;
-    jest.useRealTimers();
-    jest.restoreAllMocks();
-});
-
 describe('WaniKani', () => {
     it('sends auth headers, encodes query params, and follows paginated collection responses', async () => {
-        const fetchMock = jest.fn<typeof fetch>();
-        globalThis.fetch = fetchMock;
         const nextUrl = 'https://api.wanikani.com/v2/assignments?page_after_id=1';
-        fetchMock
-            .mockResolvedValueOnce(response(collection([makeAssignment(1)], nextUrl, '2024-01-01', 4)))
-            .mockResolvedValueOnce(response(collection([makeAssignment(2)], null, '2024-01-02', 99)));
+        const transport = new TestTransport([
+            response(collection([makeAssignment(1)], nextUrl, '2024-01-01', 4)),
+            response(collection([makeAssignment(2)], null, '2024-01-02', 99)),
+        ]);
 
-        const result = await new WaniKani('  wk-token  ').assignments({
+        const result = await new WaniKani('  wk-token  ', transport).assignments({
             subjectTypes: ['vocabulary', 'kana_vocabulary'],
             updatedAfter: '2024-01-01',
         });
@@ -93,28 +98,25 @@ describe('WaniKani', () => {
             dataUpdatedAt: '2024-01-01',
             totalCount: 4,
         });
-        expect(fetchMock).toHaveBeenCalledTimes(2);
-        const [url, init] = fetchMock.mock.calls[0];
-        const firstUrl = new URL(url as string);
+        expect(transport.requests).toHaveLength(2);
+        const firstUrl = new URL(transport.requests[0].url);
         expect(firstUrl.origin + firstUrl.pathname).toBe('https://api.wanikani.com/v2/assignments');
         expect(firstUrl.searchParams.get('subject_types')).toBe('vocabulary,kana_vocabulary');
         expect(firstUrl.searchParams.get('updated_after')).toBe('2024-01-01');
-        expect(init).toEqual({
+        expect(transport.requests[0].init).toEqual({
             method: 'GET',
             headers: {
                 Authorization: 'Bearer wk-token',
                 'Wanikani-Revision': '20170710',
             },
         });
-        expect(fetchMock.mock.calls[1][0]).toBe(nextUrl);
+        expect(transport.requests[1].url).toBe(nextUrl);
     });
 
     it('maps structured WaniKani error responses', async () => {
-        const fetchMock = jest.fn<typeof fetch>();
-        globalThis.fetch = fetchMock;
-        fetchMock.mockResolvedValue(response({ error: 'Token is invalid', code: 401 }, 401, 'Unauthorized'));
+        const transport = new TestTransport([response({ error: 'Token is invalid', code: 401 }, 401, 'Unauthorized')]);
 
-        await expect(new WaniKani('bad-token').user()).rejects.toMatchObject({
+        await expect(new WaniKani('bad-token', transport).user()).rejects.toMatchObject({
             name: 'WaniKaniApiError',
             status: 401,
             code: 401,
@@ -123,54 +125,57 @@ describe('WaniKani', () => {
     });
 
     it('falls back to HTTP status text when an error response is malformed', async () => {
-        const fetchMock = jest.fn<typeof fetch>();
-        globalThis.fetch = fetchMock;
+        const transport = new TestTransport([responseWithInvalidJson(500, 'Server Error')]);
 
-        fetchMock.mockResolvedValue(responseWithInvalidJson(500, 'Server Error'));
-
-        await expect(new WaniKani('token').subjects({ types: ['vocabulary'] })).rejects.toMatchObject({
+        await expect(new WaniKani('token', transport).subjects({ types: ['vocabulary'] })).rejects.toMatchObject({
             status: 500,
             message: 'Server Error',
         } satisfies Partial<WaniKaniApiError>);
     });
 
     it('retries one rate-limited request after the reset delay', async () => {
-        jest.useFakeTimers();
-        jest.spyOn(Date, 'now').mockReturnValue(1000);
-        const fetchMock = jest.fn<typeof fetch>();
-        globalThis.fetch = fetchMock;
-        fetchMock
-            .mockResolvedValueOnce(
-                response({ error: 'Rate limited', code: 429 }, 429, 'Too Many Requests', {
-                    get: (name: string) => (name === 'RateLimit-Reset' ? '2' : null),
-                } as Headers)
-            )
-            .mockResolvedValueOnce(response(makeSubject(1)));
+        const transport = new TestTransport([
+            response(
+                { error: 'Rate limited', code: 429 },
+                429,
+                'Too Many Requests',
+                new Headers({ 'RateLimit-Reset': '2' })
+            ),
+            response(makeSubject(1)),
+        ]);
+        const waits: number[] = [];
 
-        const promise = new WaniKani('token').user();
-        await Promise.resolve();
+        const result = await new WaniKani(
+            'token',
+            transport,
+            () => 1000,
+            async (milliseconds) => {
+                waits.push(milliseconds);
+            }
+        ).user();
 
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        jest.advanceTimersByTime(2000);
-        await expect(promise).resolves.toEqual(makeSubject(1));
-        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(result).toEqual(makeSubject(1));
+        expect(waits).toEqual([2000]);
+        expect(transport.requests).toHaveLength(2);
     });
 
     it('surfaces a second rate-limit response without retrying indefinitely', async () => {
-        jest.useFakeTimers();
-        jest.spyOn(Date, 'now').mockReturnValue(1000);
-        const fetchMock = jest.fn<typeof fetch>();
-        globalThis.fetch = fetchMock;
-        const rateLimited = response({ error: 'Rate limited', code: 429 }, 429, 'Too Many Requests', {
-            get: (name: string) => (name === 'RateLimit-Reset' ? '2' : null),
-        } as Headers);
-        fetchMock.mockResolvedValueOnce(rateLimited).mockResolvedValueOnce(rateLimited);
+        const rateLimited = response(
+            { error: 'Rate limited', code: 429 },
+            429,
+            'Too Many Requests',
+            new Headers({ 'RateLimit-Reset': '2' })
+        );
+        const transport = new TestTransport([rateLimited, rateLimited]);
 
-        const promise = new WaniKani('token').user();
-        await Promise.resolve();
-        jest.advanceTimersByTime(2000);
-
-        await expect(promise).rejects.toMatchObject({ status: 429, code: 429, message: 'Rate limited' });
-        expect(fetchMock).toHaveBeenCalledTimes(2);
+        await expect(
+            new WaniKani(
+                'token',
+                transport,
+                () => 1000,
+                async () => undefined
+            ).user()
+        ).rejects.toMatchObject({ status: 429, code: 429, message: 'Rate limited' });
+        expect(transport.requests).toHaveLength(2);
     });
 });

--- a/common/wanikani/wanikani.test.ts
+++ b/common/wanikani/wanikani.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { WaniKani, WaniKaniApiError, WaniKaniAssignment, WaniKaniSubject } from './wanikani';
+
+const originalFetch = globalThis.fetch;
+
+const collection = <T>(
+    data: T[],
+    nextUrl: string | null = null,
+    dataUpdatedAt = '2024-01-01T00:00:00.000000Z',
+    totalCount = data.length
+) => ({
+    object: 'collection',
+    url: 'https://api.wanikani.com/v2/test',
+    data_updated_at: dataUpdatedAt,
+    data,
+    pages: {
+        next_url: nextUrl,
+        previous_url: null,
+        per_page: data.length,
+    },
+    total_count: totalCount,
+});
+
+const response = (body: unknown, status = 200, statusText = 'OK', headers = new Headers()) =>
+    ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText,
+        headers,
+        json: jest.fn(async () => body),
+    }) as unknown as Response;
+
+const responseWithInvalidJson = (status: number, statusText: string) =>
+    ({
+        ok: false,
+        status,
+        statusText,
+        headers: new Headers(),
+        json: jest.fn(async () => {
+            throw new Error('invalid json');
+        }),
+    }) as unknown as Response;
+
+const makeAssignment = (id: number): WaniKaniAssignment => ({
+    id,
+    object: 'assignment',
+    url: `https://api.wanikani.com/v2/assignments/${id}`,
+    data_updated_at: '2024-01-01T00:00:00.000000Z',
+    data: {
+        subject_id: id,
+        subject_type: 'vocabulary',
+        srs_stage: 5,
+        hidden: false,
+        available_at: null,
+    },
+});
+
+const makeSubject = (id: number): WaniKaniSubject => ({
+    id,
+    object: 'vocabulary',
+    url: `https://api.wanikani.com/v2/subjects/${id}`,
+    data_updated_at: '2024-01-01T00:00:00.000000Z',
+    data: {
+        characters: `単語${id}`,
+        level: 1,
+        hidden_at: null,
+        spaced_repetition_system_id: 1,
+    },
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+});
+
+describe('WaniKani', () => {
+    it('sends auth headers, encodes query params, and follows paginated collection responses', async () => {
+        const fetchMock = jest.fn<typeof fetch>();
+        globalThis.fetch = fetchMock;
+        const nextUrl = 'https://api.wanikani.com/v2/assignments?page_after_id=1';
+        fetchMock
+            .mockResolvedValueOnce(response(collection([makeAssignment(1)], nextUrl, '2024-01-01', 4)))
+            .mockResolvedValueOnce(response(collection([makeAssignment(2)], null, '2024-01-02', 99)));
+
+        const result = await new WaniKani('  wk-token  ').assignments({
+            subjectTypes: ['vocabulary', 'kana_vocabulary'],
+            updatedAfter: '2024-01-01',
+        });
+
+        expect(result).toEqual({
+            data: [makeAssignment(1), makeAssignment(2)],
+            dataUpdatedAt: '2024-01-01',
+            totalCount: 4,
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        const [url, init] = fetchMock.mock.calls[0];
+        const firstUrl = new URL(url as string);
+        expect(firstUrl.origin + firstUrl.pathname).toBe('https://api.wanikani.com/v2/assignments');
+        expect(firstUrl.searchParams.get('subject_types')).toBe('vocabulary,kana_vocabulary');
+        expect(firstUrl.searchParams.get('updated_after')).toBe('2024-01-01');
+        expect(init).toEqual({
+            method: 'GET',
+            headers: {
+                Authorization: 'Bearer wk-token',
+                'Wanikani-Revision': '20170710',
+            },
+        });
+        expect(fetchMock.mock.calls[1][0]).toBe(nextUrl);
+    });
+
+    it('maps structured WaniKani error responses', async () => {
+        const fetchMock = jest.fn<typeof fetch>();
+        globalThis.fetch = fetchMock;
+        fetchMock.mockResolvedValue(response({ error: 'Token is invalid', code: 401 }, 401, 'Unauthorized'));
+
+        await expect(new WaniKani('bad-token').user()).rejects.toMatchObject({
+            name: 'WaniKaniApiError',
+            status: 401,
+            code: 401,
+            message: 'Token is invalid',
+        } satisfies Partial<WaniKaniApiError>);
+    });
+
+    it('falls back to HTTP status text when an error response is malformed', async () => {
+        const fetchMock = jest.fn<typeof fetch>();
+        globalThis.fetch = fetchMock;
+
+        fetchMock.mockResolvedValue(responseWithInvalidJson(500, 'Server Error'));
+
+        await expect(new WaniKani('token').subjects({ types: ['vocabulary'] })).rejects.toMatchObject({
+            status: 500,
+            message: 'Server Error',
+        } satisfies Partial<WaniKaniApiError>);
+    });
+
+    it('retries one rate-limited request after the reset delay', async () => {
+        jest.useFakeTimers();
+        jest.spyOn(Date, 'now').mockReturnValue(1000);
+        const fetchMock = jest.fn<typeof fetch>();
+        globalThis.fetch = fetchMock;
+        fetchMock
+            .mockResolvedValueOnce(
+                response({ error: 'Rate limited', code: 429 }, 429, 'Too Many Requests', {
+                    get: (name: string) => (name === 'RateLimit-Reset' ? '2' : null),
+                } as Headers)
+            )
+            .mockResolvedValueOnce(response(makeSubject(1)));
+
+        const promise = new WaniKani('token').user();
+        await Promise.resolve();
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        jest.advanceTimersByTime(2000);
+        await expect(promise).resolves.toEqual(makeSubject(1));
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('surfaces a second rate-limit response without retrying indefinitely', async () => {
+        jest.useFakeTimers();
+        jest.spyOn(Date, 'now').mockReturnValue(1000);
+        const fetchMock = jest.fn<typeof fetch>();
+        globalThis.fetch = fetchMock;
+        const rateLimited = response({ error: 'Rate limited', code: 429 }, 429, 'Too Many Requests', {
+            get: (name: string) => (name === 'RateLimit-Reset' ? '2' : null),
+        } as Headers);
+        fetchMock.mockResolvedValueOnce(rateLimited).mockResolvedValueOnce(rateLimited);
+
+        const promise = new WaniKani('token').user();
+        await Promise.resolve();
+        jest.advanceTimersByTime(2000);
+
+        await expect(promise).rejects.toMatchObject({ status: 429, code: 429, message: 'Rate limited' });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/common/wanikani/wanikani.ts
+++ b/common/wanikani/wanikani.ts
@@ -1,6 +1,14 @@
+import type { Fetcher } from '@project/common';
+
 const WANIKANI_API_BASE_URL = 'https://api.wanikani.com/v2';
 const WANIKANI_REVISION = '20170710';
 const DEFAULT_RATE_LIMIT_RETRY_MS = 61000;
+
+class WaniKaniHttpFetcher implements Fetcher<RequestInit, Response> {
+    fetch(url: string, init: RequestInit) {
+        return fetch(url, init);
+    }
+}
 
 type WaniKaniResourceObject<TObject extends string, TData> = {
     id: number;
@@ -122,9 +130,20 @@ export class WaniKaniApiError extends Error {
 
 export class WaniKani {
     private readonly apiToken: string;
+    private readonly fetcher: Fetcher<RequestInit, Response>;
+    private readonly now: () => number;
+    private readonly wait: (ms: number) => Promise<void>;
 
-    constructor(apiToken: string) {
+    constructor(
+        apiToken: string,
+        fetcher = new WaniKaniHttpFetcher(),
+        now = Date.now,
+        wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+    ) {
         this.apiToken = apiToken.trim();
+        this.fetcher = fetcher;
+        this.now = now;
+        this.wait = wait;
     }
 
     async user(): Promise<WaniKaniUser> {
@@ -195,7 +214,7 @@ export class WaniKani {
     private async _getJson<T>(url: string): Promise<T> {
         let retriedRateLimit = false;
         while (true) {
-            const response = await fetch(url, {
+            const response = await this.fetcher.fetch(url, {
                 method: 'GET',
                 headers: {
                     Authorization: `Bearer ${this.apiToken}`,
@@ -224,8 +243,8 @@ export class WaniKani {
         const resetHeader = response.headers.get('RateLimit-Reset');
         const resetValue = resetHeader === null ? Number.NaN : Number(resetHeader);
         const delay = Number.isFinite(resetValue)
-            ? Math.max(1000, resetValue * 1000 - Date.now() + 1000)
+            ? Math.max(1000, resetValue * 1000 - this.now() + 1000)
             : DEFAULT_RATE_LIMIT_RETRY_MS;
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await this.wait(delay);
     }
 }

--- a/common/yomitan/yomitan.test.ts
+++ b/common/yomitan/yomitan.test.ts
@@ -1,4 +1,4 @@
-import { Fetcher } from '@project/common';
+import { Fetcher, Progress } from '@project/common';
 import {
     DictionaryTrack,
     defaultSettings,
@@ -16,6 +16,8 @@ import {
     TermSource,
     TokenPartResult,
     Yomitan,
+    filterYomitanDictionaries,
+    splitTextForTokenization,
 } from '@project/common/yomitan';
 
 const testDictionaryTrack = (overrides: Partial<DictionaryTrack> = {}): DictionaryTrack => ({
@@ -133,6 +135,24 @@ const makeTokenizeResult = (overrides: Partial<TestTokenizeResult> = {}): TestTo
     ...overrides,
 });
 
+const makeMecabSupportResult = () =>
+    makeTokenizeResult({
+        source: 'mecab',
+        dictionary: 'UniDic 202402',
+        content: [
+            [
+                makeTokenPart({
+                    text: '思い',
+                    reading: 'おもい',
+                    lemma: '思い出す',
+                    lemmaReading: 'おもいだす',
+                }),
+                makeTokenPart({ text: '出せ', reading: 'だせ' }),
+                makeTokenPart({ text: 'なく', reading: 'なく' }),
+            ],
+        ],
+    });
+
 const makeTermEntriesResult = (index: number, dictionaryEntries: TermDictionaryEntry[]): TermEntriesResult => ({
     dictionaryEntries,
     originalTextLength: 1,
@@ -155,6 +175,7 @@ const flushMicrotasks = async (turns = 6) => {
 
 afterEach(() => {
     jest.restoreAllMocks();
+    jest.useRealTimers();
 });
 
 describe('Yomitan', () => {
@@ -174,80 +195,116 @@ describe('Yomitan', () => {
         await expect(yomitan.lemmatize('alpha')).rejects.toThrow('Unexpected Yomitan termEntries response');
     });
 
-    it('reports bulk frequency support based on parser-specific feature flags', () => {
-        const scanning = new Yomitan(testDictionaryTrack());
-        (scanning as any).supportsTokenizeFrequency = true;
-        (scanning as any).supportsTermEntriesBulk = false;
+    it('reports bulk frequency support after negotiating parser-specific capabilities', async () => {
+        const scanningFetcher = new MockFetcher();
+        scanningFetcher.fetch.mockResolvedValue({ version: '26.4.6' });
+        const scanning = new Yomitan(testDictionaryTrack(), scanningFetcher);
+        await scanning.version();
 
-        const mecab = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
-        (mecab as any).supportsTokenizeFrequency = false;
-        (mecab as any).supportsTermEntriesBulk = true;
+        const mecabFetcher = new MockFetcher();
+        mecabFetcher.fetch
+            .mockResolvedValueOnce({ version: '26.4.6' })
+            .mockResolvedValueOnce([makeMecabSupportResult()]);
+        const mecab = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), mecabFetcher);
+        await mecab.version();
 
         expect(scanning.getSupportsBulkFrequency()).toBe(true);
         expect(mecab.getSupportsBulkFrequency()).toBe(true);
     });
 
-    it('reports bulk frequency support as false when the parser-specific feature flag is disabled', () => {
-        const scanning = new Yomitan(testDictionaryTrack());
-        (scanning as any).supportsTokenizeFrequency = false;
-        (scanning as any).supportsTermEntriesBulk = true;
+    it('reports bulk frequency support as false before the bulk API version', async () => {
+        const scanningFetcher = new MockFetcher();
+        scanningFetcher.fetch.mockResolvedValue({ version: '26.4.5' });
+        const scanning = new Yomitan(testDictionaryTrack(), scanningFetcher);
+        await scanning.version();
 
-        const mecab = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
-        (mecab as any).supportsTokenizeFrequency = true;
-        (mecab as any).supportsTermEntriesBulk = false;
+        const mecabFetcher = new MockFetcher();
+        mecabFetcher.fetch
+            .mockResolvedValueOnce({ version: '26.4.5' })
+            .mockResolvedValueOnce([makeMecabSupportResult()]);
+        const mecab = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), mecabFetcher);
+        await mecab.version();
 
         expect(scanning.getSupportsBulkFrequency()).toBe(false);
         expect(mecab.getSupportsBulkFrequency()).toBe(false);
     });
 
-    it('reports bulk pitch accent support based on parser-specific feature flags', () => {
-        const scanning = new Yomitan(testDictionaryTrack());
-        (scanning as any).supportsTokenizePronunciations = true;
-        (scanning as any).supportsTermEntriesBulk = false;
+    it('reports bulk pitch accent support after negotiating parser-specific capabilities', async () => {
+        const scanningFetcher = new MockFetcher();
+        scanningFetcher.fetch.mockResolvedValue({ version: '26.7.1' });
+        const scanning = new Yomitan(testDictionaryTrack(), scanningFetcher);
+        await scanning.version();
 
-        const mecab = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
-        (mecab as any).supportsTokenizePronunciations = false;
-        (mecab as any).supportsTermEntriesBulk = true;
+        const mecabFetcher = new MockFetcher();
+        mecabFetcher.fetch
+            .mockResolvedValueOnce({ version: '26.7.1' })
+            .mockResolvedValueOnce([makeMecabSupportResult()]);
+        const mecab = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), mecabFetcher);
+        await mecab.version();
 
         expect(scanning.getSupportsBulkPitchAccent()).toBe(true);
         expect(mecab.getSupportsBulkPitchAccent()).toBe(true);
 
-        (scanning as any).supportsTokenizePronunciations = false;
-        (mecab as any).supportsTermEntriesBulk = false;
-
-        expect(scanning.getSupportsBulkPitchAccent()).toBe(false);
-        expect(mecab.getSupportsBulkPitchAccent()).toBe(false);
+        const olderFetcher = new MockFetcher();
+        olderFetcher.fetch.mockResolvedValue({ version: '26.4.5' });
+        const olderScanning = new Yomitan(testDictionaryTrack(), olderFetcher);
+        await olderScanning.version();
+        expect(olderScanning.getSupportsBulkPitchAccent()).toBe(false);
     });
 
-    it('splits, trims, and filters text before delegating splitAndTokenizeBulk', async () => {
-        const yomitan = new Yomitan(testDictionaryTrack());
-        const tokenizeBulkSpy = jest.spyOn(yomitan, 'tokenizeBulk').mockResolvedValue([]);
+    it('splits, trims, and filters text into tokenization inputs', () => {
+        expect(splitTextForTokenization(' \n。\n')).toEqual([]);
+        expect(splitTextForTokenization(' alpha ')).toEqual(['alpha']);
+        expect(splitTextForTokenization(' alpha。\n beta \n!!')).toEqual(['alpha', 'beta']);
+    });
 
-        await yomitan.splitAndTokenizeBulk(' \n。\n');
-        await yomitan.splitAndTokenizeBulk(' alpha ');
-        await yomitan.splitAndTokenizeBulk(' alpha。\n beta \n!!');
-
-        expect(tokenizeBulkSpy.mock.calls).toEqual([
-            [[], undefined, undefined],
-            [['alpha'], undefined, undefined],
-            [['alpha', 'beta'], undefined, undefined],
+    it('passes split tokenization inputs and options through the public bulk API', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue([
+            makeTokenizeResult({
+                content: [[makeTokenPart({ text: 'alpha', reading: 'alpha' })]],
+            }),
+            makeTokenizeResult({
+                id: 'result-1',
+                index: 1,
+                content: [[makeTokenPart({ text: 'beta', reading: 'beta' })]],
+            }),
         ]);
+        const progress: Progress[] = [];
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(
+            yomitan.splitAndTokenizeBulk(
+                ' alpha。\n beta \n!!',
+                async (update) => {
+                    progress.push(update);
+                },
+                'http://override:50500'
+            )
+        ).resolves.toEqual([
+            [makeTokenPart({ text: 'alpha', reading: 'alpha' })],
+            [makeTokenPart({ text: 'beta', reading: 'beta' })],
+        ]);
+        expect(fetcher.fetch).toHaveBeenCalledWith('http://override:50500/tokenize', {
+            text: ['alpha', 'beta'],
+            scanLength: 25,
+            parser: 'scanning-parser',
+        });
+        expect(progress.map(({ current, total }) => ({ current, total }))).toEqual([{ current: 2, total: 2 }]);
     });
 
     it('passes through non-mecab tokenize results unchanged in filterDictionaries', () => {
-        const yomitan = new Yomitan(testDictionaryTrack());
         const results = [makeTokenizeResult(), makeTokenizeResult({ id: 'result-1', index: 1 })];
 
-        expect((yomitan as any).filterDictionaries(results, 'scanning-parser')).toEqual(results);
+        expect(filterYomitanDictionaries(results, 'scanning-parser')).toEqual(results);
     });
 
     it('prefers the newest UniDic dictionary per index in filterDictionaries', () => {
-        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
         const older = makeTokenizeResult({ id: 'older', source: 'mecab', dictionary: 'UniDic 202401', index: 0 });
         const newer = makeTokenizeResult({ id: 'newer', source: 'mecab', dictionary: 'UniDic 202402', index: 0 });
         const other = makeTokenizeResult({ id: 'other', source: 'mecab', dictionary: 'ipadic-neologd', index: 1 });
 
-        const filtered = (yomitan as any).filterDictionaries([older, newer, other], 'mecab') as TestTokenizeResult[];
+        const filtered = filterYomitanDictionaries([older, newer, other], 'mecab') as TestTokenizeResult[];
 
         expect(filtered[0]).toEqual(newer);
         expect(filtered[1]).toEqual(other);
@@ -259,9 +316,38 @@ describe('Yomitan', () => {
         await expect(yomitan.tokenize('alpha')).rejects.toThrow('Yomitan is not configured to support MeCab');
     });
 
+    it('returns both MeCab lemma forms after support negotiation and tokenization', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch
+            .mockResolvedValueOnce({ version: '26.4.6' })
+            .mockResolvedValueOnce([makeMecabSupportResult()])
+            .mockResolvedValueOnce([
+                makeTokenizeResult({
+                    source: 'mecab',
+                    dictionary: 'UniDic 202402',
+                    content: [
+                        [
+                            makeTokenPart({
+                                text: 'alpha',
+                                lemma: 'base',
+                                lemmaReading: 'reading',
+                            }),
+                        ],
+                    ],
+                }),
+            ]);
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+
+        await yomitan.version();
+        await yomitan.tokenize('alpha');
+
+        await expect(yomitan.lemmatize('alpha')).resolves.toEqual(['base', 'reading']);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(3);
+    });
+
     it('caches tokenize results and primes lemma and frequency caches from tokenize headwords', async () => {
         const fetcher = new MockFetcher();
-        fetcher.fetch.mockResolvedValue([
+        fetcher.fetch.mockResolvedValueOnce({ version: '26.4.6' }).mockResolvedValueOnce([
             makeTokenizeResult({
                 content: [
                     [
@@ -284,15 +370,15 @@ describe('Yomitan', () => {
             }),
         ]);
         const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
-        (yomitan as any).supportsTokenizeFrequency = true;
+        await yomitan.version();
 
         const first = await yomitan.tokenize('alpha');
         const second = await yomitan.tokenize('alpha');
 
-        expect(first).toBe(second);
+        expect(second).toEqual(first);
         await expect(yomitan.lemmatize('alpha')).resolves.toEqual(['alpha']);
         await expect(yomitan.frequency('alpha')).resolves.toEqual(3);
-        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(2);
     });
 
     it('handles empty tokenize content and empty token-part groups without crashing', async () => {
@@ -378,57 +464,67 @@ describe('Yomitan', () => {
 
     it('prefetches unique term entries in tokenizeBulk for mecab bulk support', async () => {
         const fetcher = new MockFetcher();
-        fetcher.fetch.mockResolvedValue([
-            makeTokenizeResult({
-                source: 'mecab',
-                dictionary: 'UniDic 202402',
-                index: 0,
-                content: [[makeTokenPart({ text: 'alpha', reading: 'alpha' })]],
-            }),
-            makeTokenizeResult({
-                id: 'result-1',
-                source: 'mecab',
-                dictionary: 'UniDic 202402',
-                index: 1,
-                content: [
-                    [makeTokenPart({ text: 'alpha', reading: 'alpha' })],
-                    [makeTokenPart({ text: 'beta', reading: 'beta' })],
-                ],
-            }),
-        ]);
+        fetcher.fetch
+            .mockResolvedValueOnce({ version: '26.4.6' })
+            .mockResolvedValueOnce([makeMecabSupportResult()])
+            .mockResolvedValueOnce([
+                makeTokenizeResult({
+                    source: 'mecab',
+                    dictionary: 'UniDic 202402',
+                    index: 0,
+                    content: [[makeTokenPart({ text: 'alpha', reading: 'alpha' })]],
+                }),
+                makeTokenizeResult({
+                    id: 'result-1',
+                    source: 'mecab',
+                    dictionary: 'UniDic 202402',
+                    index: 1,
+                    content: [
+                        [makeTokenPart({ text: 'alpha', reading: 'alpha' })],
+                        [makeTokenPart({ text: 'beta', reading: 'beta' })],
+                    ],
+                }),
+            ])
+            .mockResolvedValueOnce([makeTermEntriesResult(0, []), makeTermEntriesResult(1, [])]);
         const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
-        const termEntriesBulkSpy = jest.spyOn(yomitan, 'termEntriesBulk').mockResolvedValue(undefined);
-        (yomitan as any).supportsMecab = true;
-        (yomitan as any).supportsTermEntriesBulk = true;
+        await yomitan.version();
 
-        await yomitan.tokenizeBulk(['alpha', 'beta']);
+        await expect(yomitan.tokenizeBulk(['alpha', 'beta'])).resolves.toEqual([
+            [makeTokenPart({ text: 'alpha', reading: 'alpha' })],
+            [makeTokenPart({ text: 'alpha', reading: 'alpha' })],
+            [makeTokenPart({ text: 'beta', reading: 'beta' })],
+        ]);
 
-        expect(termEntriesBulkSpy).toHaveBeenCalledWith(expect.arrayContaining(['alpha', 'beta']), false, undefined);
-        expect(termEntriesBulkSpy.mock.calls[0][0]).toHaveLength(2);
+        expect(fetcher.fetch).toHaveBeenLastCalledWith('http://127.0.0.1:50500/termEntries', {
+            term: ['alpha', 'beta'],
+        });
     });
 
     it('does not prefetch term entries in tokenizeBulk when supportsTermEntriesBulk is false', async () => {
         const fetcher = new MockFetcher();
-        fetcher.fetch.mockResolvedValue([
-            makeTokenizeResult({
-                source: 'mecab',
-                dictionary: 'UniDic 202402',
-                content: [[makeTokenPart({ text: 'alpha', reading: 'alpha' })]],
-            }),
-        ]);
+        fetcher.fetch
+            .mockResolvedValueOnce({ version: '26.4.5' })
+            .mockResolvedValueOnce([makeMecabSupportResult()])
+            .mockResolvedValueOnce([
+                makeTokenizeResult({
+                    source: 'mecab',
+                    dictionary: 'UniDic 202402',
+                    content: [[makeTokenPart({ text: 'alpha', reading: 'alpha' })]],
+                }),
+            ]);
         const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
-        const termEntriesBulkSpy = jest.spyOn(yomitan, 'termEntriesBulk').mockResolvedValue(undefined);
-        (yomitan as any).supportsMecab = true;
-        (yomitan as any).supportsTermEntriesBulk = false;
+        await yomitan.version();
 
-        await yomitan.tokenizeBulk(['alpha']);
+        await expect(yomitan.tokenizeBulk(['alpha'])).resolves.toEqual([
+            [makeTokenPart({ text: 'alpha', reading: 'alpha' })],
+        ]);
 
-        expect(termEntriesBulkSpy).not.toHaveBeenCalled();
+        expect(fetcher.fetch).toHaveBeenCalledTimes(3);
     });
 
     it('does not prefetch term entries in tokenizeBulk for scanning-parser even when supportsTermEntriesBulk is true', async () => {
         const fetcher = new MockFetcher();
-        fetcher.fetch.mockResolvedValue([
+        fetcher.fetch.mockResolvedValueOnce({ version: '26.4.6' }).mockResolvedValueOnce([
             makeTokenizeResult({
                 source: 'scanning-parser',
                 dictionary: 'Test Dictionary',
@@ -436,114 +532,70 @@ describe('Yomitan', () => {
             }),
         ]);
         const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
-        const termEntriesBulkSpy = jest.spyOn(yomitan, 'termEntriesBulk').mockResolvedValue(undefined);
-        (yomitan as any).supportsTermEntriesBulk = true;
+        await yomitan.version();
 
-        await yomitan.tokenizeBulk(['alpha']);
-
-        expect(termEntriesBulkSpy).not.toHaveBeenCalled();
-    });
-
-    it('extractFrequencyFromTokenize falls back from term to reading sources and ignores invalid frequencies', () => {
-        const yomitan = new Yomitan(testDictionaryTrack());
-        (yomitan as any).supportsTokenizeFrequency = true;
-
-        (yomitan as any).extractFrequencyFromTokenize('alpha', [
-            [
-                makeHeadword({
-                    sources: [makeSource({ matchSource: 'reading' })],
-                    frequencies: [
-                        makeFrequency({ frequency: 0 }),
-                        makeFrequency({ frequency: Number.POSITIVE_INFINITY }),
-                        makeFrequency({ frequency: 7 }),
-                    ],
-                }),
-            ],
+        await expect(yomitan.tokenizeBulk(['alpha'])).resolves.toEqual([
+            [makeTokenPart({ text: 'alpha', reading: 'alpha' })],
         ]);
 
-        expect((yomitan as any).frequencyCache.get('alpha')).toEqual(7);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(2);
     });
 
-    it('does not cache tokenize frequencies when supportsTokenizeFrequency is false', () => {
-        const yomitan = new Yomitan(testDictionaryTrack());
-
-        (yomitan as any).extractFrequencyFromTokenize('alpha', [
-            [
-                makeHeadword({
-                    frequencies: [makeFrequency({ frequency: 3 })],
-                }),
-            ],
+    it('uses valid tokenize frequencies from reading sources after capability negotiation', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce({ version: '26.4.6' }).mockResolvedValueOnce([
+            makeTokenizeResult({
+                content: [
+                    [
+                        makeTokenPart({
+                            headwords: [
+                                [
+                                    makeHeadword({
+                                        sources: [makeSource({ matchSource: 'reading' })],
+                                        frequencies: [
+                                            makeFrequency({ frequency: 0 }),
+                                            makeFrequency({ frequency: Number.POSITIVE_INFINITY }),
+                                            makeFrequency({ frequency: 7 }),
+                                        ],
+                                    }),
+                                ],
+                            ],
+                        }),
+                    ],
+                ],
+            }),
         ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
 
-        expect((yomitan as any).frequencyCache.has('alpha')).toBe(false);
+        await yomitan.version();
+        await yomitan.tokenize('alpha');
+
+        await expect(yomitan.frequency('alpha')).resolves.toBe(7);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(2);
     });
 
-    it('does not cache mecab lemmas when supportsMecabLemma is false', () => {
-        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
-
-        (yomitan as any).extractLemmaFromMecab('alpha', makeTokenPart({ lemma: 'base', lemmaReading: 'reading' }));
-
-        expect((yomitan as any).lemmatizeCache.has('alpha')).toBe(false);
-    });
-
-    it('caches both lemma and distinct lemmaReading from mecab token parts when supported', () => {
-        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
-        (yomitan as any).supportsMecabLemma = true;
-
-        (yomitan as any).extractLemmaFromMecab('alpha', makeTokenPart({ lemma: 'base', lemmaReading: 'reading' }));
-
-        expect((yomitan as any).lemmatizeCache.get('alpha')).toEqual(['base', 'reading']);
-    });
-
-    it('extractLemmas prefers a later kanji form over an earlier kana-only headword for kana input', () => {
-        const yomitan = new Yomitan(testDictionaryTrack());
-        const lemmas = (yomitan as any).extractLemmas('すぎます', [
-            [
-                makeHeadword({
-                    term: 'すぎる',
-                    reading: 'すぎる',
-                    sources: [
-                        makeSource({
-                            originalText: 'すぎます',
-                            transformedText: 'すぎます',
-                            deinflectedText: 'すぎる',
-                        }),
-                    ],
-                }),
-                makeHeadword({
-                    term: '過ぎる',
-                    reading: 'すぎる',
-                    sources: [
-                        makeSource({
-                            originalText: 'すぎます',
-                            transformedText: 'すぎます',
-                            deinflectedText: 'すぎる',
-                        }),
-                    ],
-                }),
-            ],
-        ]) as string[];
-
-        expect(lemmas).toEqual(['過ぎる', 'すぎる']);
-    });
-
-    it('extractLemmas falls back to the token when lemmaTokenFallback is enabled', () => {
-        const yomitan = new Yomitan(testDictionaryTrack(), new MockFetcher(), {
+    it('lemmatize falls back to the token when configured and no dictionary entries match', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ dictionaryEntries: [] });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher, {
             lemmaTokenFallback: true,
-            tokensWereModified: jest.fn(),
+            tokensWereModified: () => undefined,
         });
 
-        expect((yomitan as any).extractLemmas('alpha', [])).toEqual(['alpha']);
+        await expect(yomitan.lemmatize('alpha')).resolves.toEqual(['alpha']);
     });
 
-    it('extractLemmas caches an empty result when fallback is disabled and no entries match', () => {
-        const yomitan = new Yomitan(testDictionaryTrack(), new MockFetcher(), {
+    it('lemmatize caches an empty result when fallback is disabled and no dictionary entries match', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ dictionaryEntries: [] });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher, {
             lemmaTokenFallback: false,
-            tokensWereModified: jest.fn(),
+            tokensWereModified: () => undefined,
         });
 
-        expect((yomitan as any).extractLemmas('alpha', [])).toEqual([]);
-        expect((yomitan as any).lemmatizeCache.get('alpha')).toEqual([]);
+        await expect(yomitan.lemmatize('alpha')).resolves.toEqual([]);
+        await expect(yomitan.lemmatize('alpha')).resolves.toEqual([]);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('returns empty lemmas and null frequency for non-letter tokens in lemmatize and frequency', async () => {
@@ -579,19 +631,56 @@ describe('Yomitan', () => {
         expect(fetcher.fetch).toHaveBeenCalledTimes(1);
     });
 
-    it('returns undefined in lemmatize when resetCache cancels a pending request', async () => {
-        const fetcher = new MockFetcher();
-        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
-        const acquireDeferred = deferred<number>();
-        jest.spyOn((yomitan as any).asyncSemaphore, 'acquire').mockReturnValue(acquireDeferred.promise);
+    it('promotes only a matching later kanji headword for kana-only input', async () => {
+        const lemmatize = (token: string, headwords: TermHeadword[]) => {
+            const fetcher = new MockFetcher();
+            fetcher.fetch.mockResolvedValue({ dictionaryEntries: [makeEntry({ headwords })] });
+            return new Yomitan(testDictionaryTrack(), fetcher).lemmatize(token);
+        };
+        const source = (originalText: string, deinflectedText: string) =>
+            makeSource({ originalText, transformedText: originalText, deinflectedText });
 
+        await expect(
+            lemmatize('すぎます', [
+                makeHeadword({ term: 'すぎる', reading: 'すぎる', sources: [source('すぎます', 'すぎる')] }),
+                makeHeadword({ term: '過ぎる', reading: 'すぎる', sources: [source('すぎます', 'すぎる')] }),
+            ])
+        ).resolves.toEqual(['過ぎる', 'すぎる']);
+        await expect(
+            lemmatize('すぎます', [
+                makeHeadword({ term: 'すぎる', reading: 'すぎる', sources: [source('すぎます', 'すぎる')] }),
+                makeHeadword({ term: '誤る', reading: 'あやまる', sources: [source('すぎます', 'すぎる')] }),
+            ])
+        ).resolves.toEqual(['すぎる']);
+        await expect(
+            lemmatize('過ぎます', [
+                makeHeadword({ term: '過ぎる', reading: 'すぎる', sources: [source('過ぎます', '過ぎる')] }),
+                makeHeadword({ term: '越える', reading: 'すぎる', sources: [source('過ぎます', 'すぎる')] }),
+            ])
+        ).resolves.toEqual(['過ぎる', 'すぎる']);
+    });
+
+    it('returns undefined in lemmatize when resetCache cancels a pending request', async () => {
+        jest.useFakeTimers().setSystemTime(1000);
+        const fetcher = new MockFetcher();
+        const blockerResponse = deferred<{ dictionaryEntries: TermDictionaryEntry[] }>();
+        fetcher.fetch.mockImplementation(async (_url, body) => {
+            if ((body as { term: string }).term === 'blocker') return blockerResponse.promise;
+            throw new Error('Cancelled lemmatize should not fetch');
+        });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        const blocker = yomitan.lemmatize('blocker');
+        await flushMicrotasks();
         const lemmatizePromise = yomitan.lemmatize('alpha');
+        jest.setSystemTime(1001);
         yomitan.resetCache();
-        (yomitan as any).lastCancelledAt = Number.MAX_SAFE_INTEGER;
-        acquireDeferred.resolve(1);
+        blockerResponse.resolve({ dictionaryEntries: [] });
+        await blocker;
+        await jest.advanceTimersByTimeAsync(10);
 
         await expect(lemmatizePromise).resolves.toBeUndefined();
-        expect(fetcher.fetch).not.toHaveBeenCalled();
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('returns the minimum rank frequency and primes lemmas in frequency', async () => {
@@ -619,7 +708,7 @@ describe('Yomitan', () => {
 
     it('caches pitch accents from tokenize headword pronunciations when supported', async () => {
         const fetcher = new MockFetcher();
-        fetcher.fetch.mockResolvedValue([
+        fetcher.fetch.mockResolvedValueOnce({ version: '26.7.1' }).mockResolvedValueOnce([
             makeTokenizeResult({
                 content: [
                     [
@@ -646,12 +735,12 @@ describe('Yomitan', () => {
             }),
         ]);
         const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
-        (yomitan as any).supportsTokenizePronunciations = true;
+        await yomitan.version();
 
         await yomitan.tokenize('alpha');
 
         await expect(yomitan.pitchAccent('alpha')).resolves.toBe(2);
-        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(2);
     });
 
     it('extracts pitch accents from term entries and prefers string positions on ties', async () => {
@@ -694,140 +783,190 @@ describe('Yomitan', () => {
                 }),
             ],
         });
-        const modified = jest.fn();
+        const modified: string[] = [];
         const yomitan = new Yomitan(testDictionaryTrack(), fetcher, {
             lemmaTokenFallback: false,
-            tokensWereModified: modified,
+            tokensWereModified: (token) => modified.push(token),
         });
 
         await expect(yomitan.frequency('beta')).resolves.toBeUndefined();
         await flushMicrotasks(20);
 
-        expect(modified).toHaveBeenCalledWith('beta');
-        expect((yomitan as any).frequencyCache.get('beta')).toEqual(6);
-        expect((yomitan as any).lemmatizeCache.get('beta')).toEqual(['beta']);
+        expect(modified).toEqual(['beta']);
+        await expect(yomitan.frequency('beta')).resolves.toBe(6);
+        await expect(yomitan.lemmatize('beta')).resolves.toEqual(['beta']);
     });
 
     it('notifies without fetching when resetCache cancels async frequency updates', async () => {
+        jest.useFakeTimers().setSystemTime(1000);
         const fetcher = new MockFetcher();
-        const modified = jest.fn();
+        const blockerResponse = deferred<{ dictionaryEntries: TermDictionaryEntry[] }>();
+        fetcher.fetch.mockImplementation(async (_url, body) => {
+            if ((body as { term: string }).term === 'blocker') return blockerResponse.promise;
+            throw new Error('Cancelled frequency should not fetch');
+        });
+        const modified: string[] = [];
         const yomitan = new Yomitan(testDictionaryTrack(), fetcher, {
             lemmaTokenFallback: false,
-            tokensWereModified: modified,
+            tokensWereModified: (token) => modified.push(token),
         });
-        const acquireDeferred = deferred<number>();
-        jest.spyOn((yomitan as any).asyncSemaphore, 'acquire').mockReturnValue(acquireDeferred.promise);
 
+        const blocker = yomitan.lemmatize('blocker');
+        await flushMicrotasks();
         await expect(yomitan.frequency('gamma')).resolves.toBeUndefined();
+        jest.setSystemTime(1001);
         yomitan.resetCache();
-        (yomitan as any).lastCancelledAt = Number.MAX_SAFE_INTEGER;
-        acquireDeferred.resolve(1);
+        blockerResponse.resolve({ dictionaryEntries: [] });
+        await blocker;
+        await jest.advanceTimersByTimeAsync(10);
         await flushMicrotasks();
 
-        expect(fetcher.fetch).not.toHaveBeenCalled();
-        expect(modified).toHaveBeenCalledWith('gamma');
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+        expect(modified).toContain('gamma');
     });
 
     it('does not fetch or notify when async frequency work finds a populated cache after waiting', async () => {
+        jest.useFakeTimers().setSystemTime(1000);
         const fetcher = new MockFetcher();
-        const modified = jest.fn();
+        const blockerResponse = deferred<{ dictionaryEntries: TermDictionaryEntry[] }>();
+        fetcher.fetch.mockImplementation(async (url, body) => {
+            if (url.endsWith('/yomitanVersion')) return { version: '26.4.6' };
+            if (url.endsWith('/termEntries') && (body as { term: string }).term === 'blocker') {
+                return blockerResponse.promise;
+            }
+            if (url.endsWith('/tokenize')) {
+                return [
+                    makeTokenizeResult({
+                        content: [
+                            [
+                                makeTokenPart({
+                                    text: 'delta',
+                                    headwords: [
+                                        [
+                                            makeHeadword({
+                                                term: 'delta',
+                                                reading: 'delta',
+                                                sources: [
+                                                    makeSource({ originalText: 'delta', deinflectedText: 'delta' }),
+                                                ],
+                                                frequencies: [makeFrequency({ frequency: 12 })],
+                                            }),
+                                        ],
+                                    ],
+                                }),
+                            ],
+                        ],
+                    }),
+                ];
+            }
+            throw new Error('Cached frequency should not fetch term entries');
+        });
+        const modified: string[] = [];
         const yomitan = new Yomitan(testDictionaryTrack(), fetcher, {
             lemmaTokenFallback: false,
-            tokensWereModified: modified,
+            tokensWereModified: (token) => modified.push(token),
         });
-        const acquireDeferred = deferred<number>();
-        jest.spyOn((yomitan as any).asyncSemaphore, 'acquire').mockReturnValue(acquireDeferred.promise);
 
+        await yomitan.version();
+        const blocker = yomitan.lemmatize('blocker');
+        await flushMicrotasks();
         await expect(yomitan.frequency('delta')).resolves.toBeUndefined();
-        (yomitan as any).frequencyCache.set('delta', 12);
-        acquireDeferred.resolve(1);
+        await yomitan.tokenize('delta');
+        blockerResponse.resolve({ dictionaryEntries: [] });
+        await blocker;
+        await jest.advanceTimersByTimeAsync(10);
         await flushMicrotasks();
 
-        expect(fetcher.fetch).not.toHaveBeenCalled();
-        expect(modified).not.toHaveBeenCalled();
+        await expect(yomitan.frequency('delta')).resolves.toBe(12);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(3);
+        expect(modified).toEqual([]);
     });
 
-    it('extractFrequency falls back from term sources and ignores non-rank frequencies when tokenize frequencies are supported', () => {
-        const yomitan = new Yomitan(testDictionaryTrack());
-        (yomitan as any).supportsTokenizeFrequency = true;
-        const frequency = (yomitan as any).extractFrequency('alpha', [
-            makeEntry({
-                headwords: [
-                    makeHeadword({
-                        sources: [makeSource({ matchSource: 'reading' })],
-                    }),
-                ],
-                frequencies: [
-                    makeFrequency({ frequencyMode: 'occurrence-based', frequency: 1 }),
-                    makeFrequency({ index: 1, frequency: 8 }),
-                ],
-            }),
-        ]) as number | null;
+    it('frequency falls back to reading sources and ignores occurrence-based values', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({
+            dictionaryEntries: [
+                makeEntry({
+                    headwords: [makeHeadword({ sources: [makeSource({ matchSource: 'reading' })] })],
+                    frequencies: [
+                        makeFrequency({ frequencyMode: 'occurrence-based', frequency: 1 }),
+                        makeFrequency({ index: 1, frequency: 8 }),
+                    ],
+                }),
+            ],
+        });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
 
-        expect(frequency).toEqual(8);
+        await expect(yomitan.frequency('alpha')).resolves.toBe(8);
     });
 
-    it('ignores non-rank frequencies in extractFrequency when tokenize frequencies are not supported', () => {
-        const yomitan = new Yomitan(testDictionaryTrack());
-        const frequency = (yomitan as any).extractFrequency('alpha', [
-            makeEntry({
-                frequencies: [
-                    makeFrequency({ frequencyMode: 'occurrence-based', frequency: 2 }),
-                    makeFrequency({ index: 1, frequency: 8 }),
-                ],
-            }),
-        ]) as number | null;
+    it('frequency ignores non-rank frequencies before capability negotiation', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({
+            dictionaryEntries: [
+                makeEntry({
+                    frequencies: [
+                        makeFrequency({ frequencyMode: 'occurrence-based', frequency: 2 }),
+                        makeFrequency({ index: 1, frequency: 8 }),
+                    ],
+                }),
+            ],
+        });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
 
-        expect(frequency).toEqual(8);
+        await expect(yomitan.frequency('alpha')).resolves.toBe(8);
     });
 
-    it('infers rank-based frequency dictionaries from token occurrence ordering', () => {
+    it('infers rank-based frequency dictionaries from token occurrence ordering', async () => {
         jest.spyOn(console, 'log').mockImplementation(() => undefined);
-        const modified = jest.fn();
-        const yomitan = new Yomitan(testDictionaryTrack(), new MockFetcher(), {
+        const modified: string[] = [];
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockImplementation(async (_url, body) => {
+            const terms = (body as { term: string[] }).term;
+            return terms.map((token, index) => {
+                const tokenIndex = Number(token.substring('word'.length));
+                const frequency = tokenIndex < 10 ? tokenIndex + 1 : 1000 + tokenIndex;
+                return makeTermEntriesResult(index, [
+                    makeEntry({
+                        headwords: [
+                            makeHeadword({
+                                term: token,
+                                reading: token,
+                                sources: [makeSource({ originalText: token, deinflectedText: token })],
+                            }),
+                        ],
+                        frequencies: [
+                            makeFrequency({
+                                dictionary: 'inferred-rank',
+                                dictionaryAlias: 'inferred-rank',
+                                frequencyMode: null,
+                                frequency,
+                            }),
+                        ],
+                    }),
+                ]);
+            });
+        });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher, {
             lemmaTokenFallback: false,
-            tokensWereModified: modified,
+            tokensWereModified: (token) => modified.push(token),
         });
         const tokenOccurrences = new Map<string, number>();
         const tokens = Array.from({ length: 20 }, (_, index) => `word${index}`);
 
         for (const [index, token] of tokens.entries()) {
-            const isCommon = index < 10;
-            const frequency = isCommon ? index + 1 : 1000 + index;
-            tokenOccurrences.set(token, isCommon ? 100 - index : 20 - index);
-
-            const extractedFrequency = (yomitan as any).extractFrequency(token, [
-                makeEntry({
-                    headwords: [
-                        makeHeadword({
-                            term: token,
-                            reading: token,
-                            sources: [makeSource({ originalText: token, deinflectedText: token })],
-                        }),
-                    ],
-                    frequencies: [
-                        makeFrequency({
-                            dictionary: 'inferred-rank',
-                            dictionaryAlias: 'inferred-rank',
-                            frequencyMode: null,
-                            frequency,
-                        }),
-                    ],
-                }),
-            ]);
-
-            expect(extractedFrequency).toBeNull();
-            expect((yomitan as any).frequencyCache.get(token)).toBeNull();
+            tokenOccurrences.set(token, index < 10 ? 100 - index : 20 - index);
         }
+
+        await yomitan.termEntriesBulk(tokens, false);
+        await expect(yomitan.frequency('word0')).resolves.toBeNull();
 
         yomitan.inferFrequencyModesFromTokenOccurrences(new Map([[0, tokenOccurrences]]));
 
-        expect((yomitan as any).inferredFrequencyModes.get('inferred-rank')).toBe('rank-based');
-        expect((yomitan as any).frequencyCache.get('word0')).toBe(1);
-        expect((yomitan as any).frequencyCache.get('word19')).toBe(1019);
-        expect(modified).toHaveBeenCalledTimes(20);
-        expect(modified).toHaveBeenCalledWith('word0');
-        expect(modified).toHaveBeenCalledWith('word19');
+        await expect(yomitan.frequency('word0')).resolves.toBe(1);
+        await expect(yomitan.frequency('word19')).resolves.toBe(1019);
+        expect(modified).toHaveLength(20);
+        expect(modified).toEqual(expect.arrayContaining(['word0', 'word19']));
     });
 
     it('returns early without fetching in termEntriesBulk for 0 items', async () => {
@@ -1018,10 +1157,16 @@ describe('Yomitan', () => {
 
         await yomitan.termEntriesBulk(terms, false);
 
-        expect((yomitan as any).termEntriesBatchSize).toBe(5);
         expect(fetcher.fetch.mock.calls.map((call) => (call[1] as { term: string[] }).term.length)).toEqual([
             10, 5, 3, 2, 2, 2, 2, 2, 1,
         ]);
+
+        fetcher.fetch.mockClear();
+        await yomitan.termEntriesBulk(
+            Array.from({ length: 12 }, (_, index) => `fresh${index}`),
+            false
+        );
+        expect(fetcher.fetch.mock.calls.map((call) => (call[1] as { term: string[] }).term.length)).toEqual([5, 5, 2]);
     });
 
     it('uses the per-call Yomitan URL override for API-backed public methods', async () => {
@@ -1089,18 +1234,26 @@ describe('Yomitan', () => {
     });
 
     it('stops termEntriesBulk before fetching when resetCache cancels a pending acquire', async () => {
+        jest.useFakeTimers().setSystemTime(1000);
         const fetcher = new MockFetcher();
+        const blockerResponse = deferred<{ dictionaryEntries: TermDictionaryEntry[] }>();
+        fetcher.fetch.mockImplementation(async (_url, body) => {
+            if ((body as { term: string }).term === 'blocker') return blockerResponse.promise;
+            throw new Error('Cancelled bulk request should not fetch');
+        });
         const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
-        const acquireDeferred = deferred<number>();
-        jest.spyOn((yomitan as any).asyncSemaphore, 'acquire').mockReturnValue(acquireDeferred.promise);
 
+        const blocker = yomitan.lemmatize('blocker');
+        await flushMicrotasks();
         const promise = yomitan.termEntriesBulk(['alpha'], false);
+        jest.setSystemTime(1001);
         yomitan.resetCache();
-        (yomitan as any).lastCancelledAt = Number.MAX_SAFE_INTEGER;
-        acquireDeferred.resolve(1);
+        blockerResponse.resolve({ dictionaryEntries: [] });
+        await blocker;
+        await jest.advanceTimersByTimeAsync(10);
         await promise;
 
-        expect(fetcher.fetch).not.toHaveBeenCalled();
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('accepts dev version 0.0.0.0 and enables bulk features for non-mecab parsers', async () => {
@@ -1117,13 +1270,13 @@ describe('Yomitan', () => {
 
     it('verifies mecab support for dev version 0.0.0.0 when the parser is mecab', async () => {
         const fetcher = new MockFetcher();
-        fetcher.fetch.mockResolvedValue({ version: '0.0.0.0' });
+        fetcher.fetch.mockResolvedValueOnce({ version: '0.0.0.0' }).mockResolvedValueOnce([makeMecabSupportResult()]);
         const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
-        const verifySpy = jest.spyOn(yomitan as any, 'verifyMecabSupport').mockResolvedValue(undefined);
 
         await expect(yomitan.version()).resolves.toEqual('0.0.0.0');
 
-        expect(verifySpy).toHaveBeenCalled();
+        expect(yomitan.getSupportsMecab()).toBe(true);
+        expect(yomitan.getSupportsMecabLemma()).toBe(true);
         expect(yomitan.getSupportsBulkFrequency()).toBe(true);
     });
 
@@ -1145,13 +1298,13 @@ describe('Yomitan', () => {
 
     it('verifies mecab support at the configured threshold and toggles bulk support by version', async () => {
         const fetcher = new MockFetcher();
-        fetcher.fetch.mockResolvedValue({ version: '26.4.6' });
+        fetcher.fetch.mockResolvedValueOnce({ version: '26.4.6' }).mockResolvedValueOnce([makeMecabSupportResult()]);
         const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
-        const verifySpy = jest.spyOn(yomitan as any, 'verifyMecabSupport').mockResolvedValue(undefined);
 
         await expect(yomitan.version()).resolves.toEqual('26.4.6');
 
-        expect(verifySpy).toHaveBeenCalled();
+        expect(yomitan.getSupportsMecab()).toBe(true);
+        expect(yomitan.getSupportsMecabLemma()).toBe(true);
         expect(yomitan.getSupportsBulkFrequency()).toBe(true);
     });
 
@@ -1159,13 +1312,10 @@ describe('Yomitan', () => {
         const fetcher = new MockFetcher();
         fetcher.fetch.mockResolvedValue({ version: '26.4.5' });
         const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
-        const verifySpy = jest.spyOn(yomitan as any, 'verifyMecabSupport').mockResolvedValue(undefined);
-        (yomitan as any).supportsMecab = true;
-        (yomitan as any).supportsMecabLemma = true;
 
         await expect(yomitan.version()).resolves.toEqual('26.4.5');
 
-        expect(verifySpy).not.toHaveBeenCalled();
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
         expect(yomitan.getSupportsMecab()).toBe(false);
         expect(yomitan.getSupportsMecabLemma()).toBe(false);
         expect(yomitan.getSupportsBulkFrequency()).toBe(false);
@@ -1175,13 +1325,10 @@ describe('Yomitan', () => {
         const fetcher = new MockFetcher();
         fetcher.fetch.mockResolvedValue({ version: '26.3.8' });
         const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
-        const verifySpy = jest.spyOn(yomitan as any, 'verifyMecabSupport').mockResolvedValue(undefined);
-        (yomitan as any).supportsMecab = true;
-        (yomitan as any).supportsMecabLemma = true;
 
         await expect(yomitan.version()).resolves.toEqual('26.3.8');
 
-        expect(verifySpy).not.toHaveBeenCalled();
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
         expect(yomitan.getSupportsMecab()).toBe(false);
         expect(yomitan.getSupportsMecabLemma()).toBe(false);
         expect(yomitan.getSupportsBulkFrequency()).toBe(false);
@@ -1189,27 +1336,10 @@ describe('Yomitan', () => {
 
     it('sets full mecab and lemma support when verifyMecabSupport receives the expected tokenization', async () => {
         const fetcher = new MockFetcher();
-        fetcher.fetch.mockResolvedValue([
-            makeTokenizeResult({
-                source: 'mecab',
-                dictionary: 'UniDic 202402',
-                content: [
-                    [
-                        makeTokenPart({
-                            text: '思い',
-                            reading: 'おもい',
-                            lemma: '思い出す',
-                            lemmaReading: 'おもいだす',
-                        }),
-                        makeTokenPart({ text: '出せ', reading: 'だせ' }),
-                        makeTokenPart({ text: 'なく', reading: 'なく' }),
-                    ],
-                ],
-            }),
-        ]);
+        fetcher.fetch.mockResolvedValueOnce({ version: '26.4.6' }).mockResolvedValueOnce([makeMecabSupportResult()]);
         const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
 
-        await (yomitan as any).verifyMecabSupport();
+        await yomitan.version();
 
         expect(yomitan.getSupportsMecab()).toBe(true);
         expect(yomitan.getSupportsMecabLemma()).toBe(true);
@@ -1218,7 +1348,7 @@ describe('Yomitan', () => {
     it('keeps mecab support but disables lemma support when verifyMecabSupport sees unexpected lemmas', async () => {
         const fetcher = new MockFetcher();
         jest.spyOn(console, 'error').mockImplementation(() => {});
-        fetcher.fetch.mockResolvedValue([
+        fetcher.fetch.mockResolvedValueOnce({ version: '26.4.6' }).mockResolvedValueOnce([
             makeTokenizeResult({
                 source: 'mecab',
                 dictionary: 'UniDic 202402',
@@ -1233,7 +1363,7 @@ describe('Yomitan', () => {
         ]);
         const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
 
-        await (yomitan as any).verifyMecabSupport();
+        await yomitan.version();
 
         expect(yomitan.getSupportsMecab()).toBe(true);
         expect(yomitan.getSupportsMecabLemma()).toBe(false);
@@ -1242,7 +1372,7 @@ describe('Yomitan', () => {
     it('disables mecab support when verifyMecabSupport receives an unexpected tokenization shape', async () => {
         const fetcher = new MockFetcher();
         jest.spyOn(console, 'error').mockImplementation(() => {});
-        fetcher.fetch.mockResolvedValue([
+        fetcher.fetch.mockResolvedValueOnce({ version: '26.4.6' }).mockResolvedValueOnce([
             makeTokenizeResult({
                 source: 'mecab',
                 dictionary: 'UniDic 202402',
@@ -1251,41 +1381,48 @@ describe('Yomitan', () => {
         ]);
         const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
 
-        await (yomitan as any).verifyMecabSupport();
+        await yomitan.version();
 
         expect(yomitan.getSupportsMecab()).toBe(false);
         expect(yomitan.getSupportsMecabLemma()).toBe(false);
     });
 
     it('disables mecab support when verifyMecabSupport receives an unexpected source or fetch failure', async () => {
-        const fetcher = new MockFetcher();
+        const unexpectedSourceFetcher = new MockFetcher();
         jest.spyOn(console, 'error').mockImplementation(() => {});
-        fetcher.fetch.mockResolvedValueOnce([
+        unexpectedSourceFetcher.fetch.mockResolvedValueOnce({ version: '26.4.6' }).mockResolvedValueOnce([
             makeTokenizeResult({
                 source: 'scanning-parser',
                 content: [[makeTokenPart({ text: '思い出せなく', reading: 'おもいだせなく' })]],
             }),
         ]);
-        fetcher.fetch.mockRejectedValueOnce(new Error('boom'));
-        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+        const unexpectedSource = new Yomitan(
+            testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }),
+            unexpectedSourceFetcher
+        );
 
-        await (yomitan as any).verifyMecabSupport();
-        expect(yomitan.getSupportsMecab()).toBe(false);
-        expect(yomitan.getSupportsMecabLemma()).toBe(false);
+        await unexpectedSource.version();
+        expect(unexpectedSource.getSupportsMecab()).toBe(false);
+        expect(unexpectedSource.getSupportsMecabLemma()).toBe(false);
 
-        await (yomitan as any).verifyMecabSupport();
-        expect(yomitan.getSupportsMecab()).toBe(false);
-        expect(yomitan.getSupportsMecabLemma()).toBe(false);
+        const failureFetcher = new MockFetcher();
+        failureFetcher.fetch.mockResolvedValueOnce({ version: '26.4.6' }).mockRejectedValueOnce(new Error('boom'));
+        const failure = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), failureFetcher);
+        await failure.version();
+        expect(failure.getSupportsMecab()).toBe(false);
+        expect(failure.getSupportsMecabLemma()).toBe(false);
     });
 
-    it('throws from _executeAction when the Yomitan API returns an empty payload', async () => {
+    it('throws from tokenize when the Yomitan API returns an empty payload', async () => {
         const fetcher = new MockFetcher();
         fetcher.fetch.mockResolvedValue('{}');
         const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
 
-        await expect((yomitan as any)._executeAction('tokenize', { text: 'alpha' })).rejects.toThrow(
-            'Yomitan API error for tokenize: {}'
-        );
-        expect(fetcher.fetch).toHaveBeenCalledWith('http://127.0.0.1:50500/tokenize', { text: 'alpha' });
+        await expect(yomitan.tokenize('alpha')).rejects.toThrow('Yomitan API error for tokenize: {}');
+        expect(fetcher.fetch).toHaveBeenCalledWith('http://127.0.0.1:50500/tokenize', {
+            text: 'alpha',
+            scanLength: 25,
+            parser: 'scanning-parser',
+        });
     });
 });

--- a/common/yomitan/yomitan.test.ts
+++ b/common/yomitan/yomitan.test.ts
@@ -1,0 +1,1291 @@
+import { Fetcher } from '@project/common';
+import {
+    DictionaryTrack,
+    defaultSettings,
+    TokenFrequencyAnnotation,
+    TokenMatchStrategy,
+    TokenMatchStrategyPriority,
+    TokenReadingAnnotation,
+    TokenStyling,
+} from '@project/common/settings';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import {
+    TermDictionaryEntry,
+    TermEntriesResult,
+    TermHeadword,
+    TermSource,
+    TokenPartResult,
+    Yomitan,
+} from '@project/common/yomitan';
+
+const testDictionaryTrack = (overrides: Partial<DictionaryTrack> = {}): DictionaryTrack => ({
+    ...defaultSettings.dictionaryTracks[0],
+    dictionaryColorizeSubtitles: false,
+    dictionaryAutoGenerateStatistics: false,
+    dictionaryColorizeOnHoverOnly: false,
+    dictionaryHighlightOnHover: false,
+    dictionaryTokenMatchStrategy: TokenMatchStrategy.ANY_FORM_COLLECTED,
+    dictionaryMatchAcrossScripts: true,
+    dictionaryTokenMatchStrategyPriority: TokenMatchStrategyPriority.EXACT,
+    dictionaryYomitanUrl: 'http://127.0.0.1:50500',
+    dictionaryYomitanParser: 'scanning-parser',
+    dictionaryYomitanScanLength: 25,
+    dictionaryTokenReadingAnnotation: TokenReadingAnnotation.NEVER,
+    dictionaryDisplayIgnoredTokenReadings: false,
+    dictionaryTokenFrequencyAnnotation: TokenFrequencyAnnotation.NEVER,
+    dictionaryAnkiDecks: [],
+    dictionaryAnkiWordFields: [],
+    dictionaryAnkiSentenceFields: [],
+    dictionaryAnkiSentenceTokenMatchStrategy: TokenMatchStrategy.ANY_FORM_COLLECTED,
+    dictionaryAnkiMatureCutoff: 21,
+    dictionaryAnkiTreatSuspended: 'NORMAL',
+    dictionaryTokenStyling: TokenStyling.TEXT,
+    dictionaryTokenStylingThickness: 1,
+    dictionaryColorizeFullyKnownTokens: false,
+    dictionaryTokenStatusColors: [],
+    dictionaryTokenStatusConfig: [],
+    ...overrides,
+});
+
+type TestTermFrequency = NonNullable<TermHeadword['frequencies']>[number];
+type TestTokenizeResult = {
+    id: string;
+    source: string;
+    dictionary: string;
+    index: number;
+    content: TokenPartResult[][];
+};
+
+class MockFetcher implements Fetcher {
+    readonly fetch = jest.fn<Fetcher['fetch']>();
+}
+
+const makeSource = (overrides: Partial<TermSource> = {}): TermSource => ({
+    originalText: 'alpha',
+    transformedText: 'alpha',
+    deinflectedText: 'alpha',
+    matchType: 'exact',
+    matchSource: 'term',
+    isPrimary: true,
+    ...overrides,
+});
+
+const makeFrequency = (overrides: Partial<TestTermFrequency> = {}): TestTermFrequency => ({
+    index: 0,
+    headwordIndex: 0,
+    dictionary: 'freq',
+    dictionaryIndex: 0,
+    dictionaryAlias: 'freq',
+    hasReading: true,
+    frequencyMode: 'rank-based',
+    frequency: 10,
+    displayValue: '10',
+    displayValueParsed: true,
+    ...overrides,
+});
+
+const makeHeadword = (overrides: Partial<TermHeadword> = {}): TermHeadword => ({
+    index: 0,
+    headwordIndex: 0,
+    term: 'alpha',
+    reading: 'alpha',
+    sources: [makeSource()],
+    frequencies: [makeFrequency()],
+    ...overrides,
+});
+
+const makeEntry = (overrides: Partial<TermDictionaryEntry> = {}): TermDictionaryEntry => ({
+    headwords: [makeHeadword()],
+    frequencies: [makeFrequency()],
+    pronunciations: [],
+    ...overrides,
+});
+
+const makePitchPronunciation = (positions: number | string, headwordIndex = 0) => ({
+    index: 0,
+    headwordIndex,
+    dictionary: 'pitch',
+    dictionaryIndex: 0,
+    dictionaryAlias: 'pitch',
+    pronunciations: [
+        {
+            type: 'pitch-accent',
+            positions,
+            nasalPositions: [],
+            devoicePositions: [],
+            tags: [],
+        },
+    ],
+});
+
+const makeTokenPart = (overrides: Partial<TokenPartResult> = {}): TokenPartResult => ({
+    text: 'alpha',
+    reading: 'alpha',
+    ...overrides,
+});
+
+const makeTokenizeResult = (overrides: Partial<TestTokenizeResult> = {}): TestTokenizeResult => ({
+    id: 'result-0',
+    source: 'scanning-parser',
+    dictionary: 'Test Dictionary',
+    index: 0,
+    content: [[makeTokenPart()]],
+    ...overrides,
+});
+
+const makeTermEntriesResult = (index: number, dictionaryEntries: TermDictionaryEntry[]): TermEntriesResult => ({
+    dictionaryEntries,
+    originalTextLength: 1,
+    index,
+});
+
+const deferred = <T>() => {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+};
+
+const flushMicrotasks = async (turns = 6) => {
+    for (let i = 0; i < turns; ++i) {
+        await Promise.resolve();
+    }
+};
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+describe('Yomitan', () => {
+    it('rejects tokenizations whose reconstructed text differs from the source', () => {
+        const yomitan = new Yomitan(testDictionaryTrack());
+
+        expect(() => yomitan.verifyTokenizeResult('alpha', [[{ text: 'beta', reading: '' }]])).toThrow(
+            'Tokenize result does not match the original text'
+        );
+    });
+
+    it('rejects malformed term-entry responses instead of caching them', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ dictionaryEntries: null });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.lemmatize('alpha')).rejects.toThrow('Unexpected Yomitan termEntries response');
+    });
+
+    it('reports bulk frequency support based on parser-specific feature flags', () => {
+        const scanning = new Yomitan(testDictionaryTrack());
+        (scanning as any).supportsTokenizeFrequency = true;
+        (scanning as any).supportsTermEntriesBulk = false;
+
+        const mecab = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
+        (mecab as any).supportsTokenizeFrequency = false;
+        (mecab as any).supportsTermEntriesBulk = true;
+
+        expect(scanning.getSupportsBulkFrequency()).toBe(true);
+        expect(mecab.getSupportsBulkFrequency()).toBe(true);
+    });
+
+    it('reports bulk frequency support as false when the parser-specific feature flag is disabled', () => {
+        const scanning = new Yomitan(testDictionaryTrack());
+        (scanning as any).supportsTokenizeFrequency = false;
+        (scanning as any).supportsTermEntriesBulk = true;
+
+        const mecab = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
+        (mecab as any).supportsTokenizeFrequency = true;
+        (mecab as any).supportsTermEntriesBulk = false;
+
+        expect(scanning.getSupportsBulkFrequency()).toBe(false);
+        expect(mecab.getSupportsBulkFrequency()).toBe(false);
+    });
+
+    it('reports bulk pitch accent support based on parser-specific feature flags', () => {
+        const scanning = new Yomitan(testDictionaryTrack());
+        (scanning as any).supportsTokenizePronunciations = true;
+        (scanning as any).supportsTermEntriesBulk = false;
+
+        const mecab = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
+        (mecab as any).supportsTokenizePronunciations = false;
+        (mecab as any).supportsTermEntriesBulk = true;
+
+        expect(scanning.getSupportsBulkPitchAccent()).toBe(true);
+        expect(mecab.getSupportsBulkPitchAccent()).toBe(true);
+
+        (scanning as any).supportsTokenizePronunciations = false;
+        (mecab as any).supportsTermEntriesBulk = false;
+
+        expect(scanning.getSupportsBulkPitchAccent()).toBe(false);
+        expect(mecab.getSupportsBulkPitchAccent()).toBe(false);
+    });
+
+    it('splits, trims, and filters text before delegating splitAndTokenizeBulk', async () => {
+        const yomitan = new Yomitan(testDictionaryTrack());
+        const tokenizeBulkSpy = jest.spyOn(yomitan, 'tokenizeBulk').mockResolvedValue([]);
+
+        await yomitan.splitAndTokenizeBulk(' \n。\n');
+        await yomitan.splitAndTokenizeBulk(' alpha ');
+        await yomitan.splitAndTokenizeBulk(' alpha。\n beta \n!!');
+
+        expect(tokenizeBulkSpy.mock.calls).toEqual([
+            [[], undefined, undefined],
+            [['alpha'], undefined, undefined],
+            [['alpha', 'beta'], undefined, undefined],
+        ]);
+    });
+
+    it('passes through non-mecab tokenize results unchanged in filterDictionaries', () => {
+        const yomitan = new Yomitan(testDictionaryTrack());
+        const results = [makeTokenizeResult(), makeTokenizeResult({ id: 'result-1', index: 1 })];
+
+        expect((yomitan as any).filterDictionaries(results, 'scanning-parser')).toEqual(results);
+    });
+
+    it('prefers the newest UniDic dictionary per index in filterDictionaries', () => {
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
+        const older = makeTokenizeResult({ id: 'older', source: 'mecab', dictionary: 'UniDic 202401', index: 0 });
+        const newer = makeTokenizeResult({ id: 'newer', source: 'mecab', dictionary: 'UniDic 202402', index: 0 });
+        const other = makeTokenizeResult({ id: 'other', source: 'mecab', dictionary: 'ipadic-neologd', index: 1 });
+
+        const filtered = (yomitan as any).filterDictionaries([older, newer, other], 'mecab') as TestTokenizeResult[];
+
+        expect(filtered[0]).toEqual(newer);
+        expect(filtered[1]).toEqual(other);
+    });
+
+    it('throws when tokenize is called with mecab parser support disabled', async () => {
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
+
+        await expect(yomitan.tokenize('alpha')).rejects.toThrow('Yomitan is not configured to support MeCab');
+    });
+
+    it('caches tokenize results and primes lemma and frequency caches from tokenize headwords', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue([
+            makeTokenizeResult({
+                content: [
+                    [
+                        makeTokenPart({
+                            text: 'alpha',
+                            reading: 'alpha',
+                            headwords: [
+                                [
+                                    makeHeadword({
+                                        term: 'alpha',
+                                        reading: 'alpha',
+                                        sources: [makeSource({ originalText: 'alpha', deinflectedText: 'alpha' })],
+                                        frequencies: [makeFrequency({ frequency: 3 })],
+                                    }),
+                                ],
+                            ],
+                        }),
+                    ],
+                ],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+        (yomitan as any).supportsTokenizeFrequency = true;
+
+        const first = await yomitan.tokenize('alpha');
+        const second = await yomitan.tokenize('alpha');
+
+        expect(first).toBe(second);
+        await expect(yomitan.lemmatize('alpha')).resolves.toEqual(['alpha']);
+        await expect(yomitan.frequency('alpha')).resolves.toEqual(3);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles empty tokenize content and empty token-part groups without crashing', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce([makeTokenizeResult({ content: [] })]);
+        fetcher.fetch.mockResolvedValueOnce([makeTokenizeResult({ content: [[]] })]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.tokenize('empty')).resolves.toEqual([]);
+        await expect(yomitan.tokenizeBulk(['empty-group'])).resolves.toEqual([]);
+    });
+
+    it('returns an empty array without fetching in tokenizeBulk for 0 items', async () => {
+        const fetcher = new MockFetcher();
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.tokenizeBulk([])).resolves.toEqual([]);
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('throws when tokenizeBulk is called with mecab parser support disabled', async () => {
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
+
+        await expect(yomitan.tokenizeBulk(['alpha'])).rejects.toThrow('Yomitan is not configured to support MeCab');
+    });
+
+    it('reuses cached texts and preserves order in tokenizeBulk', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTokenizeResult({
+                content: [[makeTokenPart({ text: 'cached', reading: 'cached' })]],
+            }),
+        ]);
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTokenizeResult({
+                content: [[makeTokenPart({ text: 'fresh', reading: 'fresh' })]],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await yomitan.tokenize('cached');
+        const result = await yomitan.tokenizeBulk(['cached', 'fresh']);
+
+        expect(result).toEqual([
+            [makeTokenPart({ text: 'cached', reading: 'cached' })],
+            [makeTokenPart({ text: 'fresh', reading: 'fresh' })],
+        ]);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(2);
+        expect(fetcher.fetch.mock.calls[1]).toEqual([
+            'http://127.0.0.1:50500/tokenize',
+            {
+                text: ['fresh'],
+                scanLength: 25,
+                parser: 'scanning-parser',
+            },
+        ]);
+    });
+
+    it('does not fetch in tokenizeBulk when all texts are already cached', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTokenizeResult({
+                content: [[makeTokenPart({ text: 'alpha', reading: 'alpha' })]],
+            }),
+        ]);
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTokenizeResult({
+                content: [[makeTokenPart({ text: 'beta', reading: 'beta' })]],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await yomitan.tokenize('alpha');
+        await yomitan.tokenize('beta');
+        fetcher.fetch.mockClear();
+
+        await expect(yomitan.tokenizeBulk(['alpha', 'beta'])).resolves.toEqual([
+            [makeTokenPart({ text: 'alpha', reading: 'alpha' })],
+            [makeTokenPart({ text: 'beta', reading: 'beta' })],
+        ]);
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('prefetches unique term entries in tokenizeBulk for mecab bulk support', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue([
+            makeTokenizeResult({
+                source: 'mecab',
+                dictionary: 'UniDic 202402',
+                index: 0,
+                content: [[makeTokenPart({ text: 'alpha', reading: 'alpha' })]],
+            }),
+            makeTokenizeResult({
+                id: 'result-1',
+                source: 'mecab',
+                dictionary: 'UniDic 202402',
+                index: 1,
+                content: [
+                    [makeTokenPart({ text: 'alpha', reading: 'alpha' })],
+                    [makeTokenPart({ text: 'beta', reading: 'beta' })],
+                ],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+        const termEntriesBulkSpy = jest.spyOn(yomitan, 'termEntriesBulk').mockResolvedValue(undefined);
+        (yomitan as any).supportsMecab = true;
+        (yomitan as any).supportsTermEntriesBulk = true;
+
+        await yomitan.tokenizeBulk(['alpha', 'beta']);
+
+        expect(termEntriesBulkSpy).toHaveBeenCalledWith(expect.arrayContaining(['alpha', 'beta']), false, undefined);
+        expect(termEntriesBulkSpy.mock.calls[0][0]).toHaveLength(2);
+    });
+
+    it('does not prefetch term entries in tokenizeBulk when supportsTermEntriesBulk is false', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue([
+            makeTokenizeResult({
+                source: 'mecab',
+                dictionary: 'UniDic 202402',
+                content: [[makeTokenPart({ text: 'alpha', reading: 'alpha' })]],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+        const termEntriesBulkSpy = jest.spyOn(yomitan, 'termEntriesBulk').mockResolvedValue(undefined);
+        (yomitan as any).supportsMecab = true;
+        (yomitan as any).supportsTermEntriesBulk = false;
+
+        await yomitan.tokenizeBulk(['alpha']);
+
+        expect(termEntriesBulkSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not prefetch term entries in tokenizeBulk for scanning-parser even when supportsTermEntriesBulk is true', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue([
+            makeTokenizeResult({
+                source: 'scanning-parser',
+                dictionary: 'Test Dictionary',
+                content: [[makeTokenPart({ text: 'alpha', reading: 'alpha' })]],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+        const termEntriesBulkSpy = jest.spyOn(yomitan, 'termEntriesBulk').mockResolvedValue(undefined);
+        (yomitan as any).supportsTermEntriesBulk = true;
+
+        await yomitan.tokenizeBulk(['alpha']);
+
+        expect(termEntriesBulkSpy).not.toHaveBeenCalled();
+    });
+
+    it('extractFrequencyFromTokenize falls back from term to reading sources and ignores invalid frequencies', () => {
+        const yomitan = new Yomitan(testDictionaryTrack());
+        (yomitan as any).supportsTokenizeFrequency = true;
+
+        (yomitan as any).extractFrequencyFromTokenize('alpha', [
+            [
+                makeHeadword({
+                    sources: [makeSource({ matchSource: 'reading' })],
+                    frequencies: [
+                        makeFrequency({ frequency: 0 }),
+                        makeFrequency({ frequency: Number.POSITIVE_INFINITY }),
+                        makeFrequency({ frequency: 7 }),
+                    ],
+                }),
+            ],
+        ]);
+
+        expect((yomitan as any).frequencyCache.get('alpha')).toEqual(7);
+    });
+
+    it('does not cache tokenize frequencies when supportsTokenizeFrequency is false', () => {
+        const yomitan = new Yomitan(testDictionaryTrack());
+
+        (yomitan as any).extractFrequencyFromTokenize('alpha', [
+            [
+                makeHeadword({
+                    frequencies: [makeFrequency({ frequency: 3 })],
+                }),
+            ],
+        ]);
+
+        expect((yomitan as any).frequencyCache.has('alpha')).toBe(false);
+    });
+
+    it('does not cache mecab lemmas when supportsMecabLemma is false', () => {
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
+
+        (yomitan as any).extractLemmaFromMecab('alpha', makeTokenPart({ lemma: 'base', lemmaReading: 'reading' }));
+
+        expect((yomitan as any).lemmatizeCache.has('alpha')).toBe(false);
+    });
+
+    it('caches both lemma and distinct lemmaReading from mecab token parts when supported', () => {
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }));
+        (yomitan as any).supportsMecabLemma = true;
+
+        (yomitan as any).extractLemmaFromMecab('alpha', makeTokenPart({ lemma: 'base', lemmaReading: 'reading' }));
+
+        expect((yomitan as any).lemmatizeCache.get('alpha')).toEqual(['base', 'reading']);
+    });
+
+    it('extractLemmas prefers a later kanji form over an earlier kana-only headword for kana input', () => {
+        const yomitan = new Yomitan(testDictionaryTrack());
+        const lemmas = (yomitan as any).extractLemmas('すぎます', [
+            [
+                makeHeadword({
+                    term: 'すぎる',
+                    reading: 'すぎる',
+                    sources: [
+                        makeSource({
+                            originalText: 'すぎます',
+                            transformedText: 'すぎます',
+                            deinflectedText: 'すぎる',
+                        }),
+                    ],
+                }),
+                makeHeadword({
+                    term: '過ぎる',
+                    reading: 'すぎる',
+                    sources: [
+                        makeSource({
+                            originalText: 'すぎます',
+                            transformedText: 'すぎます',
+                            deinflectedText: 'すぎる',
+                        }),
+                    ],
+                }),
+            ],
+        ]) as string[];
+
+        expect(lemmas).toEqual(['過ぎる', 'すぎる']);
+    });
+
+    it('extractLemmas falls back to the token when lemmaTokenFallback is enabled', () => {
+        const yomitan = new Yomitan(testDictionaryTrack(), new MockFetcher(), {
+            lemmaTokenFallback: true,
+            tokensWereModified: jest.fn(),
+        });
+
+        expect((yomitan as any).extractLemmas('alpha', [])).toEqual(['alpha']);
+    });
+
+    it('extractLemmas caches an empty result when fallback is disabled and no entries match', () => {
+        const yomitan = new Yomitan(testDictionaryTrack(), new MockFetcher(), {
+            lemmaTokenFallback: false,
+            tokensWereModified: jest.fn(),
+        });
+
+        expect((yomitan as any).extractLemmas('alpha', [])).toEqual([]);
+        expect((yomitan as any).lemmatizeCache.get('alpha')).toEqual([]);
+    });
+
+    it('returns empty lemmas and null frequency for non-letter tokens in lemmatize and frequency', async () => {
+        const fetcher = new MockFetcher();
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.lemmatize('!!')).resolves.toEqual([]);
+        await expect(yomitan.frequency('!!')).resolves.toBeNull();
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('fetches lemmas once and reuses the cache in lemmatize', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({
+            dictionaryEntries: [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: '過ぎる',
+                            reading: 'すぎる',
+                            sources: [makeSource({ originalText: '過ぎます', deinflectedText: '過ぎる' })],
+                        }),
+                    ],
+                    frequencies: [makeFrequency({ frequency: 4 })],
+                }),
+            ],
+        });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.lemmatize('過ぎます')).resolves.toEqual(['過ぎる', 'すぎる']);
+        await expect(yomitan.lemmatize('過ぎます')).resolves.toEqual(['過ぎる', 'すぎる']);
+        await expect(yomitan.frequency('過ぎます')).resolves.toEqual(4);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns undefined in lemmatize when resetCache cancels a pending request', async () => {
+        const fetcher = new MockFetcher();
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+        const acquireDeferred = deferred<number>();
+        jest.spyOn((yomitan as any).asyncSemaphore, 'acquire').mockReturnValue(acquireDeferred.promise);
+
+        const lemmatizePromise = yomitan.lemmatize('alpha');
+        yomitan.resetCache();
+        (yomitan as any).lastCancelledAt = Number.MAX_SAFE_INTEGER;
+        acquireDeferred.resolve(1);
+
+        await expect(lemmatizePromise).resolves.toBeUndefined();
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns the minimum rank frequency and primes lemmas in frequency', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({
+            dictionaryEntries: [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: 'alpha',
+                            reading: 'alpha',
+                            sources: [makeSource({ originalText: 'alpha', deinflectedText: 'alpha' })],
+                        }),
+                    ],
+                    frequencies: [makeFrequency({ frequency: 9 }), makeFrequency({ index: 1, frequency: 4 })],
+                }),
+            ],
+        });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.frequency('alpha')).resolves.toEqual(4);
+        await expect(yomitan.lemmatize('alpha')).resolves.toEqual(['alpha']);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches pitch accents from tokenize headword pronunciations when supported', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue([
+            makeTokenizeResult({
+                content: [
+                    [
+                        makeTokenPart({
+                            text: 'alpha',
+                            reading: 'alpha',
+                            headwords: [
+                                [
+                                    makeHeadword({
+                                        term: 'alpha',
+                                        reading: 'alpha',
+                                        sources: [makeSource({ originalText: 'alpha', deinflectedText: 'alpha' })],
+                                        pronunciations: [
+                                            makePitchPronunciation(2),
+                                            makePitchPronunciation(2),
+                                            makePitchPronunciation(0),
+                                        ] as any,
+                                    }),
+                                ],
+                            ],
+                        }),
+                    ],
+                ],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+        (yomitan as any).supportsTokenizePronunciations = true;
+
+        await yomitan.tokenize('alpha');
+
+        await expect(yomitan.pitchAccent('alpha')).resolves.toBe(2);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('extracts pitch accents from term entries and prefers string positions on ties', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({
+            dictionaryEntries: [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: 'alpha',
+                            reading: 'alpha',
+                            sources: [makeSource({ originalText: 'alpha', deinflectedText: 'alpha' })],
+                        }),
+                    ],
+                    pronunciations: [makePitchPronunciation(1), makePitchPronunciation('LH')] as any,
+                }),
+            ],
+        });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.pitchAccent('alpha')).resolves.toBe('LH');
+        await expect(yomitan.frequency('alpha')).resolves.toBe(10);
+        await expect(yomitan.lemmatize('alpha')).resolves.toEqual(['alpha']);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns undefined immediately and updates the cache asynchronously in frequency when a callback is configured', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({
+            dictionaryEntries: [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: 'beta',
+                            reading: 'beta',
+                            sources: [makeSource({ originalText: 'beta', deinflectedText: 'beta' })],
+                        }),
+                    ],
+                    frequencies: [makeFrequency({ frequency: 6 })],
+                }),
+            ],
+        });
+        const modified = jest.fn();
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher, {
+            lemmaTokenFallback: false,
+            tokensWereModified: modified,
+        });
+
+        await expect(yomitan.frequency('beta')).resolves.toBeUndefined();
+        await flushMicrotasks(20);
+
+        expect(modified).toHaveBeenCalledWith('beta');
+        expect((yomitan as any).frequencyCache.get('beta')).toEqual(6);
+        expect((yomitan as any).lemmatizeCache.get('beta')).toEqual(['beta']);
+    });
+
+    it('notifies without fetching when resetCache cancels async frequency updates', async () => {
+        const fetcher = new MockFetcher();
+        const modified = jest.fn();
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher, {
+            lemmaTokenFallback: false,
+            tokensWereModified: modified,
+        });
+        const acquireDeferred = deferred<number>();
+        jest.spyOn((yomitan as any).asyncSemaphore, 'acquire').mockReturnValue(acquireDeferred.promise);
+
+        await expect(yomitan.frequency('gamma')).resolves.toBeUndefined();
+        yomitan.resetCache();
+        (yomitan as any).lastCancelledAt = Number.MAX_SAFE_INTEGER;
+        acquireDeferred.resolve(1);
+        await flushMicrotasks();
+
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+        expect(modified).toHaveBeenCalledWith('gamma');
+    });
+
+    it('does not fetch or notify when async frequency work finds a populated cache after waiting', async () => {
+        const fetcher = new MockFetcher();
+        const modified = jest.fn();
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher, {
+            lemmaTokenFallback: false,
+            tokensWereModified: modified,
+        });
+        const acquireDeferred = deferred<number>();
+        jest.spyOn((yomitan as any).asyncSemaphore, 'acquire').mockReturnValue(acquireDeferred.promise);
+
+        await expect(yomitan.frequency('delta')).resolves.toBeUndefined();
+        (yomitan as any).frequencyCache.set('delta', 12);
+        acquireDeferred.resolve(1);
+        await flushMicrotasks();
+
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+        expect(modified).not.toHaveBeenCalled();
+    });
+
+    it('extractFrequency falls back from term sources and ignores non-rank frequencies when tokenize frequencies are supported', () => {
+        const yomitan = new Yomitan(testDictionaryTrack());
+        (yomitan as any).supportsTokenizeFrequency = true;
+        const frequency = (yomitan as any).extractFrequency('alpha', [
+            makeEntry({
+                headwords: [
+                    makeHeadword({
+                        sources: [makeSource({ matchSource: 'reading' })],
+                    }),
+                ],
+                frequencies: [
+                    makeFrequency({ frequencyMode: 'occurrence-based', frequency: 1 }),
+                    makeFrequency({ index: 1, frequency: 8 }),
+                ],
+            }),
+        ]) as number | null;
+
+        expect(frequency).toEqual(8);
+    });
+
+    it('ignores non-rank frequencies in extractFrequency when tokenize frequencies are not supported', () => {
+        const yomitan = new Yomitan(testDictionaryTrack());
+        const frequency = (yomitan as any).extractFrequency('alpha', [
+            makeEntry({
+                frequencies: [
+                    makeFrequency({ frequencyMode: 'occurrence-based', frequency: 2 }),
+                    makeFrequency({ index: 1, frequency: 8 }),
+                ],
+            }),
+        ]) as number | null;
+
+        expect(frequency).toEqual(8);
+    });
+
+    it('infers rank-based frequency dictionaries from token occurrence ordering', () => {
+        jest.spyOn(console, 'log').mockImplementation(() => undefined);
+        const modified = jest.fn();
+        const yomitan = new Yomitan(testDictionaryTrack(), new MockFetcher(), {
+            lemmaTokenFallback: false,
+            tokensWereModified: modified,
+        });
+        const tokenOccurrences = new Map<string, number>();
+        const tokens = Array.from({ length: 20 }, (_, index) => `word${index}`);
+
+        for (const [index, token] of tokens.entries()) {
+            const isCommon = index < 10;
+            const frequency = isCommon ? index + 1 : 1000 + index;
+            tokenOccurrences.set(token, isCommon ? 100 - index : 20 - index);
+
+            const extractedFrequency = (yomitan as any).extractFrequency(token, [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: token,
+                            reading: token,
+                            sources: [makeSource({ originalText: token, deinflectedText: token })],
+                        }),
+                    ],
+                    frequencies: [
+                        makeFrequency({
+                            dictionary: 'inferred-rank',
+                            dictionaryAlias: 'inferred-rank',
+                            frequencyMode: null,
+                            frequency,
+                        }),
+                    ],
+                }),
+            ]);
+
+            expect(extractedFrequency).toBeNull();
+            expect((yomitan as any).frequencyCache.get(token)).toBeNull();
+        }
+
+        yomitan.inferFrequencyModesFromTokenOccurrences(new Map([[0, tokenOccurrences]]));
+
+        expect((yomitan as any).inferredFrequencyModes.get('inferred-rank')).toBe('rank-based');
+        expect((yomitan as any).frequencyCache.get('word0')).toBe(1);
+        expect((yomitan as any).frequencyCache.get('word19')).toBe(1019);
+        expect(modified).toHaveBeenCalledTimes(20);
+        expect(modified).toHaveBeenCalledWith('word0');
+        expect(modified).toHaveBeenCalledWith('word19');
+    });
+
+    it('returns early without fetching in termEntriesBulk for 0 items', async () => {
+        const fetcher = new MockFetcher();
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await yomitan.termEntriesBulk([], false);
+
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('caches letter and non-letter results in termEntriesBulk', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue([
+            makeTermEntriesResult(0, [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: 'alpha',
+                            reading: 'alpha',
+                            sources: [makeSource({ originalText: 'alpha', deinflectedText: 'alpha' })],
+                        }),
+                    ],
+                    frequencies: [makeFrequency({ frequency: 2 })],
+                }),
+            ]),
+            makeTermEntriesResult(1, [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: 'beta',
+                            reading: 'beta',
+                            sources: [makeSource({ originalText: 'beta', deinflectedText: 'beta' })],
+                        }),
+                    ],
+                    frequencies: [makeFrequency({ frequency: 5 })],
+                }),
+            ]),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await yomitan.termEntriesBulk(['alpha', '!', 'beta'], false);
+
+        await expect(yomitan.lemmatize('alpha')).resolves.toEqual(['alpha']);
+        await expect(yomitan.frequency('alpha')).resolves.toEqual(2);
+        await expect(yomitan.lemmatize('beta')).resolves.toEqual(['beta']);
+        await expect(yomitan.frequency('beta')).resolves.toEqual(5);
+        await expect(yomitan.frequency('!')).resolves.toBeNull();
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches only uncached letter tokens in termEntriesBulk', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTermEntriesResult(0, [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: 'alpha',
+                            reading: 'alpha',
+                            sources: [makeSource({ originalText: 'alpha', deinflectedText: 'alpha' })],
+                        }),
+                    ],
+                    frequencies: [makeFrequency({ frequency: 2 })],
+                }),
+            ]),
+        ]);
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTermEntriesResult(0, [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: 'beta',
+                            reading: 'beta',
+                            sources: [makeSource({ originalText: 'beta', deinflectedText: 'beta' })],
+                        }),
+                    ],
+                    frequencies: [makeFrequency({ frequency: 5 })],
+                }),
+            ]),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await yomitan.termEntriesBulk(['alpha'], false);
+        fetcher.fetch.mockClear();
+
+        await yomitan.termEntriesBulk(['alpha', '!', 'beta'], false);
+
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+        expect(fetcher.fetch).toHaveBeenCalledWith('http://127.0.0.1:50500/termEntries', { term: ['beta'] });
+        await expect(yomitan.frequency('beta')).resolves.toEqual(5);
+    });
+
+    it('does not fetch in termEntriesBulk when all tokens are already cached', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue([
+            makeTermEntriesResult(0, [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: 'alpha',
+                            reading: 'alpha',
+                            sources: [makeSource({ originalText: 'alpha', deinflectedText: 'alpha' })],
+                        }),
+                    ],
+                    frequencies: [makeFrequency({ frequency: 2 })],
+                }),
+            ]),
+            makeTermEntriesResult(1, [
+                makeEntry({
+                    headwords: [
+                        makeHeadword({
+                            term: 'beta',
+                            reading: 'beta',
+                            sources: [makeSource({ originalText: 'beta', deinflectedText: 'beta' })],
+                        }),
+                    ],
+                    frequencies: [makeFrequency({ frequency: 5 })],
+                }),
+            ]),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await yomitan.termEntriesBulk(['alpha', 'beta'], false);
+        fetcher.fetch.mockClear();
+
+        await yomitan.termEntriesBulk(['alpha', '!', 'beta'], false);
+
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('retries tokenizeBulk with smaller batches after native messaging size failures', async () => {
+        const fetcher = new MockFetcher();
+        let failures = 1;
+        fetcher.fetch.mockImplementation(async (_url, body) => {
+            if (failures > 0) {
+                --failures;
+                return 'Message exceeded maximum allowed size of 64MiB.';
+            }
+
+            const texts = (body as { text: string[] }).text;
+            return texts.map((text, index) =>
+                makeTokenizeResult({
+                    id: `result-${index}`,
+                    index,
+                    content: [[makeTokenPart({ text, reading: text })]],
+                })
+            );
+        });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+        const texts = Array.from({ length: 101 }, (_, index) => `text${index}`);
+
+        const result = await yomitan.tokenizeBulk(texts);
+
+        expect(result).toHaveLength(101);
+        expect(fetcher.fetch.mock.calls.map((call) => (call[1] as { text: string[] }).text.length)).toEqual([
+            100, 50, 50, 1,
+        ]);
+    });
+
+    it('permanently reduces the termEntriesBulk batch size after repeated native messaging size failures', async () => {
+        jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const fetcher = new MockFetcher();
+        let failures = 3;
+        fetcher.fetch.mockImplementation(async (_url, body) => {
+            if (failures > 0) {
+                --failures;
+                return 'Message exceeded maximum allowed size of 64MiB.';
+            }
+
+            const terms = (body as { term: string[] }).term;
+            return terms.map((term, index) =>
+                makeTermEntriesResult(index, [
+                    makeEntry({
+                        headwords: [
+                            makeHeadword({
+                                term,
+                                reading: term,
+                                sources: [makeSource({ originalText: term, deinflectedText: term })],
+                            }),
+                        ],
+                    }),
+                ])
+            );
+        });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+        const terms = Array.from({ length: 11 }, (_, index) => `term${index}`);
+
+        await yomitan.termEntriesBulk(terms, false);
+
+        expect((yomitan as any).termEntriesBatchSize).toBe(5);
+        expect(fetcher.fetch.mock.calls.map((call) => (call[1] as { term: string[] }).term.length)).toEqual([
+            10, 5, 3, 2, 2, 2, 2, 2, 1,
+        ]);
+    });
+
+    it('uses the per-call Yomitan URL override for API-backed public methods', async () => {
+        const fetcher = new MockFetcher();
+        const overrideUrl = 'http://override:50500';
+        fetcher.fetch.mockImplementation(async (url, body) => {
+            if (url.endsWith('/tokenize')) {
+                return [makeTokenizeResult({ content: [] })];
+            }
+            if (url.endsWith('/termEntries')) {
+                const term = (body as { term: string | string[] }).term;
+                if (Array.isArray(term)) {
+                    return term.map((_, index) => makeTermEntriesResult(index, [makeEntry()]));
+                }
+                return { dictionaryEntries: [makeEntry()] };
+            }
+            if (url.endsWith('/yomitanVersion')) {
+                return { version: '26.4.6' };
+            }
+            throw new Error(`Unexpected URL ${url}`);
+        });
+
+        await new Yomitan(testDictionaryTrack(), fetcher).tokenize('alpha', overrideUrl);
+        await new Yomitan(testDictionaryTrack(), fetcher).lemmatize('alpha', overrideUrl);
+        await new Yomitan(testDictionaryTrack(), fetcher).frequency('alpha', overrideUrl);
+        await new Yomitan(testDictionaryTrack(), fetcher).termEntriesBulk(['alpha'], false, overrideUrl);
+        await new Yomitan(testDictionaryTrack(), fetcher).version(overrideUrl);
+
+        expect(fetcher.fetch.mock.calls.map((call) => call[0])).toEqual([
+            `${overrideUrl}/tokenize`,
+            `${overrideUrl}/termEntries`,
+            `${overrideUrl}/termEntries`,
+            `${overrideUrl}/termEntries`,
+            `${overrideUrl}/yomitanVersion`,
+        ]);
+    });
+
+    it('batches termEntriesBulk requests in groups of 10', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockImplementation(async (_url, body) => {
+            const terms = (body as { term: string[] }).term;
+            return terms.map((term, index) =>
+                makeTermEntriesResult(index, [
+                    makeEntry({
+                        headwords: [
+                            makeHeadword({
+                                term,
+                                reading: term,
+                                sources: [makeSource({ originalText: term, deinflectedText: term })],
+                            }),
+                        ],
+                        frequencies: [makeFrequency({ frequency: index + 1 })],
+                    }),
+                ])
+            );
+        });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+        const terms = Array.from({ length: 11 }, (_, index) => `term${index}`);
+
+        await yomitan.termEntriesBulk(terms, false);
+
+        expect(fetcher.fetch).toHaveBeenCalledTimes(2);
+        expect((fetcher.fetch.mock.calls[0][1] as { term: string[] }).term).toHaveLength(10);
+        expect((fetcher.fetch.mock.calls[1][1] as { term: string[] }).term).toHaveLength(1);
+    });
+
+    it('stops termEntriesBulk before fetching when resetCache cancels a pending acquire', async () => {
+        const fetcher = new MockFetcher();
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+        const acquireDeferred = deferred<number>();
+        jest.spyOn((yomitan as any).asyncSemaphore, 'acquire').mockReturnValue(acquireDeferred.promise);
+
+        const promise = yomitan.termEntriesBulk(['alpha'], false);
+        yomitan.resetCache();
+        (yomitan as any).lastCancelledAt = Number.MAX_SAFE_INTEGER;
+        acquireDeferred.resolve(1);
+        await promise;
+
+        expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('accepts dev version 0.0.0.0 and enables bulk features for non-mecab parsers', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ version: '0.0.0.0' });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.version()).resolves.toEqual('0.0.0.0');
+
+        expect(yomitan.getSupportsMecab()).toBe(false);
+        expect(yomitan.getSupportsMecabLemma()).toBe(false);
+        expect(yomitan.getSupportsBulkFrequency()).toBe(true);
+    });
+
+    it('verifies mecab support for dev version 0.0.0.0 when the parser is mecab', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ version: '0.0.0.0' });
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+        const verifySpy = jest.spyOn(yomitan as any, 'verifyMecabSupport').mockResolvedValue(undefined);
+
+        await expect(yomitan.version()).resolves.toEqual('0.0.0.0');
+
+        expect(verifySpy).toHaveBeenCalled();
+        expect(yomitan.getSupportsBulkFrequency()).toBe(true);
+    });
+
+    it('rejects versions older than the minimum supported Yomitan release', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ version: '25.12.15.9' });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.version()).rejects.toThrow('Minimum Yomitan version is 25.12.16.0, found 25.12.15.9');
+    });
+
+    it('rejects malformed Yomitan versions that semver cannot coerce', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ version: 'not-a-version' });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.version()).rejects.toThrow('Minimum Yomitan version is 25.12.16.0, found not-a-version');
+    });
+
+    it('verifies mecab support at the configured threshold and toggles bulk support by version', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ version: '26.4.6' });
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+        const verifySpy = jest.spyOn(yomitan as any, 'verifyMecabSupport').mockResolvedValue(undefined);
+
+        await expect(yomitan.version()).resolves.toEqual('26.4.6');
+
+        expect(verifySpy).toHaveBeenCalled();
+        expect(yomitan.getSupportsBulkFrequency()).toBe(true);
+    });
+
+    it('does not verify mecab support for non-mecab parsers and keeps bulk support disabled before 26.4.6', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ version: '26.4.5' });
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+        const verifySpy = jest.spyOn(yomitan as any, 'verifyMecabSupport').mockResolvedValue(undefined);
+        (yomitan as any).supportsMecab = true;
+        (yomitan as any).supportsMecabLemma = true;
+
+        await expect(yomitan.version()).resolves.toEqual('26.4.5');
+
+        expect(verifySpy).not.toHaveBeenCalled();
+        expect(yomitan.getSupportsMecab()).toBe(false);
+        expect(yomitan.getSupportsMecabLemma()).toBe(false);
+        expect(yomitan.getSupportsBulkFrequency()).toBe(false);
+    });
+
+    it('does not verify mecab support before version 26.3.9 even when the parser is mecab', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue({ version: '26.3.8' });
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+        const verifySpy = jest.spyOn(yomitan as any, 'verifyMecabSupport').mockResolvedValue(undefined);
+        (yomitan as any).supportsMecab = true;
+        (yomitan as any).supportsMecabLemma = true;
+
+        await expect(yomitan.version()).resolves.toEqual('26.3.8');
+
+        expect(verifySpy).not.toHaveBeenCalled();
+        expect(yomitan.getSupportsMecab()).toBe(false);
+        expect(yomitan.getSupportsMecabLemma()).toBe(false);
+        expect(yomitan.getSupportsBulkFrequency()).toBe(false);
+    });
+
+    it('sets full mecab and lemma support when verifyMecabSupport receives the expected tokenization', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue([
+            makeTokenizeResult({
+                source: 'mecab',
+                dictionary: 'UniDic 202402',
+                content: [
+                    [
+                        makeTokenPart({
+                            text: '思い',
+                            reading: 'おもい',
+                            lemma: '思い出す',
+                            lemmaReading: 'おもいだす',
+                        }),
+                        makeTokenPart({ text: '出せ', reading: 'だせ' }),
+                        makeTokenPart({ text: 'なく', reading: 'なく' }),
+                    ],
+                ],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+
+        await (yomitan as any).verifyMecabSupport();
+
+        expect(yomitan.getSupportsMecab()).toBe(true);
+        expect(yomitan.getSupportsMecabLemma()).toBe(true);
+    });
+
+    it('keeps mecab support but disables lemma support when verifyMecabSupport sees unexpected lemmas', async () => {
+        const fetcher = new MockFetcher();
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        fetcher.fetch.mockResolvedValue([
+            makeTokenizeResult({
+                source: 'mecab',
+                dictionary: 'UniDic 202402',
+                content: [
+                    [
+                        makeTokenPart({ text: '思い', reading: 'おもい', lemma: 'wrong', lemmaReading: 'wrong' }),
+                        makeTokenPart({ text: '出せ', reading: 'だせ' }),
+                        makeTokenPart({ text: 'なく', reading: 'なく' }),
+                    ],
+                ],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+
+        await (yomitan as any).verifyMecabSupport();
+
+        expect(yomitan.getSupportsMecab()).toBe(true);
+        expect(yomitan.getSupportsMecabLemma()).toBe(false);
+    });
+
+    it('disables mecab support when verifyMecabSupport receives an unexpected tokenization shape', async () => {
+        const fetcher = new MockFetcher();
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        fetcher.fetch.mockResolvedValue([
+            makeTokenizeResult({
+                source: 'mecab',
+                dictionary: 'UniDic 202402',
+                content: [[makeTokenPart({ text: '思い出せない', reading: 'おもいだせない' })]],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+
+        await (yomitan as any).verifyMecabSupport();
+
+        expect(yomitan.getSupportsMecab()).toBe(false);
+        expect(yomitan.getSupportsMecabLemma()).toBe(false);
+    });
+
+    it('disables mecab support when verifyMecabSupport receives an unexpected source or fetch failure', async () => {
+        const fetcher = new MockFetcher();
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTokenizeResult({
+                source: 'scanning-parser',
+                content: [[makeTokenPart({ text: '思い出せなく', reading: 'おもいだせなく' })]],
+            }),
+        ]);
+        fetcher.fetch.mockRejectedValueOnce(new Error('boom'));
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+
+        await (yomitan as any).verifyMecabSupport();
+        expect(yomitan.getSupportsMecab()).toBe(false);
+        expect(yomitan.getSupportsMecabLemma()).toBe(false);
+
+        await (yomitan as any).verifyMecabSupport();
+        expect(yomitan.getSupportsMecab()).toBe(false);
+        expect(yomitan.getSupportsMecabLemma()).toBe(false);
+    });
+
+    it('throws from _executeAction when the Yomitan API returns an empty payload', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValue('{}');
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect((yomitan as any)._executeAction('tokenize', { text: 'alpha' })).rejects.toThrow(
+            'Yomitan API error for tokenize: {}'
+        );
+        expect(fetcher.fetch).toHaveBeenCalledWith('http://127.0.0.1:50500/tokenize', { text: 'alpha' });
+    });
+});

--- a/common/yomitan/yomitan.ts
+++ b/common/yomitan/yomitan.ts
@@ -93,12 +93,58 @@ interface TermPronunciation {
     pronunciations: (PitchAccent | PhoneticTranscription)[];
 }
 
-interface TokenizeResult {
+export interface TokenizeResult {
     id: string;
     source: string;
     dictionary: string;
     index: number;
     content: TokenPartResult[][];
+}
+
+export const splitTextForTokenization = (text: string) =>
+    text
+        .split(STERM_AND_NEWLINES_REGEX)
+        .map((part) => part.trim())
+        .filter((part) => HAS_LETTER_REGEX.test(part));
+
+export function filterYomitanDictionaries(
+    tokenizeResults: TokenizeResult[],
+    parser: DictionaryTrack['dictionaryYomitanParser']
+): TokenizeResult[] {
+    if (parser !== 'mecab') return tokenizeResults;
+
+    const preferenceMap = new Map<string, { year: number; month: number }>();
+    const preference = (dictionary: string): { year: number; month: number } => {
+        const lower = dictionary.toLowerCase();
+        if (preferenceMap.has(lower)) return preferenceMap.get(lower)!;
+        let year = 1;
+        let month = 0;
+        if (lower.includes('unidic')) {
+            const match = dictionary.match(YEAR_MONTH_REGEX);
+            year = match?.groups?.year ? parseInt(match.groups.year) : 2;
+            month = match?.groups?.month ? parseInt(match.groups.month) : 0;
+        } else if (lower === 'ipadic-neologd') {
+            year = 0;
+        }
+        preferenceMap.set(lower, { year, month });
+        return preferenceMap.get(lower)!;
+    };
+
+    const indexDictMap = new Map<number, { res: TokenizeResult; year: number; month: number }>();
+    for (const result of tokenizeResults) {
+        const current = indexDictMap.get(result.index);
+        const preferred = preference(result.dictionary);
+        if (
+            !current ||
+            preferred.year > current.year ||
+            (preferred.year === current.year && preferred.month > current.month)
+        ) {
+            indexDictMap.set(result.index, { res: result, ...preferred });
+        }
+    }
+    const results: TokenizeResult[] = [];
+    for (const [index, value] of indexDictMap.entries()) results[index] = value.res;
+    return results;
 }
 
 export interface TermEntriesResult {
@@ -201,14 +247,7 @@ export class Yomitan {
         statusUpdates?: (progress: Progress) => Promise<void>,
         yomitanUrl?: string
     ): Promise<TokenPart[][]> {
-        return this.tokenizeBulk(
-            text
-                .split(STERM_AND_NEWLINES_REGEX)
-                .map((p) => p.trim())
-                .filter((p) => HAS_LETTER_REGEX.test(p)),
-            statusUpdates,
-            yomitanUrl
-        );
+        return this.tokenizeBulk(splitTextForTokenization(text), statusUpdates, yomitanUrl);
     }
 
     async tokenize(text: string, yomitanUrl?: string): Promise<TokenPart[][]> {
@@ -225,12 +264,12 @@ export class Yomitan {
             yomitanUrl
         );
         if (!Array.isArray(res)) throw new Error(`Unexpected Yomitan tokenize response: ${JSON.stringify(res)}`);
-        const tokenizeResults = this.filterDictionaries(res, this.dt.dictionaryYomitanParser);
+        const tokenizeResults = filterYomitanDictionaries(res, this.dt.dictionaryYomitanParser);
 
         const newlines: { text: string; index: number }[] = [];
         for (const m of text.matchAll(NEWLINES_REGEX)) newlines.push({ text: m[0], index: m.index });
 
-        for (const tokenizeResult of tokenizeResults) this.cacheFromTokenize(tokenizeResult, tokens, newlines); // Requires this.filterDictionaries to ensure one tokenizeResult per index
+        for (const tokenizeResult of tokenizeResults) this.cacheFromTokenize(tokenizeResult, tokens, newlines);
         this.tokenizeCache.set(text, tokens);
         return tokens;
     }
@@ -280,9 +319,8 @@ export class Yomitan {
                         if (typeof res === 'string' && res.includes('exceed')) batchError = true; // {"message":"Message exceeded maximum allowed size of 64MiB."}
                         throw new Error(`Unexpected Yomitan tokenize response: ${JSON.stringify(res)}`);
                     }
-                    const tokenizeResults = this.filterDictionaries(res, this.dt.dictionaryYomitanParser);
+                    const tokenizeResults = filterYomitanDictionaries(res, this.dt.dictionaryYomitanParser);
 
-                    // Requires this.filterDictionaries to ensure one tokenizeResult per index
                     for (const tokenizeResult of tokenizeResults) {
                         const tokensForText: TokenPart[][] = [];
                         this.cacheFromTokenize(tokenizeResult, tokensForText, newlinesByText[tokenizeResult.index]);
@@ -323,50 +361,6 @@ export class Yomitan {
             }
             return this.tokenizeBulk(allTexts, statusUpdates, yomitanUrl, Math.ceil(batchSize / 2));
         }
-    }
-
-    /**
-     * Filter MeCab tokenize results to prefer the newest UniDic dictionary when multiple dictionaries are returned.
-     * Ensures one TokenizeResult per text index.
-     * @param tokenizeRes The array of TokenizeResult from Yomitan's tokenize API.
-     * @param parser The parser used (only 'mecab' requires filtering).
-     * @returns The filtered array of TokenizeResult.
-     */
-    private filterDictionaries(
-        tokenizeRes: TokenizeResult[],
-        parser: typeof this.dt.dictionaryYomitanParser
-    ): TokenizeResult[] {
-        if (parser !== 'mecab') return tokenizeRes;
-
-        const preferenceMap = new Map<string, { year: number; month: number }>();
-        const preference = (dictionary: string): { year: number; month: number } => {
-            const lower = dictionary.toLowerCase();
-            if (preferenceMap.has(lower)) return preferenceMap.get(lower)!;
-            let year = 1;
-            let month = 0;
-            if (lower.includes('unidic')) {
-                const match = dictionary.match(YEAR_MONTH_REGEX);
-                year = match?.groups?.year ? parseInt(match.groups.year) : 2;
-                month = match?.groups?.month ? parseInt(match.groups.month) : 0;
-            } else if (lower === 'ipadic-neologd') {
-                year = 0;
-                month = 0;
-            }
-            preferenceMap.set(lower, { year, month });
-            return preferenceMap.get(lower)!;
-        };
-
-        const indexDictMap = new Map<number, { res: TokenizeResult; year: number; month: number }>();
-        for (const res of tokenizeRes) {
-            const curr = indexDictMap.get(res.index);
-            const pref = preference(res.dictionary);
-            if (!curr || pref.year > curr.year || (pref.year === curr.year && pref.month > curr.month)) {
-                indexDictMap.set(res.index, { res, ...pref });
-            }
-        }
-        const results: TokenizeResult[] = [];
-        for (const [index, val] of indexDictMap.entries()) results[index] = val.res;
-        return results;
     }
 
     private cacheFromTokenize(
@@ -996,7 +990,7 @@ export class Yomitan {
     private async verifyMecabSupport(yomitanUrl?: string) {
         const text = '思い出せなくなった';
         try {
-            const tokenizeResults = this.filterDictionaries(
+            const tokenizeResults = filterYomitanDictionaries(
                 await this._executeAction(
                     'tokenize',
                     {

--- a/common/yomitan/yomitan.ts
+++ b/common/yomitan/yomitan.ts
@@ -25,13 +25,13 @@ export interface TokenPart {
     reading: string;
 }
 
-interface TokenPartResult extends TokenPart {
+export interface TokenPartResult extends TokenPart {
     lemma?: string;
     lemmaReading?: string;
     headwords?: TermHeadword[][];
 }
 
-interface TermHeadword {
+export interface TermHeadword {
     index: number;
     headwordIndex?: number;
     term: string;
@@ -41,7 +41,7 @@ interface TermHeadword {
     pronunciations?: TermPronunciation[];
 }
 
-interface TermSource {
+export interface TermSource {
     originalText: string;
     transformedText: string;
     deinflectedText: string;
@@ -101,13 +101,13 @@ interface TokenizeResult {
     content: TokenPartResult[][];
 }
 
-interface TermEntriesResult {
+export interface TermEntriesResult {
     dictionaryEntries: TermDictionaryEntry[];
     originalTextLength: number;
     index: number;
 }
 
-interface TermDictionaryEntry {
+export interface TermDictionaryEntry {
     headwords: TermHeadword[];
     frequencies: TermFrequency[];
     pronunciations: TermPronunciation[];

--- a/docs/docs/reference/settings.md
+++ b/docs/docs/reference/settings.md
@@ -305,7 +305,20 @@ Controls how asbplayer matches a subtitle word against your known words.
 - **Lemma or exact form collected**: treat the word as collected if either lemma or exact form matches (any of the above).
 - **Any form collected**: treat the word as collected if any related form matches (running -> run, ran, runs, etc.).
 
-When **Lemma form collected**, **Lemma or exact form collected**, or **Any form collected** is selected, **Match across language scripts** controls whether lemma-based matching may cross between different scripts for a language (e.g Kanji, Hiragana, Katakana).
+When **Lemma form collected**, **Lemma or exact form collected**, or **Any form collected** is selected, [**Match across language scripts**](#match-across-language-scripts) controls whether lemma-based matching may cross between different scripts for a language (e.g Kanji, Hiragana, Katakana).
+
+### Match across language scripts
+
+Controls whether lemma-based matching may cross between different scripts for a language (e.g Kanji, Hiragana, Katakana).
+
+```
+if true:
+  - Kana subtitles can match kanji in collection, could be homophones but text processing can't handle it so we allow it.
+  - Kanji subtitles only match with kanji in collection, prevents kana collected matches all kanji homophones.
+if false:
+  - Never match across scripts, downside is if kanji is collected kana will need to be collected too.
+  - Essentially a strict mode where the you need to collect all script forms of a word.
+```
 
 ### Card choice priority
 
@@ -320,7 +333,7 @@ If multiple Anki cards match a word, this controls which card is used to determi
 
 Controls how asbplayer searches your configured [**Anki sentence fields**](#anki-sentence-fields), it has the same options as [**Word field search strategy**](#word-field-search-strategy).
 
-When **Lemma form collected**, **Lemma or exact form collected**, or **Any form collected** is selected, **Match across language scripts** controls whether lemma-based matching may cross between different scripts for a language (e.g Kanji, Hiragana, Katakana).
+When **Lemma form collected**, **Lemma or exact form collected**, or **Any form collected** is selected, [**Match across language scripts**](#match-across-language-scripts) controls whether lemma-based matching may cross between different scripts for a language (e.g Kanji, Hiragana, Katakana).
 
 :::tip
 Since sentences will contain multiple words thus diluting the relevance of the card state to any individual word, it's best to keep this as **Exact form collected** unless you only have sentence cards.

--- a/docs/docs/reference/settings.md
+++ b/docs/docs/reference/settings.md
@@ -485,6 +485,18 @@ This setting only applies if [**Display pitch accent (Japanese)**](#display-pitc
 
 If enabled for video or subtitle list, pitch accent is hidden by default and only appears when you hover over the subtitle text in the video or subtitle list respectively.
 
+### Word reading size
+
+Controls the size of word readings (furigana) in em units (% of subtitle font size).
+
+### Word frequency size
+
+Controls the size of word frequency in em units (% of subtitle font size).
+
+### Pitch accent size
+
+Controls the size of pitch accent in em units (% of subtitle font size).
+
 ### Word status colors
 
 Each status has a configurable color and transparency used by [**Word color style**](#word-color-style) which can be individually enabled or disabled.

--- a/extension/src/pages/util.test.ts
+++ b/extension/src/pages/util.test.ts
@@ -1,0 +1,342 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { extractExtension, inferTracks, poll, trackFromDef, trackId } from '@project/extension/src/pages/util';
+
+function track(label: string, language: string, url: string | string[]) {
+    return { label, language, url, extension: 'vtt' };
+}
+
+const deferred = <T>() => {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+};
+
+describe('extractExtension', () => {
+    it('returns the fallback when there is no extension', () => {
+        expect(extractExtension('/path/to/subtitles', 'vtt')).toBe('vtt');
+    });
+
+    it('extracts a plain extension for 1 item', () => {
+        expect(extractExtension('https://example.com/path/to/subtitles.srt', 'vtt')).toBe('srt');
+    });
+
+    it('extracts the extension for 2 common URL variants with multiple dots and query strings', () => {
+        expect(extractExtension('https://example.com/path.to/subtitles.ass?token=abc', 'vtt')).toBe('ass');
+        expect(extractExtension('https://example.com/path/file.vtt?lang=ja', 'srt')).toBe('vtt');
+    });
+});
+
+describe('poll', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('resolves immediately and stops polling after the condition passes', async () => {
+        const test = jest.fn(() => true);
+
+        const promise = poll(test, 5000);
+        await expect(promise).resolves.toBe(true);
+        await jest.advanceTimersByTimeAsync(10000);
+
+        expect(test).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves after the condition passes on the second poll', async () => {
+        let calls = 0;
+        const promise = poll(() => ++calls >= 2, 2500);
+
+        await jest.advanceTimersByTimeAsync(1000);
+
+        await expect(promise).resolves.toBe(true);
+        expect(calls).toBe(2);
+    });
+
+    it('returns false when the timeout expires', async () => {
+        const test = jest.fn(() => false);
+        const promise = poll(test, 1500);
+
+        await jest.advanceTimersByTimeAsync(2000);
+
+        await expect(promise).resolves.toBe(false);
+        expect(test).toHaveBeenCalledTimes(3);
+    });
+});
+
+describe('track helpers', () => {
+    it('builds deterministic ids from track definitions', () => {
+        expect(trackId(track('English', 'en', 'https://example.com/en.vtt'))).toBe(
+            'en:English:https://example.com/en.vtt'
+        );
+        expect(trackId(track('English', 'en', ['https://example.com/en-1.vtt', 'https://example.com/en-2.vtt']))).toBe(
+            'en:English:https://example.com/en-1.vtt,https://example.com/en-2.vtt'
+        );
+    });
+
+    it('adds the computed id when building a track from a definition', () => {
+        expect(trackFromDef(track('Japanese', 'ja', 'https://example.com/ja.vtt'))).toEqual({
+            id: 'ja:Japanese:https://example.com/ja.vtt',
+            label: 'Japanese',
+            language: 'ja',
+            url: 'https://example.com/ja.vtt',
+            extension: 'vtt',
+        });
+    });
+});
+
+describe('inferTracks', () => {
+    const originalParse = JSON.parse;
+    const originalPath = window.location.pathname;
+    let requestHandler: ((event: Event) => Promise<void> | void) | undefined;
+    let dispatchedDetails: any[];
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        history.replaceState({}, '', '/first');
+        requestHandler = undefined;
+        dispatchedDetails = [];
+        jest.spyOn(document, 'addEventListener').mockImplementation(
+            (type: string, listener: EventListenerOrEventListenerObject) => {
+                if (type === 'asbplayer-get-synced-data') {
+                    requestHandler =
+                        typeof listener === 'function' ? listener : async (event: Event) => listener.handleEvent(event);
+                }
+            }
+        );
+        jest.spyOn(document, 'dispatchEvent').mockImplementation((event: Event) => {
+            dispatchedDetails.push((event as CustomEvent).detail);
+            return true;
+        });
+    });
+
+    afterEach(() => {
+        JSON.parse = originalParse;
+        history.replaceState({}, '', originalPath || '/');
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+
+    it('dedupes requested tracks and emits basename before the final synced payload when not waiting for basename', async () => {
+        inferTracks(
+            {
+                onRequest: async (addTrack, setBasename) => {
+                    setBasename('Episode 1');
+                    addTrack(track('English', 'en', 'https://example.com/en.vtt'));
+                    addTrack(track('English', 'en', 'https://example.com/en.vtt'));
+                    addTrack(track('Japanese', 'ja', 'https://example.com/ja.vtt'));
+                },
+                waitForBasename: false,
+            },
+            1000
+        );
+
+        await jest.runOnlyPendingTimersAsync();
+        await requestHandler?.(new Event('asbplayer-get-synced-data'));
+
+        expect(dispatchedDetails).toEqual([
+            { error: '', basename: 'Episode 1', subtitles: undefined },
+            {
+                error: '',
+                basename: 'Episode 1',
+                subtitles: [
+                    {
+                        id: 'en:English:https://example.com/en.vtt',
+                        label: 'English',
+                        language: 'en',
+                        url: 'https://example.com/en.vtt',
+                        extension: 'vtt',
+                    },
+                    {
+                        id: 'ja:Japanese:https://example.com/ja.vtt',
+                        label: 'Japanese',
+                        language: 'ja',
+                        url: 'https://example.com/ja.vtt',
+                        extension: 'vtt',
+                    },
+                ],
+            },
+        ]);
+    });
+
+    it('waits for the basename to arrive through JSON.parse when configured to do so', async () => {
+        inferTracks(
+            {
+                onJson: (value, _addTrack, setBasename) => {
+                    if (value.basename) {
+                        setBasename(value.basename);
+                    }
+                },
+                onRequest: async (addTrack) => {
+                    addTrack(track('English', 'en', 'https://example.com/en.vtt'));
+                },
+                waitForBasename: true,
+            },
+            2000
+        );
+
+        await jest.runOnlyPendingTimersAsync();
+        const requestPromise = requestHandler?.(new Event('asbplayer-get-synced-data'));
+        JSON.parse('{"basename":"Episode 2"}');
+        await jest.advanceTimersByTimeAsync(1000);
+        await requestPromise;
+
+        expect(dispatchedDetails).toEqual([
+            {
+                error: '',
+                basename: 'Episode 2',
+                subtitles: [
+                    {
+                        id: 'en:English:https://example.com/en.vtt',
+                        label: 'English',
+                        language: 'en',
+                        url: 'https://example.com/en.vtt',
+                        extension: 'vtt',
+                    },
+                ],
+            },
+        ]);
+    });
+
+    it('emits additional synced data when JSON.parse discovers a new track after the initial request', async () => {
+        inferTracks(
+            {
+                onJson: (value, addTrack, setBasename) => {
+                    if (value.basename) {
+                        setBasename(value.basename);
+                    }
+                    if (value.track) {
+                        addTrack(value.track);
+                    }
+                },
+                onRequest: async (addTrack, setBasename) => {
+                    setBasename('Episode 3');
+                    addTrack(track('English', 'en', 'https://example.com/en.vtt'));
+                },
+                waitForBasename: false,
+            },
+            1000
+        );
+
+        await jest.runOnlyPendingTimersAsync();
+        await requestHandler?.(new Event('asbplayer-get-synced-data'));
+        JSON.parse(
+            '{"track":{"label":"Japanese","language":"ja","url":"https://example.com/ja.vtt","extension":"vtt"}}'
+        );
+        const dispatchCountAfterNewTrack = dispatchedDetails.length;
+        JSON.parse(
+            '{"track":{"label":"Japanese","language":"ja","url":"https://example.com/ja.vtt","extension":"vtt"}}'
+        );
+
+        expect(dispatchedDetails[dispatchCountAfterNewTrack - 1]).toEqual({
+            error: '',
+            basename: 'Episode 3',
+            subtitles: [
+                {
+                    id: 'en:English:https://example.com/en.vtt',
+                    label: 'English',
+                    language: 'en',
+                    url: 'https://example.com/en.vtt',
+                    extension: 'vtt',
+                },
+                {
+                    id: 'ja:Japanese:https://example.com/ja.vtt',
+                    label: 'Japanese',
+                    language: 'ja',
+                    url: 'https://example.com/ja.vtt',
+                    extension: 'vtt',
+                },
+            ],
+        });
+        expect(dispatchedDetails).toHaveLength(dispatchCountAfterNewTrack);
+    });
+
+    it('times out to an empty subtitle list when no tracks are discovered', async () => {
+        inferTracks({ waitForBasename: false }, 1000);
+
+        await jest.runOnlyPendingTimersAsync();
+        const requestPromise = requestHandler?.(new Event('asbplayer-get-synced-data'));
+        await jest.advanceTimersByTimeAsync(1000);
+        await requestPromise;
+
+        expect(dispatchedDetails).toEqual([{ error: '', basename: '', subtitles: [] }]);
+    });
+
+    it('garbage collects inferred tracks for paths that are no longer current', async () => {
+        let requestCount = 0;
+        inferTracks(
+            {
+                onRequest: async (addTrack) => {
+                    requestCount++;
+                    if (requestCount === 1) {
+                        addTrack(track('English', 'en', 'https://example.com/en.vtt'));
+                    } else if (requestCount === 2) {
+                        addTrack(track('Japanese', 'ja', 'https://example.com/ja.vtt'));
+                    }
+                },
+                waitForBasename: false,
+            },
+            1000
+        );
+
+        await jest.runOnlyPendingTimersAsync();
+        await requestHandler?.(new Event('asbplayer-get-synced-data'));
+        expect(
+            dispatchedDetails[dispatchedDetails.length - 1].subtitles.map((subtitle: any) => subtitle.language)
+        ).toEqual(['en']);
+
+        history.replaceState({}, '', '/second');
+        await requestHandler?.(new Event('asbplayer-get-synced-data'));
+        expect(
+            dispatchedDetails[dispatchedDetails.length - 1].subtitles.map((subtitle: any) => subtitle.language)
+        ).toEqual(['ja']);
+
+        history.replaceState({}, '', '/first');
+        const requestPromise = requestHandler?.(new Event('asbplayer-get-synced-data'));
+        await jest.advanceTimersByTimeAsync(1000);
+        await requestPromise;
+
+        expect(dispatchedDetails[dispatchedDetails.length - 1]).toEqual({ error: '', basename: '', subtitles: [] });
+    });
+
+    it('files tracks from a late async request under the request path after navigation', async () => {
+        const request = deferred<void>();
+        inferTracks(
+            {
+                onRequest: async (addTrack) => {
+                    await request.promise;
+                    addTrack(track('English', 'en', 'https://example.com/en.vtt'));
+                },
+                waitForBasename: false,
+            },
+            1000
+        );
+
+        await jest.runOnlyPendingTimersAsync();
+        void requestHandler?.(new Event('asbplayer-get-synced-data'));
+        history.replaceState({}, '', '/second');
+
+        request.resolve();
+        await Promise.resolve();
+        history.replaceState({}, '', '/first');
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(dispatchedDetails[dispatchedDetails.length - 1]).toEqual({
+            error: '',
+            basename: '',
+            subtitles: [
+                {
+                    id: 'en:English:https://example.com/en.vtt',
+                    label: 'English',
+                    language: 'en',
+                    url: 'https://example.com/en.vtt',
+                    extension: 'vtt',
+                },
+            ],
+        });
+    });
+});

--- a/extension/src/pages/util.test.ts
+++ b/extension/src/pages/util.test.ts
@@ -38,13 +38,16 @@ describe('poll', () => {
     });
 
     it('resolves immediately and stops polling after the condition passes', async () => {
-        const test = jest.fn(() => true);
+        let calls = 0;
 
-        const promise = poll(test, 5000);
+        const promise = poll(() => {
+            calls++;
+            return true;
+        }, 5000);
         await expect(promise).resolves.toBe(true);
         await jest.advanceTimersByTimeAsync(10000);
 
-        expect(test).toHaveBeenCalledTimes(1);
+        expect(calls).toBe(1);
     });
 
     it('resolves after the condition passes on the second poll', async () => {
@@ -58,13 +61,16 @@ describe('poll', () => {
     });
 
     it('returns false when the timeout expires', async () => {
-        const test = jest.fn(() => false);
-        const promise = poll(test, 1500);
+        let calls = 0;
+        const promise = poll(() => {
+            calls++;
+            return false;
+        }, 1500);
 
         await jest.advanceTimersByTimeAsync(2000);
 
         await expect(promise).resolves.toBe(false);
-        expect(test).toHaveBeenCalledTimes(3);
+        expect(calls).toBe(3);
     });
 });
 

--- a/extension/src/services/binding.test.ts
+++ b/extension/src/services/binding.test.ts
@@ -1,0 +1,555 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { AutoPausePreference, PlayMode, type IndexedSubtitleModel } from '@project/common';
+import type { SubtitleSlice } from '@project/common/subtitle-collection';
+
+jest.mock('@project/common/subtitle-reader', () => ({
+    SubtitleReader: class SubtitleReader {},
+}));
+
+jest.mock('../controllers/anki-ui-controller', () => ({
+    __esModule: true,
+    default: class AnkiUiController {},
+}));
+
+jest.mock('../controllers/controls-controller', () => ({
+    __esModule: true,
+    default: class ControlsController {},
+}));
+
+jest.mock('../controllers/drag-controller', () => ({
+    __esModule: true,
+    default: class DragController {},
+}));
+
+jest.mock('../controllers/mobile-gesture-controller', () => ({
+    MobileGestureController: class MobileGestureController {},
+}));
+
+jest.mock('../controllers/mobile-video-overlay-controller', () => ({
+    MobileVideoOverlayController: class MobileVideoOverlayController {
+        updateModel = jest.fn();
+    },
+}));
+
+jest.mock('../controllers/notification-controller', () => ({
+    __esModule: true,
+    default: class NotificationController {},
+}));
+
+jest.mock('../controllers/subtitle-controller', () => ({
+    __esModule: true,
+    default: class SubtitleController {
+        autoPauseContext = {
+            onStartedShowing: undefined,
+            onWillStopShowing: undefined,
+            clear: jest.fn(),
+        };
+        onNextSeekableToShow = undefined;
+        onSeekableSlice = undefined;
+        notification = jest.fn();
+    },
+}));
+
+jest.mock('../controllers/bulk-export-controller', () => ({
+    __esModule: true,
+    default: class BulkExportController {},
+}));
+
+jest.mock('../controllers/video-data-sync-controller', () => ({
+    __esModule: true,
+    default: class VideoDataSyncController {},
+}));
+
+jest.mock('./audio-recorder', () => ({
+    __esModule: true,
+    default: class AudioRecorder {},
+    TimedRecordingInProgressError: class TimedRecordingInProgressError extends Error {},
+}));
+
+jest.mock('./key-bindings', () => ({
+    __esModule: true,
+    default: class KeyBindings {},
+}));
+
+jest.mock('./i18n', () => ({
+    i18nInit: jest.fn(),
+}));
+
+jest.mock('./pgs-parser-worker-factory', () => ({
+    pgsParserWorkerFactory: jest.fn(),
+}));
+
+import Binding from './binding';
+import { MockStorageArea } from './mock-storage-area';
+
+type BindingHarness = ReturnType<typeof createBindingHarness>;
+type BindingTestInternals = {
+    autoPausePreference: AutoPausePreference;
+    recordingState: number;
+    _pendingAutoRepeatTargetTimestamp: number;
+    _subscribe: () => void;
+    playListener: (event: Event) => void;
+    seekedListener: (event: Event) => void;
+};
+
+type MutableVideoStub = {
+    paused: boolean;
+    currentTime: number;
+    playbackRate: number;
+    readyState: number;
+    duration: number;
+    src: string;
+    addEventListener: ReturnType<typeof jest.fn>;
+    removeEventListener: ReturnType<typeof jest.fn>;
+    play: ReturnType<typeof jest.fn>;
+    pause: ReturnType<typeof jest.fn>;
+    getBoundingClientRect: ReturnType<typeof jest.fn>;
+};
+
+const sortedModes = (modes: Set<PlayMode>) => [...modes].sort((left, right) => left - right);
+
+const makeSubtitle = (overrides: Partial<IndexedSubtitleModel> = {}): IndexedSubtitleModel => ({
+    text: 'subtitle',
+    start: 0,
+    end: 1000,
+    originalStart: 0,
+    originalEnd: 1000,
+    track: 0,
+    index: 0,
+    ...overrides,
+});
+
+const allowedModeCombinations: readonly PlayMode[][] = [
+    [PlayMode.autoPause],
+    [PlayMode.condensed],
+    [PlayMode.fastForward],
+    [PlayMode.repeat],
+    [PlayMode.autoPause, PlayMode.condensed],
+    [PlayMode.autoPause, PlayMode.fastForward],
+    [PlayMode.autoPause, PlayMode.repeat],
+    [PlayMode.condensed, PlayMode.repeat],
+    [PlayMode.fastForward, PlayMode.repeat],
+    [PlayMode.autoPause, PlayMode.condensed, PlayMode.repeat],
+    [PlayMode.autoPause, PlayMode.fastForward, PlayMode.repeat],
+];
+
+function createVideoStub() {
+    return {
+        paused: false,
+        currentTime: 0,
+        playbackRate: 1,
+        readyState: 4,
+        duration: 120,
+        src: 'https://example.com/video.mp4',
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        play: jest.fn(async () => undefined),
+        pause: jest.fn(),
+        getBoundingClientRect: jest.fn(() => ({ left: 0, top: 0, width: 100, height: 100 })),
+    } as MutableVideoStub;
+}
+
+function createBindingHarness() {
+    const video = createVideoStub();
+    const binding = new Binding(video as unknown as HTMLMediaElement, false) as Binding & Record<string, any>;
+    const bindingInternals = binding as unknown as BindingTestInternals;
+    const updateModel = jest.fn();
+    const notification = jest.fn();
+    const clearAutoPauseContext = jest.fn();
+    const pause = jest.fn();
+    const seek = jest.fn();
+    const play = jest.fn(async () => undefined);
+
+    const subtitleController = {
+        autoPauseContext: {
+            onStartedShowing: undefined as undefined | ((subtitle: IndexedSubtitleModel) => void),
+            onWillStopShowing: undefined as undefined | ((subtitle: IndexedSubtitleModel) => void),
+            clear: clearAutoPauseContext,
+        },
+        onNextSeekableToShow: undefined as undefined | ((subtitle: IndexedSubtitleModel) => Promise<void> | void),
+        onSeekableSlice: undefined as
+            | undefined
+            | ((slice: SubtitleSlice<IndexedSubtitleModel>) => Promise<void> | void),
+        subtitleAtIndex: jest.fn(() => [null, null]),
+        notification,
+    };
+
+    Object.assign(binding, {
+        video,
+        subtitleController,
+        mobileVideoOverlayController: { updateModel },
+        dictionary: {
+            onRequestStatisticsSeek: jest.fn(() => jest.fn()),
+            onRequestStatisticsMineSentences: jest.fn(() => jest.fn()),
+        },
+        autoPausePreference: AutoPausePreference.atEnd,
+        condensedPlaybackMinimumSkipIntervalMs: 1000,
+        fastForwardPlaybackMinimumGapMs: 600,
+        fastForwardModePlaybackRate: 2.7,
+        seekableTracks: 1,
+        recordingState: 2,
+        recordingPostMineAction: undefined,
+        _playModes: new Set([PlayMode.normal]),
+        _pendingAutoRepeatTargetTimestamp: 0,
+        _synced: false,
+        pausedDueToHover: false,
+        pause,
+        seek,
+        play,
+    });
+
+    return {
+        binding,
+        bindingInternals,
+        updateModel,
+        notification,
+        clearAutoPauseContext,
+        pause,
+        seek,
+        play,
+        subtitleController,
+        video,
+    };
+}
+
+function enableModes(binding: Binding, modes: readonly PlayMode[]) {
+    for (const mode of modes) {
+        binding.togglePlayMode(mode);
+    }
+}
+
+async function assertCombinationBehavior(harness: BindingHarness, modes: readonly PlayMode[]) {
+    const { binding, bindingInternals, pause, seek, play, subtitleController, video, updateModel } = harness;
+    const hasAutoPause = modes.includes(PlayMode.autoPause);
+    const hasCondensed = modes.includes(PlayMode.condensed);
+    const hasFastForward = modes.includes(PlayMode.fastForward);
+    const hasRepeat = modes.includes(PlayMode.repeat);
+
+    enableModes(binding, modes);
+
+    expect(sortedModes(binding.playModes)).toEqual(sortedModes(new Set(modes)));
+    expect(updateModel).toHaveBeenCalledTimes(modes.length);
+    expect(typeof subtitleController.autoPauseContext.onStartedShowing === 'function').toBe(hasAutoPause);
+    expect(typeof subtitleController.autoPauseContext.onWillStopShowing === 'function').toBe(hasAutoPause || hasRepeat);
+    expect(typeof subtitleController.onNextSeekableToShow === 'function').toBe(hasCondensed);
+    expect(typeof subtitleController.onSeekableSlice === 'function').toBe(hasFastForward);
+
+    pause.mockClear();
+    seek.mockClear();
+    play.mockClear();
+
+    if (hasAutoPause) {
+        bindingInternals.autoPausePreference = AutoPausePreference.atStart;
+        subtitleController.autoPauseContext.onStartedShowing?.(makeSubtitle());
+        expect(pause).toHaveBeenCalledTimes(1);
+        pause.mockClear();
+    }
+
+    if (hasAutoPause || hasRepeat) {
+        bindingInternals.autoPausePreference = AutoPausePreference.atEnd;
+        const subtitle = makeSubtitle({ start: 2000, end: 2600 });
+
+        subtitleController.autoPauseContext.onWillStopShowing?.(subtitle);
+
+        if (hasAutoPause && hasRepeat) {
+            expect(pause).toHaveBeenCalledTimes(1);
+            expect(seek).not.toHaveBeenCalled();
+            expect(bindingInternals._pendingAutoRepeatTargetTimestamp).toBe(2);
+        } else if (hasAutoPause) {
+            expect(pause).toHaveBeenCalledTimes(1);
+            expect(seek).not.toHaveBeenCalled();
+            expect(bindingInternals._pendingAutoRepeatTargetTimestamp).toBe(0);
+        } else {
+            expect(seek).toHaveBeenCalledTimes(1);
+            expect(seek).toHaveBeenCalledWith(2);
+            expect(pause).not.toHaveBeenCalled();
+        }
+
+        pause.mockClear();
+        seek.mockClear();
+
+        if (hasAutoPause && hasRepeat) {
+            bindingInternals.autoPausePreference = AutoPausePreference.atStart;
+
+            subtitleController.autoPauseContext.onWillStopShowing?.(subtitle);
+
+            expect(seek).toHaveBeenCalledTimes(1);
+            expect(seek).toHaveBeenCalledWith(2);
+            expect(pause).not.toHaveBeenCalled();
+            expect(bindingInternals._pendingAutoRepeatTargetTimestamp).toBe(0);
+
+            seek.mockClear();
+        }
+    }
+
+    if (hasCondensed) {
+        video.paused = false;
+        video.currentTime = 0;
+
+        await subtitleController.onNextSeekableToShow?.(makeSubtitle({ start: 3000, end: 3500 }));
+
+        if (hasRepeat) {
+            expect(seek).not.toHaveBeenCalled();
+            expect(play).not.toHaveBeenCalled();
+        } else {
+            expect(seek).toHaveBeenCalledTimes(1);
+            expect(seek).toHaveBeenCalledWith(3);
+            expect(play).toHaveBeenCalledTimes(1);
+        }
+
+        seek.mockClear();
+        play.mockClear();
+    }
+
+    if (hasFastForward) {
+        video.currentTime = 1;
+        video.playbackRate = 1;
+
+        await subtitleController.onSeekableSlice?.({
+            showing: [],
+            lastShown: [makeSubtitle({ start: 0, end: 200, index: 0 })],
+            nextToShow: [makeSubtitle({ start: 2000, end: 2500, index: 1 })],
+            startedShowing: undefined,
+            willStopShowing: undefined,
+        });
+        expect(video.playbackRate).toBe(2.7);
+
+        await subtitleController.onSeekableSlice?.({
+            showing: [makeSubtitle({ start: 1000, end: 1400, index: 0 })],
+            lastShown: undefined,
+            nextToShow: undefined,
+            startedShowing: undefined,
+            willStopShowing: undefined,
+        });
+        expect(video.playbackRate).toBe(1);
+    }
+}
+
+describe('Binding playback modes', () => {
+    beforeEach(() => {
+        (globalThis as any).browser = {
+            storage: {
+                local: new MockStorageArea(),
+            },
+            runtime: {
+                sendMessage: jest.fn(),
+                onMessage: {
+                    addListener: jest.fn(),
+                },
+            },
+        };
+    });
+
+    afterEach(() => {
+        delete (globalThis as any).browser;
+        jest.restoreAllMocks();
+    });
+
+    it('constructs a real binding and applies playback modes through its real methods', async () => {
+        const video = createVideoStub();
+        const binding = new Binding(video as unknown as HTMLMediaElement, false);
+
+        expect(binding.video).toBe(video);
+        expect(binding.registeredVideoSrc).toBe(video.src);
+        expect(binding.synced).toBe(false);
+        expect(binding.recordingMedia).toBe(false);
+        expect(sortedModes(binding.playModes)).toEqual([PlayMode.normal]);
+
+        binding.togglePlayMode(PlayMode.autoPause);
+        await binding.subtitleController.autoPauseContext.onWillStopShowing?.(makeSubtitle({ start: 2000, end: 2600 }));
+
+        expect(video.pause).toHaveBeenCalledTimes(1);
+
+        binding.togglePlayMode(PlayMode.repeat);
+        binding.togglePlayMode(PlayMode.condensed);
+        await binding.subtitleController.onNextSeekableToShow?.(makeSubtitle({ start: 5000, end: 5500 }));
+
+        expect(video.play).not.toHaveBeenCalled();
+        expect(video.currentTime).toBe(0);
+    });
+
+    it.each(allowedModeCombinations.map((modes) => [modes]))(
+        'supports the allowed mode combination %j',
+        async (modes) => {
+            const harness = createBindingHarness();
+
+            await assertCombinationBehavior(harness, modes);
+        }
+    );
+
+    it('consumes the pending repeat target on play after auto-pause plus repeat schedules it', () => {
+        const harness = createBindingHarness();
+        const { binding, bindingInternals, seek, subtitleController } = harness;
+
+        enableModes(binding, [PlayMode.autoPause, PlayMode.repeat]);
+        bindingInternals.autoPausePreference = AutoPausePreference.atEnd;
+        subtitleController.autoPauseContext.onWillStopShowing?.(makeSubtitle({ start: 4500, end: 5000 }));
+
+        bindingInternals._subscribe();
+        bindingInternals.playListener(new Event('play'));
+
+        expect(seek).toHaveBeenLastCalledWith(4.5);
+        expect(bindingInternals._pendingAutoRepeatTargetTimestamp).toBe(0);
+    });
+
+    it('clears pending repeat state and the auto-pause context on seeked', () => {
+        const harness = createBindingHarness();
+        const { bindingInternals, clearAutoPauseContext, video } = harness;
+
+        bindingInternals._pendingAutoRepeatTargetTimestamp = 9;
+        video.currentTime = 12;
+        video.readyState = 3;
+        bindingInternals._subscribe();
+
+        bindingInternals.seekedListener(new Event('seeked'));
+
+        expect(bindingInternals._pendingAutoRepeatTargetTimestamp).toBe(0);
+        expect(clearAutoPauseContext).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not seek during condensed playback when the gap is too small or the video is paused', async () => {
+        const harness = createBindingHarness();
+        const { binding, seek, play, subtitleController, video } = harness;
+
+        enableModes(binding, [PlayMode.condensed]);
+
+        video.currentTime = 2.2;
+        await subtitleController.onNextSeekableToShow?.(makeSubtitle({ start: 3000, end: 3500 }));
+        video.paused = true;
+        video.currentTime = 0;
+        await subtitleController.onNextSeekableToShow?.(makeSubtitle({ start: 4000, end: 4500 }));
+
+        expect(seek).not.toHaveBeenCalled();
+        expect(play).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-pause at subtitle start while recording or when configured to pause at the end', () => {
+        const harness = createBindingHarness();
+        const { binding, bindingInternals, pause, subtitleController } = harness;
+
+        enableModes(binding, [PlayMode.autoPause]);
+        bindingInternals.autoPausePreference = AutoPausePreference.atStart;
+        bindingInternals.recordingState = 1;
+        subtitleController.autoPauseContext.onStartedShowing?.(makeSubtitle());
+
+        expect(pause).not.toHaveBeenCalled();
+
+        bindingInternals.recordingState = 2;
+        bindingInternals.autoPausePreference = AutoPausePreference.atEnd;
+        subtitleController.autoPauseContext.onStartedShowing?.(makeSubtitle());
+
+        expect(pause).not.toHaveBeenCalled();
+    });
+
+    it('does not seek during condensed playback while recording', async () => {
+        const harness = createBindingHarness();
+        const { binding, bindingInternals, seek, play, subtitleController, video } = harness;
+
+        enableModes(binding, [PlayMode.condensed]);
+        bindingInternals.recordingState = 1;
+        video.paused = false;
+        video.currentTime = 0;
+
+        await subtitleController.onNextSeekableToShow?.(makeSubtitle({ start: 3000, end: 3500 }));
+
+        expect(seek).not.toHaveBeenCalled();
+        expect(play).not.toHaveBeenCalled();
+    });
+
+    it('ignores concurrent condensed playback callbacks while a seek is in progress', async () => {
+        const harness = createBindingHarness();
+        const { binding, seek, play, subtitleController, video } = harness;
+        let finishPlay: (() => void) | undefined;
+        play.mockImplementationOnce(() => new Promise<undefined>((resolve) => (finishPlay = () => resolve(undefined))));
+
+        enableModes(binding, [PlayMode.condensed]);
+        video.paused = false;
+        video.currentTime = 0;
+
+        const firstSeek = subtitleController.onNextSeekableToShow?.(makeSubtitle({ start: 3000, end: 3500 }));
+        await subtitleController.onNextSeekableToShow?.(makeSubtitle({ start: 5000, end: 5500 }));
+
+        expect(seek).toHaveBeenCalledTimes(1);
+        expect(seek).toHaveBeenCalledWith(3);
+        expect(play).toHaveBeenCalledTimes(1);
+
+        finishPlay?.();
+        await firstSeek;
+    });
+
+    it('lets repeat take precedence over condensed playback on the same subtitle transition', async () => {
+        const harness = createBindingHarness();
+        const { binding, seek, play, subtitleController, video } = harness;
+
+        enableModes(binding, [PlayMode.repeat, PlayMode.condensed]);
+        video.paused = false;
+        video.currentTime = 2.6;
+
+        subtitleController.autoPauseContext.onWillStopShowing?.(makeSubtitle({ start: 2000, end: 2600 }));
+        await subtitleController.onNextSeekableToShow?.(makeSubtitle({ start: 5000, end: 5500 }));
+
+        expect(seek).toHaveBeenCalledTimes(1);
+        expect(seek).toHaveBeenCalledWith(2);
+        expect(play).not.toHaveBeenCalled();
+    });
+
+    it('keeps fast forward at normal speed when subtitle edges are too close to the current time', async () => {
+        const harness = createBindingHarness();
+        const { binding, subtitleController, video } = harness;
+
+        enableModes(binding, [PlayMode.fastForward]);
+        video.currentTime = 1;
+        video.playbackRate = 1;
+
+        await subtitleController.onSeekableSlice?.({
+            showing: [],
+            lastShown: [makeSubtitle({ start: 0, end: 700, index: 0 })],
+            nextToShow: [makeSubtitle({ start: 1500, end: 1800, index: 1 })],
+            startedShowing: undefined,
+            willStopShowing: undefined,
+        });
+
+        expect(video.playbackRate).toBe(1);
+    });
+
+    it('fast-forwards before the first subtitle and after the last subtitle when one edge is absent', async () => {
+        const harness = createBindingHarness();
+        const { binding, subtitleController, video } = harness;
+
+        enableModes(binding, [PlayMode.fastForward]);
+        video.currentTime = 1;
+
+        await subtitleController.onSeekableSlice?.({
+            showing: [],
+            lastShown: undefined,
+            nextToShow: [makeSubtitle({ start: 3000, end: 3500 })],
+            startedShowing: undefined,
+            willStopShowing: undefined,
+        });
+        expect(video.playbackRate).toBe(2.7);
+
+        await subtitleController.onSeekableSlice?.({
+            showing: [],
+            lastShown: [makeSubtitle({ start: 0, end: 200 })],
+            nextToShow: undefined,
+            startedShowing: undefined,
+            willStopShowing: undefined,
+        });
+        expect(video.playbackRate).toBe(2.7);
+    });
+
+    it('resets extension fast-forward state when condensed mode replaces it', () => {
+        const harness = createBindingHarness();
+        const { binding, subtitleController, updateModel, video } = harness;
+
+        binding.togglePlayMode(PlayMode.fastForward);
+        video.playbackRate = 2.7;
+        binding.togglePlayMode(PlayMode.condensed);
+
+        expect(sortedModes(binding.playModes)).toEqual([PlayMode.condensed]);
+        expect(subtitleController.onSeekableSlice).toBeUndefined();
+        expect(typeof subtitleController.onNextSeekableToShow).toBe('function');
+        expect(video.playbackRate).toBe(1);
+        expect(updateModel).toHaveBeenCalledTimes(2);
+    });
+});

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -409,6 +409,7 @@ export default class Binding {
                         if (
                             this.recordingMedia ||
                             seeking ||
+                            this._playModes.has(PlayMode.repeat) ||
                             !isTrackSeekable(this.seekableTracks, subtitle.track) ||
                             this.video.paused ||
                             subtitle.start - this.contentTimeMs <= this.condensedPlaybackMinimumSkipIntervalMs

--- a/extension/src/services/extension-global-state-provider.test.ts
+++ b/extension/src/services/extension-global-state-provider.test.ts
@@ -1,5 +1,6 @@
 import { ExtensionGlobalStateProvider } from './extension-global-state-provider';
 import { MockStorageArea } from './mock-storage-area';
+import { expect, it } from '@jest/globals';
 
 it('can retrieve list of keys', async () => {
     const provider = new ExtensionGlobalStateProvider(new MockStorageArea());

--- a/extension/src/services/extension-settings-storage.test.ts
+++ b/extension/src/services/extension-settings-storage.test.ts
@@ -1,6 +1,7 @@
 import { ExtensionSettingsStorage } from './extension-settings-storage';
 import { defaultSettings } from '@project/common/settings';
 import { MockStorageArea } from './mock-storage-area';
+import { expect, it, beforeEach } from '@jest/globals';
 
 const settingsStorage = new ExtensionSettingsStorage(new MockStorageArea());
 

--- a/extension/src/services/pages.test.ts
+++ b/extension/src/services/pages.test.ts
@@ -1,5 +1,6 @@
 import { defaultSettings } from '@project/common/settings';
 import pagesConfig from '../pages.json';
+import { expect, it } from '@jest/globals';
 
 it('page settings and page configs are consistent', () => {
     for (const page of pagesConfig.pages) {


### PR DESCRIPTION
Now that the design for annotations are more stable, it's worth adding tests to enshrine the various invariants and behavior that the current pipeline depends on. I expect future features to change some of these tests as the goal is that breaking any of these should be intentional especially around the database. It also serves as getting a lot of the knowledge and assumptions I have in my head out concretely so it's easier for others to maintain as well.

I also did some refactoring of the playback mode logic to make it more testable in preparation for future integration with annotations.

**Bug fixes**
- Fix getting last anki note id from sorting
- Fix Anki html tag regex so repeat captures retain the entire tag
- Fix using normalized tokens for `getBulk()` lookup, `anyOfIgnoreCase()` does not work for virtual indexes from compound indexes
- Fix SubtitleCollection gap having a last shown when it precedes the first subtitle
- Fix extension controlled media not preferring repeat mode over condensed like the app

**Other code changes**
- `keysAreEqual()` to only compare an objects own keys rather than inherited as well (no behavior change)
- Toggling a mode off doesn't affect other playback modes (not currently possible)
- Ensure normal play mode is removed when other modes are enabled (not currently possible)
- Extract playback mode logic so it's more testable
- Ensure states are sorted for local tokens when saving
- Explicitly ensure invariants around Anki and WaniKani records when saving

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex:GPT-5.6
