### PR TITLE
[codex] Add Bilibili mainland subtitle support

### DIFF
--- a/common/subtitle-reader/subtitle-reader.test.ts
+++ b/common/subtitle-reader/subtitle-reader.test.ts
@@ -150,3 +150,24 @@ describe('SubtitleReader dfxp timestamp handling', () => {
         expect(subtitles).toHaveLength(0);
     });
 });
+
+describe('SubtitleReader Bilibili JSON parsing', () => {
+    it('parses Bilibili JSON cues', async () => {
+        const file = {
+            name: 'test.bbjson',
+            text: async () =>
+                JSON.stringify({
+                    body: [
+                        { from: 1.25, to: 3.5, content: 'First subtitle' },
+                        { from: 4, to: 6.75, content: 'Second subtitle' },
+                    ],
+                }),
+        } as unknown as File;
+
+        const subtitles = await createReader().subtitles([file]);
+
+        expect(subtitles).toHaveLength(2);
+        expect(subtitles[0]).toMatchObject({ start: 1250, end: 3500, text: 'First subtitle' });
+        expect(subtitles[1]).toMatchObject({ start: 4000, end: 6750, text: 'Second subtitle' });
+    });
+});

--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -42,7 +42,7 @@ sidebar_position: 7
 | Rakuten Viki            |                                                                                            ✓                                                                                             |
 | osnplus                 |                                             Compatibility with osnplus is currently unknown. Reach out if you have more information on this.                                             |
 | Plex                    | Supports external subtitles. As for internal subtitles, first select them from Plex UI to make them selectable from asbplayer. Configure custom domains from the page-specific settings. |
