### PR TITLE
Support condensed and fast-forward modes together

### DIFF
--- a/common/playback/controllers/playback-mode-controller.test.ts
+++ b/common/playback/controllers/playback-mode-controller.test.ts
@@ -39,6 +39,11 @@ const modeSelectionCases: ModeSelectionCase[] = [
         expected: [PlayMode.condensed, PlayMode.repeat],
     },
     {
+        name: 'condensed + fast-forward',
+        toggles: [PlayMode.condensed, PlayMode.fastForward],
+        expected: [PlayMode.condensed, PlayMode.fastForward],
+    },
+    {
         name: 'condensed + auto-pause + repeat',
         toggles: [PlayMode.condensed, PlayMode.autoPause, PlayMode.repeat],
         expected: [PlayMode.condensed, PlayMode.autoPause, PlayMode.repeat],
@@ -173,23 +178,23 @@ describe('playback mode selection', () => {
         ]);
     });
 
-    it('makes condensed and fast-forward mutually exclusive and reports the observable transition', () => {
+    it('allows condensed and fast-forward together and reports the observable transition', () => {
         const controller = controllerWithModes(PlayMode.fastForward, PlayMode.repeat);
 
         const transition = controller.transition(PlayMode.condensed);
 
-        expect(sortedModes(transition.modes)).toEqual([PlayMode.condensed, PlayMode.repeat]);
+        expect(sortedModes(transition.modes)).toEqual([PlayMode.condensed, PlayMode.fastForward, PlayMode.repeat]);
         expect(transition).toMatchObject({
             added: new Set([PlayMode.condensed]),
-            removed: new Set([PlayMode.fastForward]),
+            removed: new Set(),
         });
         expect(transition).not.toHaveProperty('resetPlaybackRate');
 
         const reverseTransition = controller.transition(PlayMode.fastForward);
-        expect(sortedModes(reverseTransition.modes)).toEqual([PlayMode.fastForward, PlayMode.repeat]);
+        expect(sortedModes(reverseTransition.modes)).toEqual([PlayMode.condensed, PlayMode.repeat]);
         expect(reverseTransition).toMatchObject({
-            added: new Set([PlayMode.fastForward]),
-            removed: new Set([PlayMode.condensed]),
+            added: new Set(),
+            removed: new Set([PlayMode.fastForward]),
         });
     });
 

--- a/common/playback/controllers/playback-mode-controller.ts
+++ b/common/playback/controllers/playback-mode-controller.ts
@@ -114,7 +114,6 @@ export default class PlaybackModeController {
         } else {
             this.modes.delete(PlayMode.normal);
             this.modes.add(targetMode);
-            this.resolveConflicts(targetMode);
         }
 
         const modes = this.playModes;
@@ -122,10 +121,5 @@ export default class PlaybackModeController {
             modes,
             ...modeChanges(oldModes, modes),
         };
-    }
-
-    private resolveConflicts(newMode: PlayMode): void {
-        if (newMode === PlayMode.condensed) this.modes.delete(PlayMode.fastForward);
-        if (newMode === PlayMode.fastForward) this.modes.delete(PlayMode.condensed);
     }
 }

