### PR TITLE
Stricter subtitle sanitation

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -9,7 +9,7 @@
         "@types/semver": "^7.3.9",
         "ass-compiler": "0.1.1",
         "dexie": "^4.0.11",
-        "dompurify": "^3.3.1",
+        "dompurify": "^3.4.12",
         "fast-xml-parser": "^4.0.7",
         "hotkeys-js": "^3.10.0",
         "i18next": "^22.4.14",

--- a/common/subtitle-reader/subtitle-reader.test.ts
+++ b/common/subtitle-reader/subtitle-reader.test.ts
@@ -20,8 +20,28 @@ const createReader = (convertNetflixRuby = false) =>
 
 const nfimscFile = (xml: string) => ({ name: 'test.nfimsc', text: async () => xml }) as unknown as File;
 
-const parse = (xml: string, convertNetflixRuby = false) =>
-    createReader(convertNetflixRuby).subtitles([nfimscFile(xml)]);
+const parse = (xml: string, convertNetflixRuby = false, flatten = false, fileCount = 1) =>
+    createReader(convertNetflixRuby).subtitles(
+        Array.from({ length: fileCount }, () => nfimscFile(xml)),
+        flatten
+    );
+
+const rubyWithPrecedingKanaXml =
+    '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:tickRate="10000000">' +
+    '<head><styling>' +
+    '<style xml:id="container" tts:ruby="container"/>' +
+    '<style xml:id="base" tts:ruby="base"/>' +
+    '<style xml:id="text" tts:ruby="text"/>' +
+    '</styling></head>' +
+    '<body><div>' +
+    '<p begin="10000000t" end="30000000t">ひろ<span style="container"><span style="base">子</span><span style="text">こ</span></span>そんな</p>' +
+    '</div></body>' +
+    '</tt>';
+
+const nfimscDocument = (text: string) =>
+    '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ttp:tickRate="10000000">' +
+    `<body><div><p begin="10000000t" end="30000000t">${text}</p></div></body>` +
+    '</tt>';
 
 describe('SubtitleReader Netflix IMSC parsing', () => {
     it('parses Netflix IMSC cues', async () => {
@@ -80,17 +100,7 @@ describe('SubtitleReader Netflix IMSC parsing', () => {
     it('binds a ruby reading to its own base when preceded by kanji or kana', async () => {
         // The base 子 is preceded by the kana ひろ. The reading must bind to 子 alone,
         // not to the whole ひろ子 run.
-        const xml =
-            '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:tickRate="10000000">' +
-            '<head><styling>' +
-            '<style xml:id="container" tts:ruby="container"/>' +
-            '<style xml:id="base" tts:ruby="base"/>' +
-            '<style xml:id="text" tts:ruby="text"/>' +
-            '</styling></head>' +
-            '<body><div>' +
-            '<p begin="10000000t" end="30000000t">ひろ<span style="container"><span style="base">子</span><span style="text">こ</span></span>そんな</p>' +
-            '</div></body>' +
-            '</tt>';
+        const xml = rubyWithPrecedingKanaXml;
 
         const withRuby = await parse(xml, true);
         expect(withRuby).toHaveLength(1);
@@ -105,6 +115,36 @@ describe('SubtitleReader Netflix IMSC parsing', () => {
         expect(withoutRuby[0].text).toBe('ひろ子(こ)そんな');
         expect(withoutRuby[0].text).not.toContain('\u2063');
         expect(withoutRuby[0].tokenization).toBeUndefined();
+    });
+
+    it('keeps ruby conversion while flattening and deduplicates identical files', async () => {
+        const subtitles = await parse(rubyWithPrecedingKanaXml, true, true, 2);
+
+        expect(subtitles).toHaveLength(1);
+        expect(subtitles[0]).toMatchObject({
+            start: 1000,
+            end: 3000,
+            track: 0,
+            text: 'ひろ子そんな',
+            tokenization: {
+                tokens: [{ pos: [2, 3], readings: [{ pos: [0, 1], reading: 'こ' }], states: [] }],
+            },
+        });
+    });
+
+    it('deduplicates cues that become equal after sanitization', async () => {
+        const subtitles = await createReader().subtitles(
+            [nfimscFile(nfimscDocument('safe&lt;img src=x onerror=alert(1)&gt;')), nfimscFile(nfimscDocument('safe'))],
+            true
+        );
+
+        expect(subtitles).toHaveLength(1);
+        expect(subtitles[0]).toMatchObject({
+            start: 1000,
+            end: 3000,
+            track: 0,
+            text: 'safe',
+        });
     });
 
     it('does not fence a reading containing a closing paren', async () => {

--- a/common/subtitle-reader/subtitle-reader.ts
+++ b/common/subtitle-reader/subtitle-reader.ts
@@ -6,6 +6,19 @@ import { XMLParser } from 'fast-xml-parser';
 import { SubtitleHtml, SubtitleTextImage, Token, Tokenization } from '@project/common';
 import DOMPurify from 'dompurify';
 
+/**
+ * Subtitle files are untrusted input.  Keep this list deliberately small: subtitle
+ * markup is for presentation only and must not be able to navigate, fetch, or run
+ * code.  In particular, do not add `style` or URL-bearing attributes here.
+ */
+export const sanitizeSubtitleHtml = (html: string) =>
+    DOMPurify.sanitize(html, {
+        ALLOWED_TAGS: ['b', 'strong', 'i', 'em', 'u', 's', 'del', 'br', 'ruby', 'rt', 'rp', 'span'],
+        ALLOWED_ATTR: [],
+        ALLOW_DATA_ATTR: false,
+        ALLOW_ARIA_ATTR: false,
+    });
+
 const vttClassRegex = /<(\/)?c(\.[^>]*)?>/g;
 const assNewLineRegex = RegExp(/\\[nN]/, 'ig');
 // Character classes shared by the Netflix ruby regexes below so they cannot drift apart.
@@ -125,18 +138,19 @@ export default class SubtitleReader {
             if (flatten) {
                 // Flattened output keeps inline base(reading) without tokenizing, so
                 // the ruby base markers are simply dropped here.
-                for (const node of allNodes) {
-                    node.text = node.text.replaceAll(netflixRubyBaseMarker, '');
-                }
-            } else {
-                for (const node of allNodes) {
-                    this._convertNetflixRubyToHtml(node);
-                }
+                for (const node of allNodes) node.text = node.text.replaceAll(netflixRubyBaseMarker, '');
             }
         }
 
+        // Sanitize after all parser, filter, decoding, and flattening transformations.
+        // Ruby tokenization runs afterwards because it relies on positions in this
+        // sanitized text and does not introduce any new markup.
+        for (const node of allNodes) node.text = sanitizeSubtitleHtml(node.text);
+
         if (flatten) {
             return this._deduplicate(allNodes);
+        } else if (this._convertNetflixRuby) {
+            for (const node of allNodes) this._convertNetflixRubyToHtml(node);
         }
 
         return allNodes;
@@ -766,7 +780,6 @@ export default class SubtitleReader {
     }
 
     private _filterText(text: string): string {
-        text = DOMPurify.sanitize(text);
         text =
             this._textFilter === undefined
                 ? text

--- a/common/subtitle-reader/subtitle-reader.ts
+++ b/common/subtitle-reader/subtitle-reader.ts
@@ -134,26 +134,16 @@ export default class SubtitleReader {
             .filter((node) => node.textImage !== undefined || node.text !== '')
             .sort((n1, n2) => n1.start - n2.start);
 
-        if (this._convertNetflixRuby) {
-            if (flatten) {
-                // Flattened output keeps inline base(reading) without tokenizing, so
-                // the ruby base markers are simply dropped here.
-                for (const node of allNodes) node.text = node.text.replaceAll(netflixRubyBaseMarker, '');
-            }
-        }
-
         // Sanitize after all parser, filter, decoding, and flattening transformations.
         // Ruby tokenization runs afterwards because it relies on positions in this
         // sanitized text and does not introduce any new markup.
         for (const node of allNodes) node.text = sanitizeSubtitleHtml(node.text);
 
-        if (flatten) {
-            return this._deduplicate(allNodes);
-        } else if (this._convertNetflixRuby) {
+        if (this._convertNetflixRuby) {
             for (const node of allNodes) this._convertNetflixRubyToHtml(node);
         }
 
-        return allNodes;
+        return flatten ? this._deduplicate(allNodes) : allNodes;
     }
 
     private _deduplicate(nodes: SubtitleNode[]) {

--- a/common/subtitle-reader/subtitle-sanitation.test.ts
+++ b/common/subtitle-reader/subtitle-sanitation.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, jest } from '@jest/globals';
+jest.mock('@qgustavor/srt-parser', () => ({
+    __esModule: true,
+    default: class {
+        fromSrt(value: string) {
+            const text = value.split(/\r?\n/).slice(2).join('\n');
+            return [{ startTime: 0, endTime: 1, text }];
+        }
+    },
+}));
+jest.mock('ass-compiler', () => ({
+    compile: (value: string) => {
+        const dialogue = value.split(/\r?\n/).find((line) => line.startsWith('Dialogue:'));
+        const text = dialogue?.split(',').slice(9).join(',') ?? '';
+        return {
+            dialogues: [{ start: 0, end: 1, slices: [{ fragments: [{ text }] }] }],
+        };
+    },
+}));
+jest.mock('videojs-vtt.js', () => ({ WebVTT: {} }));
+import SubtitleReader, { sanitizeSubtitleHtml } from './subtitle-reader';
+import { SubtitleHtml } from '@project/common';
+
+const file = (name: string, text: string) => ({ name, text: async () => text }) as unknown as File;
+
+const reader = (
+    options: Partial<{
+        subtitleHtml: SubtitleHtml;
+        regexFilter: string;
+        replacement: string;
+        convertNetflixRuby: boolean;
+    }> = {}
+) =>
+    new SubtitleReader({
+        regexFilter: options.regexFilter ?? '',
+        regexFilterTextReplacement: options.replacement ?? '',
+        subtitleHtml: options.subtitleHtml ?? SubtitleHtml.render,
+        convertNetflixRuby: options.convertNetflixRuby ?? false,
+        pgsParserWorkerFactory: () => Promise.reject(new Error('PGS worker is not used in these tests')),
+    });
+
+const allowedTags = ['B', 'STRONG', 'I', 'EM', 'U', 'S', 'DEL', 'BR', 'RUBY', 'RT', 'RP', 'SPAN'];
+
+const assertSafeSink = (text: string) => {
+    const sink = document.createElement('div');
+    sink.innerHTML = `<span>${text}</span>`;
+    for (const element of sink.querySelectorAll('*')) {
+        expect(allowedTags).toContain(element.tagName);
+        expect(Array.from(element.attributes).map((attribute) => attribute.name)).toEqual([]);
+    }
+    return sink;
+};
+
+const srt = (text: string) => file('attack.srt', `1\n00:00:00,000 --> 00:00:01,000\nsafe${text}`);
+
+describe('subtitle reader security', () => {
+    it.each([
+        '<img src=x onerror=alert(1)>',
+        '&lt;img src=x onerror=alert(1)&gt;',
+        '<svg onload=alert(1)>x</svg>',
+        '&lt;svg onload=alert(1)&gt;x&lt;/svg&gt;',
+        '<a href="javascript:alert(1)">x</a>',
+        '<span style="background-image:url(https://attacker.invalid/x)">x</span>',
+        '<img src="https://attacker.invalid/x">',
+        '<b><i>malformed',
+    ])('sanitizes dangerous markup in parsed SRT cue text (%s)', async (payload) => {
+        const subtitles = await reader().subtitles([srt(payload)]);
+
+        expect(subtitles).toHaveLength(1);
+        expect(assertSafeSink(subtitles[0].text).textContent).toContain('safe');
+    });
+
+    it('sanitizes SRT after regex replacement and XML decoding', async () => {
+        const [subtitle] = await reader({
+            regexFilter: 'SAFE',
+            replacement: '<img src=x onerror=alert(1)>safe',
+        }).subtitles([file('replace.srt', '1\n00:00:00,000 --> 00:00:01,000\nSAFE')]);
+        expect(assertSafeSink(subtitle.text).textContent).toBe('safe');
+
+        const [plain] = await reader({ subtitleHtml: SubtitleHtml.remove }).subtitles([
+            file('encoded.srt', '1\n00:00:00,000 --> 00:00:01,000\n&lt;img src=x onerror=alert(1)&gt;safe'),
+        ]);
+        expect(assertSafeSink(plain.text).textContent).toBe('safe');
+    });
+
+    it('preserves allowed subtitle formatting, strips every attribute, and is idempotent', () => {
+        const input =
+            '<b id="x" data-reading="bold" aria-label="bold">bold</b><br><ruby class="reading">語<rt style="color:red">ご</rt><rp>(</rp></ruby>';
+        const sanitized = sanitizeSubtitleHtml(input);
+
+        expect(sanitized).toBe('<b>bold</b><br><ruby>語<rt>ご</rt><rp>(</rp></ruby>');
+        expect(sanitizeSubtitleHtml(sanitized)).toBe(sanitized);
+    });
+
+    it('sanitizes dialogue text parsed from ASS files', async () => {
+        const ass = `[Script Info]\nScriptType: v4.00+\n[V4+ Styles]\nFormat: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\nStyle: Default,Arial,20,&H00FFFFFF,&H00FFFFFF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,10,1\n[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\nDialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,{\\b1}safe{\\b0} <img src=https://attacker.invalid/x onerror=alert(1)>`;
+        const [subtitle] = await reader().subtitles([file('attack.ass', ass)]);
+        const sink = assertSafeSink(subtitle.text);
+        expect(sink.textContent).toContain('safe');
+    });
+
+    it.each([
+        '<img src=x onerror=alert(1)>',
+        '&lt;img src=x onerror=alert(1)&gt;',
+        '<a href="javascript:alert(1)">x</a>',
+        '<span style="background:url(https://attacker.invalid/x)">x</span>',
+        '<ruby>語<rt>ご</rt></ruby>',
+    ])('keeps ASS output formatting-only for %s', async (payload) => {
+        const ass = `[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\nDialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,REPLACE`;
+        const subtitles = await reader({ regexFilter: 'REPLACE', replacement: `safe${payload}` }).subtitles([
+            file('attack.ass', ass),
+        ]);
+        expect(subtitles).toHaveLength(1);
+        expect(assertSafeSink(subtitles[0].text).textContent).toContain('safe');
+    });
+
+    it.each([
+        '&lt;img src=x onerror=alert(1)&gt;',
+        '&lt;svg onload=alert(1)&gt;x&lt;/svg&gt;',
+        '&lt;a href="javascript:alert(1)"&gt;x&lt;/a&gt;',
+    ])('sanitizes TTML/DFXP text revived by entity decoding (%s)', async (payload) => {
+        const dfxp =
+            '<tt xmlns="http://www.w3.org/ns/ttml"><body><div>' +
+            `<p begin="0s" end="1s">safe${payload}</p>` +
+            '</div></body></tt>';
+        const [subtitle] = await reader().subtitles([file('attack.dfxp', dfxp)]);
+
+        expect(assertSafeSink(subtitle.text).textContent).toContain('safe');
+    });
+
+    it('sanitizes YouTube XML text revived by entity decoding', async () => {
+        const ytxml =
+            '<transcript>' +
+            '<text start="0" dur="1">safe&lt;img src=x onerror=alert(1)&gt;</text>' +
+            '<text start="1" dur="1">safe&lt;svg onload=alert(1)&gt;x&lt;/svg&gt;</text>' +
+            '</transcript>';
+        const subtitles = await reader().subtitles([file('attack.ytxml', ytxml)]);
+
+        expect(subtitles).toHaveLength(2);
+        for (const subtitle of subtitles) {
+            expect(assertSafeSink(subtitle.text).textContent).toContain('safe');
+        }
+    });
+
+    it('sanitizes bbjson content', async () => {
+        const bbjson = JSON.stringify({
+            body: [{ from: 0, to: 1, content: 'safe<img src=x onerror=alert(1)><span style="color:red">x</span>' }],
+        });
+        const [subtitle] = await reader().subtitles([file('attack.bbjson', bbjson)]);
+
+        expect(assertSafeSink(subtitle.text).textContent).toContain('safe');
+    });
+
+    it('keeps text and extracted readings formatting-only through Netflix ruby conversion', async () => {
+        const [subtitle] = await reader({ convertNetflixRuby: true }).subtitles([srt('語(ご<b>x)')]);
+
+        expect(assertSafeSink(subtitle.text).textContent).toContain('safe');
+        expect(subtitle.tokenization?.tokens).toHaveLength(1);
+
+        const [token] = subtitle.tokenization!.tokens;
+        expect(subtitle.text.substring(token.pos[0], token.pos[1])).toBe('語');
+        assertSafeSink(token.readings[0].reading);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3583,7 +3583,7 @@ __metadata:
     ass-compiler: 0.1.1
     core-js: ^3.44.0
     dexie: ^4.0.11
-    dompurify: ^3.3.1
+    dompurify: ^3.4.12
     fast-xml-parser: ^4.0.7
     hotkeys-js: ^3.10.0
     i18next: ^22.4.14
@@ -6775,15 +6775,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "dompurify@npm:3.3.1"
+"dompurify@npm:^3.4.12":
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
   dependencies:
     "@types/trusted-types": ^2.0.7
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 884fe0acc21a9a2e5aa1b8ce4cecc8f9a71217423b389f760fca7b44595d3c9376d234f1c4ba16d79824789762b3d611d10653c4a90a7e23b351b71e5ef7dd33
+  checksum: 477e944e669bac9247c9ebfa55c7ea5c73f3cc6cd6b21ee72e306000e3e53d308e7bdaac89e655a0e2661de2ffbdd877e6a92537d07ba1d70c6c441fcef8c65c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes #1102

This strengthens the original fix in #905 by:
- Updating `DOMPurify` as the previous version had an `mXSS` vulnerability
- Strict allow list over the default `DOMPurify` config, asbplayer only needs presentation html, attributes such as `<img src>` could be used for tracking.
- Apply the sanitization as the final step after all parsing to prevent `mXSS` opportunities
- Added regression tests

The other source we should look at is the data from Yomitan (which mainly comes from the user's dictionaries). We do verify that the subtitle text remains the same after tokenization so the base text is safe, but the readings could exhibit the same issue. This is of course far less problematic than arbitrary subtitle files and may be fine implicitly trusting it so I left it out. We could easily reject any reading that contains html since that's obviously invalid.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex:GPT-5.6, Claude:Fable-5