-| BiliBili                |                                                                                            ✓                                                                                             |
+| BiliBili                |                                              ✓ (`bilibili.tv` and desktop `www.bilibili.com/video/*`; mainland subtitles may require login)                                              |
 | NRK TV                  |                                                                                            ✓                                                                                             |
 | HBO Max                 |                                                             See [issue](https://github.com/asbplayer/asbplayer/issues/1006)                                                              |
 | Yle Areena              |                                                                                            ✓                                                                                             |

--- a/extension/src/entrypoints/bilibili-page.ts
+++ b/extension/src/entrypoints/bilibili-page.ts
@@ -1,32 +1,27 @@
-import { extractExtension, inferTracks } from '@/pages/util';
+import { extractBilibiliTracks } from '@/pages/bilibili';
+import { inferTracks } from '@/pages/util';
+
+const getCacheKey = () => {
+    if (window.location.hostname !== 'www.bilibili.com') {
+        return window.location.pathname;
+    }
+
+    const part = new URLSearchParams(window.location.search).get('p') ?? '1';
+    return `${window.location.pathname}?p=${part}`;
+};
 
 export default defineUnlistedScript(() => {
     inferTracks({
         onJson: (value, addTrack) => {
-            if (value?.data?.subtitles instanceof Array) {
-                for (const track of value.data.subtitles) {
-                    if (
-                        typeof track.lang === 'string' &&
-                        typeof track.lang_key === 'string' &&
-                        ((typeof track.srt === 'object' && typeof track.srt.url === 'string') ||
-                            typeof track.url === 'string')
-                    ) {
-                        const url = track.srt?.url ?? track.url;
-                        const extension = extractExtension(url, 'srt');
-
-                        addTrack({
-                            label: track.lang,
-                            language: track.lang_key,
-                            url,
-                            extension: extension === 'json' ? 'bbjson' : extension,
-                        });
-                    }
-                }
+            for (const track of extractBilibiliTracks(value, window.location.href)) {
+                addTrack(track);
             }
         },
         onRequest: async (_addTrack, setBasename) => {
             setBasename(document.title);
         },
+        observeResponseJson: true,
+        getCacheKey,
         waitForBasename: false,
     });
 });

--- a/extension/src/pages.json
+++ b/extension/src/pages.json
@@ -147,7 +147,7 @@
         },
         {
             "key": "bilibili",
-            "host": "www\\.bilibili\\.tv",
+            "host": "www\\.bilibili\\.(tv|com)",
             "pageScript": "bilibili-page.js",
             "syncAllowedAtPath": "play|video",
             "autoSync": {

--- a/extension/src/pages/bilibili.test.ts
+++ b/extension/src/pages/bilibili.test.ts
@@ -1,0 +1,103 @@
+import { extractBilibiliTracks } from './bilibili';
+
+describe('extractBilibiliTracks', () => {
+    it('extracts international SRT and JSON tracks', () => {
+        const tracks = extractBilibiliTracks(
+            {
+                data: {
+                    subtitles: [
+                        {
+                            lang: 'English',
+                            lang_key: 'en',
+                            srt: { url: '//cdn.example.com/subtitles/english.srt' },
+                        },
+                        {
+                            lang: '日本語',
+                            lang_key: 'ja',
+                            url: 'https://cdn.example.com/subtitles/japanese.json?token=abc',
+                        },
+                    ],
+                },
+            },
+            'https://www.bilibili.tv/en/video/123'
+        );
+
+        expect(tracks).toEqual([
+            {
+                label: 'English',
+                language: 'en',
+                url: 'https://cdn.example.com/subtitles/english.srt',
+                extension: 'srt',
+            },
+            {
+                label: '日本語',
+                language: 'ja',
+                url: 'https://cdn.example.com/subtitles/japanese.json?token=abc',
+                extension: 'bbjson',
+            },
+        ]);
+    });
+
+    it('extracts mainland manual and AI subtitle tracks as Bilibili JSON', () => {
+        const tracks = extractBilibiliTracks(
+            {
+                data: {
+                    subtitle: {
+                        subtitles: [
+                            {
+                                lan: 'zh-CN',
+                                lan_doc: '中文（简体）',
+                                subtitle_url: '//aisubtitle.hdslb.com/bfs/subtitle/manual.json',
+                                ai_type: 0,
+                            },
+                            {
+                                lan: 'ja-JP',
+                                subtitle_url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/generated',
+                                ai_type: 1,
+                            },
+                        ],
+                    },
+                },
+            },
+            'https://www.bilibili.com/video/BV1sM4y1V7x1/'
+        );
+
+        expect(tracks).toEqual([
+            {
+                label: '中文（简体）',
+                language: 'zh-CN',
+                url: 'https://aisubtitle.hdslb.com/bfs/subtitle/manual.json',
+                extension: 'bbjson',
+            },
+            {
+                label: 'ja-JP',
+                language: 'ja-JP',
+                url: 'https://aisubtitle.hdslb.com/bfs/ai_subtitle/generated',
+                extension: 'bbjson',
+            },
+        ]);
+    });
+
+    it('ignores malformed tracks and unrelated JSON', () => {
+        expect(
+            extractBilibiliTracks(
+                {
+                    data: {
+                        subtitles: [
+                            { lang: 'Missing language key', url: 'https://example.com/one.srt' },
+                            { lang: 'Missing URL', lang_key: 'en' },
+                        ],
+                        subtitle: {
+                            subtitles: [
+                                { lan: '', lan_doc: 'Empty language', subtitle_url: 'https://example.com/one.json' },
+                                { lan: 'en', lan_doc: 'Missing URL' },
+                            ],
+                        },
+                    },
+                },
+                'https://www.bilibili.com/video/BV1sM4y1V7x1/'
+            )
+        ).toEqual([]);
+        expect(extractBilibiliTracks({ data: { unrelated: true } }, 'https://www.bilibili.com/')).toEqual([]);
+    });
+});

--- a/extension/src/pages/bilibili.test.ts
+++ b/extension/src/pages/bilibili.test.ts
@@ -38,6 +38,32 @@ describe('extractBilibiliTracks', () => {
         ]);
     });
 
+    it('extracts international ASS tracks from the current direct subtitle list', () => {
+        const tracks = extractBilibiliTracks(
+            {
+                data: {
+                    subtitles: [
+                        {
+                            lang: 'English',
+                            lang_key: 'en',
+                            url: 'https://s.bstarstatic.com/ogv/subtitle/english.ass?auth_key=test',
+                        },
+                    ],
+                },
+            },
+            'https://www.bilibili.tv/en/play/1063218/11511707'
+        );
+
+        expect(tracks).toEqual([
+            {
+                label: 'English',
+                language: 'en',
+                url: 'https://s.bstarstatic.com/ogv/subtitle/english.ass?auth_key=test',
+                extension: 'ass',
+            },
+        ]);
+    });
+
     it('extracts mainland manual and AI subtitle tracks as Bilibili JSON', () => {
         const tracks = extractBilibiliTracks(
             {

--- a/extension/src/pages/bilibili.ts
+++ b/extension/src/pages/bilibili.ts
@@ -1,0 +1,80 @@
+import { VideoDataSubtitleTrackDef } from '@project/common';
+import { extractExtension } from './util';
+
+type JsonObject = Record<string, unknown>;
+
+const objectValue = (value: unknown): JsonObject | undefined =>
+    value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as JsonObject) : undefined;
+
+const nonEmptyString = (value: unknown): string | undefined =>
+    typeof value === 'string' && value.length > 0 ? value : undefined;
+
+const absoluteUrl = (url: string, baseUrl: string): string | undefined => {
+    try {
+        return new URL(url, baseUrl).href;
+    } catch {
+        return undefined;
+    }
+};
+
+export function extractBilibiliTracks(value: unknown, baseUrl: string): VideoDataSubtitleTrackDef[] {
+    const tracks: VideoDataSubtitleTrackDef[] = [];
+    const data = objectValue(objectValue(value)?.data);
+
+    if (Array.isArray(data?.subtitles)) {
+        for (const value of data.subtitles) {
+            const track = objectValue(value);
+            const label = nonEmptyString(track?.lang);
+            const language = nonEmptyString(track?.lang_key);
+            const srt = objectValue(track?.srt);
+            const rawUrl = nonEmptyString(srt?.url) ?? nonEmptyString(track?.url);
+
+            if (label === undefined || language === undefined || rawUrl === undefined) {
+                continue;
+            }
+
+            const url = absoluteUrl(rawUrl, baseUrl);
+
+            if (url === undefined) {
+                continue;
+            }
+
+            const extension = extractExtension(url, 'srt').toLowerCase();
+            tracks.push({
+                label,
+                language,
+                url,
+                extension: extension === 'json' ? 'bbjson' : extension,
+            });
+        }
+    }
+
+    const mainlandSubtitles = objectValue(data?.subtitle)?.subtitles;
+
+    if (Array.isArray(mainlandSubtitles)) {
+        for (const value of mainlandSubtitles) {
+            const track = objectValue(value);
+            const language = nonEmptyString(track?.lan);
+            const rawUrl = nonEmptyString(track?.subtitle_url);
+
+            if (language === undefined || rawUrl === undefined) {
+                continue;
+            }
+
+            const url = absoluteUrl(rawUrl, baseUrl);
+
+            if (url === undefined) {
+                continue;
+            }
+
+            tracks.push({
+                label: nonEmptyString(track?.lan_doc) ?? language,
+                language,
+                url,
+                extension: 'bbjson',
+            });
+        }
+    }
+
+    return tracks;
+}

--- a/extension/src/pages/util.test.ts
+++ b/extension/src/pages/util.test.ts
@@ -345,4 +345,67 @@ describe('inferTracks', () => {
             ],
         });
     });
+
+    it('observes Response.json, dedupes tracks across JSON hooks, and separates custom cache keys', async () => {
+        const originalResponse = globalThis.Response;
+
+        class TestResponse {
+            constructor(private readonly value: unknown) {}
+
+            async json() {
+                return this.value;
+            }
+        }
+
+        Object.defineProperty(globalThis, 'Response', {
+            configurable: true,
+            writable: true,
+            value: TestResponse,
+        });
+
+        try {
+            history.replaceState({}, '', '/video/BV1test?p=1');
+            inferTracks({
+                onJson: (value, addTrack) => {
+                    const inferredTrack = (value as { track?: ReturnType<typeof track> }).track;
+
+                    if (inferredTrack !== undefined) {
+                        addTrack(inferredTrack);
+                    }
+                },
+                onRequest: async (_addTrack, setBasename) => setBasename(document.title),
+                observeResponseJson: true,
+                getCacheKey: () =>
+                    `${window.location.pathname}?p=${new URLSearchParams(window.location.search).get('p') ?? '1'}`,
+                waitForBasename: false,
+            });
+            await jest.runOnlyPendingTimersAsync();
+
+            const firstTrack = track('First part', 'ja', 'https://example.com/first.json');
+            JSON.parse(JSON.stringify({ track: firstTrack }));
+
+            const ResponseConstructor = globalThis.Response as unknown as new (value: unknown) => TestResponse;
+            await new ResponseConstructor({ track: firstTrack }).json();
+            await requestHandler?.(new Event('asbplayer-get-synced-data'));
+            await Promise.resolve();
+
+            expect(dispatchedDetails[dispatchedDetails.length - 1].subtitles).toEqual([
+                expect.objectContaining(firstTrack),
+            ]);
+
+            history.replaceState({}, '', '/video/BV1test?p=2');
+            const secondTrack = track('Second part', 'zh-CN', 'https://example.com/second.json');
+            await new ResponseConstructor({ track: secondTrack }).json();
+
+            expect(dispatchedDetails[dispatchedDetails.length - 1].subtitles).toEqual([
+                expect.objectContaining(secondTrack),
+            ]);
+        } finally {
+            Object.defineProperty(globalThis, 'Response', {
+                configurable: true,
+                writable: true,
+                value: originalResponse,
+            });
+        }
+    });
 });