--- a/common/playback/plan/playback-plan-executor.test.ts
+++ b/common/playback/plan/playback-plan-executor.test.ts
@@ -112,6 +112,14 @@ const playbackBehaviorCases: PlaybackBehaviorCase[] = [
         fastForward: false,
     },
     {
+        name: 'condensed + fast-forward',
+        modes: [PlayMode.condensed, PlayMode.fastForward],
+        autoPausePreference: AutoPausePreference.atEnd,
+        corrections: [],
+        seeks: [3999],
+        fastForward: true,
+    },
+    {
         name: 'fast-forward',
         modes: [PlayMode.fastForward],
         autoPausePreference: AutoPausePreference.atEnd,

--- a/common/playback/plan/playback-plan.test.ts
+++ b/common/playback/plan/playback-plan.test.ts
@@ -64,6 +64,13 @@ describe('buildPlaybackPlan', () => {
         expect(mode === PlayMode.condensed ? plan.condensed : plan.fastForward).toBeDefined();
     });
 
+    it('encodes condensed seeking and fast-forward rate changes together', () => {
+        const plan = makePlan([PlayMode.condensed, PlayMode.fastForward]);
+
+        expect(plan.condensed).toEqual({ minimumSkipIntervalMs: 500, pauseAtStart: false });
+        expect(plan.fastForward).toEqual({ playbackRate: 2.5, minimumSkipIntervalMs: 250 });
+    });
+
     it('swaps crossed playback mode offset roles for auto-pause and repeat', () => {
         const plan = makePlan([PlayMode.autoPause, PlayMode.repeat], {
             autoPausePreference: AutoPausePreference.atStartAndEnd,
@@ -201,6 +208,20 @@ describe('buildPlaybackPlan', () => {
         expect(rateAt(3999)).toBe(1.25);
         expect(rateAt(4500)).toBe(1.25);
         expect(rateAt(5000)).toBe(2.5);
+    });
+
+    it('retains both condensed and fast-forward timeline state in the same gap', () => {
+        const plan = makePlan([PlayMode.condensed, PlayMode.fastForward], {
+            subtitles: [
+                makeSubtitle(),
+                makeSubtitle({ start: 4000, end: 5000, originalStart: 4000, originalEnd: 5000, index: 1 }),
+            ],
+        });
+        const timeline = PlaybackTimeline.fromSubtitles(plan.timelineSubtitles);
+        const lookup = timeline.lookupAt(2100);
+
+        expect(lookup.segment.condensedTarget).toBe(3999);
+        expect(fastForwardingForPlanState(plan, lookup.state)).toBe(true);
     });
 
     it('keeps an entire subminimum subtitle gap at the normal rate', () => {

--- a/common/playback/timeline/playback-timeline-html.test.ts
+++ b/common/playback/timeline/playback-timeline-html.test.ts
@@ -296,7 +296,7 @@ describe('playbackTimelineToHtml', () => {
         expect(document.querySelector('.event.autoPause-start')?.getAttribute('style')).toContain('left:15%');
     });
 
-    it('keeps normal subtitles visible while making normal and other modes mutually exclusive', () => {
+    it('keeps normal subtitles visible while allowing fast-forward and condensed modes together', () => {
         const html = playbackTimelineToHtml({
             plan: plan([makeTextSubtitle(1000, 2000, 'one', 0)]),
             themeColor: '#123456',
@@ -312,8 +312,10 @@ describe('playbackTimelineToHtml', () => {
         window.eval(scriptText ?? '');
         const normalCheckbox = document.querySelector<HTMLInputElement>('input[data-mode="normal"]');
         const fastForwardCheckbox = document.querySelector<HTMLInputElement>('input[data-mode="fast-forward"]');
+        const condensedCheckbox = document.querySelector<HTMLInputElement>('input[data-mode="condensed"]');
         expect(normalCheckbox?.checked).toBe(true);
         expect(fastForwardCheckbox?.checked).toBe(false);
+        expect(condensedCheckbox?.checked).toBe(false);
 
         fastForwardCheckbox!.checked = true;
         fastForwardCheckbox!.dispatchEvent(new Event('change', { bubbles: true }));
@@ -321,10 +323,17 @@ describe('playbackTimelineToHtml', () => {
         expect(document.body.classList).not.toContain('hide-normal');
         expect(document.querySelector('.event.normal')).not.toBeNull();
 
+        condensedCheckbox!.checked = true;
+        condensedCheckbox!.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(fastForwardCheckbox?.checked).toBe(true);
+        expect(condensedCheckbox?.checked).toBe(true);
+
         normalCheckbox!.checked = true;
         normalCheckbox!.dispatchEvent(new Event('change', { bubbles: true }));
         expect(fastForwardCheckbox?.checked).toBe(false);
+        expect(condensedCheckbox?.checked).toBe(false);
         expect(document.body.classList).toContain('hide-fast-forward');
+        expect(document.body.classList).toContain('hide-condensed');
 
         normalCheckbox!.checked = false;
         normalCheckbox!.dispatchEvent(new Event('change', { bubbles: true }));

--- a/common/playback/timeline/playback-timeline-html.ts
+++ b/common/playback/timeline/playback-timeline-html.ts
@@ -729,14 +729,6 @@ document.querySelectorAll('input[data-mode]').forEach((checkbox) => {
             if (normalCheckbox) normalCheckbox.checked = false;
         }
 
-        if (mode === 'fast-forward' || mode === 'condensed') {
-            const otherMode = mode === 'fast-forward' ? 'condensed' : 'fast-forward';
-            const otherCheckbox = document.querySelector('input[data-mode="' + otherMode + '"]');
-            if (checkbox.checked && otherCheckbox) {
-                otherCheckbox.checked = false;
-                document.body.classList.add('hide-' + otherMode);
-            }
-        }
         document.body.classList.toggle('hide-' + mode, !checkbox.checked);
         if (!checkbox.checked) {
             const normalCheckbox = document.querySelector('input[data-mode="normal"]');


### PR DESCRIPTION
`PlaybackEngine` already supports this, we just need to allow it in the UI. The main reason for doing this is that there is no reason not do it. Even if the value is small, there is still some cases where it can benefit:
- Can set fast foward minimum to be lower than condensed, e.g 500ms while condensed triggers with 10s+ gaps
  - This means `0-500ms` gaps are normal playback, `500ms-10s` are fast forwarded, and `10s+` are skipped
- After the last subtitle appears, the rest of the media is fastforwarded
- We could optimize by preventing setting the playback rate if we are going to condensed seek, but it doesn't feel like an issue so I didn't

- [X] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex:GPT-5.6