--- a/extension/src/pages/util.ts
+++ b/extension/src/pages/util.ts
@@ -26,7 +26,7 @@ export async function poll(test: () => boolean, timeout: number = 10000): Promis
     return passed;
 }
 
-type SubtitlesByPath = { [key: string]: VideoDataSubtitleTrack[] };
+type SubtitlesByKey = { [key: string]: VideoDataSubtitleTrack[] };
 
 export interface InferHooks {
     onJson?: (
@@ -38,6 +38,8 @@ export interface InferHooks {
         addTrack: (track: VideoDataSubtitleTrackDef) => void,
         setBasename: (basename: string) => void
     ) => Promise<void>;
+    observeResponseJson?: boolean;
+    getCacheKey?: () => string;
     waitForBasename: boolean;
 }
 
@@ -49,71 +51,89 @@ export const trackId = (def: VideoDataSubtitleTrackDef) => {
     return `${def.language}:${def.label}:${def.url}`;
 };
 
-export function inferTracks({ onJson, onRequest, waitForBasename }: InferHooks, timeout?: number) {
+export function inferTracks(
+    { onJson, onRequest, observeResponseJson = false, getCacheKey, waitForBasename }: InferHooks,
+    timeout?: number
+) {
     setTimeout(() => {
-        const subtitlesByPath: SubtitlesByPath = {};
-        const basenameByPath: { [key: string]: string } = {};
+        const subtitlesByKey: SubtitlesByKey = {};
+        const basenameByKey: { [key: string]: string } = {};
         let trackDataRequestHandled = false;
+        const currentCacheKey = () => getCacheKey?.() ?? window.location.pathname;
 
         if (onJson !== undefined) {
-            const originalParse = JSON.parse;
-
-            JSON.parse = function (...args: unknown[]) {
-                // @ts-expect-error: forwarding original parse arguments
-                const value = originalParse.apply(this, args);
+            const handleJson = (value: unknown) => {
                 let tracksFound = false;
                 let basenameFound = false;
 
-                onJson?.(
+                onJson(
                     value,
                     (track) => {
-                        const path = window.location.pathname;
+                        const key = currentCacheKey();
 
-                        if (typeof subtitlesByPath[path] === 'undefined') {
-                            subtitlesByPath[path] = [];
+                        if (typeof subtitlesByKey[key] === 'undefined') {
+                            subtitlesByKey[key] = [];
                         }
 
                         const newId = trackId(track);
 
-                        if (subtitlesByPath[path].find((s) => s.id === newId) === undefined) {
-                            subtitlesByPath[path].push({ id: newId, ...track });
+                        if (subtitlesByKey[key].find((s) => s.id === newId) === undefined) {
+                            subtitlesByKey[key].push({ id: newId, ...track });
                             tracksFound = true;
                         }
                     },
                     (theBasename) => {
-                        basenameByPath[window.location.pathname] = theBasename;
+                        basenameByKey[currentCacheKey()] = theBasename;
                         basenameFound = true;
                     }
                 );
 
                 if (trackDataRequestHandled && (tracksFound || basenameFound)) {
                     // Only notify additional tracks after the initial request for track info
-                    const currentPath = window.location.pathname;
+                    const key = currentCacheKey();
                     document.dispatchEvent(
                         new CustomEvent('asbplayer-synced-data', {
                             detail: {
                                 error: '',
-                                basename: basenameByPath[currentPath] ?? '',
-                                subtitles: subtitlesByPath[currentPath],
+                                basename: basenameByKey[key] ?? '',
+                                subtitles: subtitlesByKey[key],
                             },
                         })
                     );
                 }
+            };
+
+            const originalParse = JSON.parse;
+
+            JSON.parse = function (...args: unknown[]) {
+                // @ts-expect-error: forwarding original parse arguments
+                const value = originalParse.apply(this, args);
+                handleJson(value);
 
                 return value;
             };
+
+            if (observeResponseJson && typeof Response !== 'undefined') {
+                const originalResponseJson = Response.prototype.json;
+
+                Response.prototype.json = async function (this: Response) {
+                    const value: unknown = await originalResponseJson.call(this);
+                    handleJson(value);
+                    return value;
+                };
+            }
         }
 
         function garbageCollect() {
-            const currentPath = window.location.pathname;
-            for (const path of Object.keys(subtitlesByPath)) {
-                if (path !== currentPath) {
-                    delete subtitlesByPath[path];
+            const currentKey = currentCacheKey();
+            for (const key of Object.keys(subtitlesByKey)) {
+                if (key !== currentKey) {
+                    delete subtitlesByKey[key];
                 }
             }
-            for (const path of Object.keys(basenameByPath)) {
-                if (path !== currentPath) {
-                    delete basenameByPath[path];
+            for (const key of Object.keys(basenameByKey)) {
+                if (key !== currentKey) {
+                    delete basenameByKey[key];
                 }
             }
         }
@@ -122,27 +142,26 @@ export function inferTracks({ onJson, onRequest, waitForBasename }: InferHooks, 
             'asbplayer-get-synced-data',
             () => {
                 void (async () => {
-                    // Pin the pathname at request-start time so async onRequest
-                    // callbacks resolving after a soft-navigation still file their
-                    // tracks and basename under the path they were fetched for.
-                    const requestPath = window.location.pathname;
+                    // Pin the cache key at request-start time so async onRequest callbacks
+                    // resolving after a soft-navigation still file their data correctly.
+                    const requestKey = currentCacheKey();
 
                     if (onRequest !== undefined) {
                         void onRequest(
                             (track) => {
-                                if (typeof subtitlesByPath[requestPath] === 'undefined') {
-                                    subtitlesByPath[requestPath] = [];
+                                if (typeof subtitlesByKey[requestKey] === 'undefined') {
+                                    subtitlesByKey[requestKey] = [];
                                 }
 
                                 const newId = trackId(track);
 
-                                if (subtitlesByPath[requestPath].find((s) => s.id === newId) === undefined) {
-                                    subtitlesByPath[requestPath].push({ id: newId, ...track });
+                                if (subtitlesByKey[requestKey].find((s) => s.id === newId) === undefined) {
+                                    subtitlesByKey[requestKey].push({ id: newId, ...track });
                                 }
                             },
                             (theBasename) => {
-                                basenameByPath[requestPath] = theBasename;
-                                if (!trackDataRequestHandled && requestPath === window.location.pathname) {
+                                basenameByKey[requestKey] = theBasename;
+                                if (!trackDataRequestHandled && requestKey === currentCacheKey()) {
                                     // Notify basename even if still waiting for subtitle track info
                                     document.dispatchEvent(
                                         new CustomEvent('asbplayer-synced-data', {
@@ -159,21 +178,21 @@ export function inferTracks({ onJson, onRequest, waitForBasename }: InferHooks, 
                     }
 
                     const ready = () => {
-                        const path = window.location.pathname;
-                        return (!waitForBasename || (basenameByPath[path] ?? '') !== '') && path in subtitlesByPath;
+                        const key = currentCacheKey();
+                        return (!waitForBasename || (basenameByKey[key] ?? '') !== '') && key in subtitlesByKey;
                     };
 
                     if (!ready()) {
                         await poll(ready, timeout);
                     }
 
-                    const currentPath = window.location.pathname;
+                    const currentKey = currentCacheKey();
                     document.dispatchEvent(
                         new CustomEvent('asbplayer-synced-data', {
                             detail: {
                                 error: '',
-                                basename: basenameByPath[currentPath] ?? '',
-                                subtitles: subtitlesByPath[currentPath] ?? [],
+                                basename: basenameByKey[currentKey] ?? '',
+                                subtitles: subtitlesByKey[currentKey] ?? [],
                             },
                         })
                     );


### PR DESCRIPTION
## Summary

- add subtitle detection for desktop `www.bilibili.com/video/*` pages while preserving `bilibili.tv` support
- parse mainland manual and AI subtitle metadata, including protocol-relative subtitle URLs
- observe both `JSON.parse()` and `Response.json()` results and isolate tracks by video path and multipart `p` value
- document support for the mainland site and its login-dependent subtitle availability

> [!NOTE]
> Bilibili mainland may expose subtitle track metadata only to **signed-in** users. When signed out, `data.subtitle.subtitles` may be omitted, so asbplayer will not detect any subtitle tracks. This is expected behavior: the integration reuses the page's current authenticated session and does not bypass Bilibili's access controls.

## Root cause

The existing Bilibili adapter only matched `www.bilibili.tv` and understood its `data.subtitles` response shape. The mainland site exposes tracks under `data.subtitle.subtitles` with different field names, and the relevant data may be consumed through `Response.json()` instead of a direct `JSON.parse()` call.

## User impact

Users signed in to the desktop mainland Bilibili site can select detected manual or AI subtitle tracks, load the subtitle list, and use the existing copy and card-creation flows. Videos without accessible subtitle metadata continue to return an empty track list.

## Screenshot

Bilibili subtitle tracks are detected in the selector, and the selected Japanese track is successfully loaded into the asbplayer subtitle list.The screenshot below was captured while **signed in** to Bilibili.

![Bilibili mainland subtitle detection](https://github.com/user-attachments/assets/651eaca3-a402-4463-8b01-9550c1b5912c)

## Validation

- 22 Jest suites passed (109 tests total) across common, client, and extension workspaces
- ESLint passed for `common`, `extension/src`, and `client/src`
- Prettier passed for all files changed by this PR
- extension TypeScript compilation passed
- Chromium MV3 development build passed
- locale-key, locale-code, and page-script reference checks passed via equivalent PowerShell checks
- manually verified subtitle loading and card creation on `https://www.bilibili.com/video/BV1sM4y1V7x1/`

The root `yarn verify` wrapper could not run directly in this Windows checkout because its Bash helpers require WSL/`jq`, and the checkout uses CRLF for untouched files. All constituent checks relevant to this change were run separately; the upstream Ubuntu workflow will run the canonical verification.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).