### PR TITLE
Use `timeupdate` instead of `rVFC` for audio only

### DIFF
--- a/common/app/components/VideoPlayer.tsx
+++ b/common/app/components/VideoPlayer.tsx
@@ -607,6 +607,10 @@ export default function VideoPlayer({
                     playbackRate: () => video.playbackRate,
                     durationMs: () => video.duration * 1000,
                     currentTimeMs: () => video.currentTime * 1000,
+                    hasVideoTrack: () =>
+                        video.readyState >= HTMLMediaElement.HAVE_METADATA &&
+                        video.videoWidth > 0 &&
+                        video.videoHeight > 0,
                     frameTimestampMs: () => undefined,
                     externalSeekEvents: false,
                     requestVideoFrameCallback: (callback) => video.requestVideoFrameCallback(callback),

--- a/common/playback/timing/video-frame-timing-driver.test.ts
+++ b/common/playback/timing/video-frame-timing-driver.test.ts
@@ -13,11 +13,14 @@ class FakeVideo extends EventTarget {
     currentTime = 0;
     playbackRate = 1;
     paused = true;
+    hasVideoTrack = true;
+    requestVideoFrameCallbackCalls = 0;
     private nextHandle = 1;
     private callbacks = new Map<number, VideoFrameRequestCallback>();
     private presentedFrameCount = 0;
 
     requestVideoFrameCallback(callback: VideoFrameRequestCallback): number {
+        this.requestVideoFrameCallbackCalls++;
         const handle = this.nextHandle++;
         this.callbacks.set(handle, callback);
         return handle;
@@ -88,6 +91,7 @@ const videoSource = (video: FakeVideo, currentTimeMs = () => video.currentTime *
     playbackRate: () => video.playbackRate,
     durationMs: () => 120_000,
     currentTimeMs,
+    hasVideoTrack: () => video.hasVideoTrack,
     frameTimestampMs: () => undefined,
     externalSeekEvents: false,
     requestVideoFrameCallback: (callback) => video.requestVideoFrameCallback(callback),
@@ -958,6 +962,98 @@ describe('VideoFrameTimingDriver', () => {
         await flush();
 
         expect(updates).toEqual([250, 250]);
+        driver.unbind();
+    });
+
+    it('uses timeupdate for audio-only media and switches to video frame callbacks after metadata changes', async () => {
+        const video = new FakeVideo();
+        video.hasVideoTrack = false;
+        const updates: number[] = [];
+        const driver = timingDriver(videoSource(video), {
+            onTime: async (timestampMs) => {
+                updates.push(timestampMs);
+            },
+            onDiscontinuity: () => {},
+        });
+
+        driver.bind();
+        video.play();
+        video.currentTime = 0.25;
+        video.dispatchEvent(new Event('timeupdate'));
+        await flush();
+
+        expect(updates).toEqual([250]);
+        expect(video.requestVideoFrameCallbackCalls).toBe(0);
+
+        video.hasVideoTrack = true;
+        video.dispatchEvent(new Event('loadedmetadata'));
+        video.currentTime = 0.5;
+        video.dispatchEvent(new Event('timeupdate'));
+        await flush();
+
+        expect(updates).toEqual([250]);
+        video.present(500);
+        await flush();
+
+        expect(updates).toEqual([250, 500]);
+        expect(video.requestVideoFrameCallbackCalls).toBeGreaterThan(0);
+        driver.unbind();
+    });
+
+    it('reevaluates the video track after binding, visibility, and media metadata changes', () => {
+        const video = new FakeVideo();
+        let hasVideoTrackCalls = 0;
+        const source = {
+            ...videoSource(video),
+            hasVideoTrack: () => {
+                hasVideoTrackCalls++;
+                return video.hasVideoTrack;
+            },
+        };
+        const driver = timingDriver(source, {});
+
+        expect(hasVideoTrackCalls).toBe(0);
+        driver.bind();
+        expect(hasVideoTrackCalls).toBe(1);
+
+        document.dispatchEvent(new Event('visibilitychange'));
+        video.dispatchEvent(new Event('timeupdate'));
+        expect(hasVideoTrackCalls).toBe(2);
+
+        video.dispatchEvent(new Event('loadedmetadata'));
+        video.dispatchEvent(new Event('resize'));
+        video.dispatchEvent(new Event('emptied'));
+        expect(hasVideoTrackCalls).toBe(5);
+
+        driver.unbind();
+        video.dispatchEvent(new Event('loadedmetadata'));
+        expect(hasVideoTrackCalls).toBe(5);
+    });
+
+    it('cancels a pending video frame callback when the video track disappears', async () => {
+        const video = new FakeVideo();
+        const updates: number[] = [];
+        const driver = timingDriver(videoSource(video), {
+            onTime: async (timestampMs) => {
+                updates.push(timestampMs);
+            },
+            onDiscontinuity: () => {},
+        });
+
+        driver.bind();
+        video.play();
+        expect(video.requestVideoFrameCallbackCalls).toBe(1);
+
+        video.hasVideoTrack = false;
+        video.dispatchEvent(new Event('resize'));
+        video.currentTime = 0.25;
+        video.dispatchEvent(new Event('timeupdate'));
+        await flush();
+
+        expect(updates).toEqual([250]);
+        video.present(500);
+        await flush();
+        expect(updates).toEqual([250]);
         driver.unbind();
     });
 

--- a/common/playback/timing/video-frame-timing-driver.ts
+++ b/common/playback/timing/video-frame-timing-driver.ts
@@ -6,12 +6,26 @@ import TimingUpdateQueue, {
 } from '@project/common/playback/timing/timing-driver';
 
 const defaultFrameTimeMs = 1000 / 60;
+type VideoFrameTimingEvent =
+    | 'play'
+    | 'pause'
+    | 'seeking'
+    | 'seeked'
+    | 'timeupdate'
+    | 'ratechange'
+    | 'durationchange'
+    | 'loadedmetadata'
+    | 'resize'
+    | 'emptied'
+    | 'error';
 
 export interface VideoFrameTimingSource {
     readonly paused: () => boolean;
     readonly playbackRate: () => number;
     readonly durationMs: () => number;
     readonly currentTimeMs: () => number;
+    /** Whether the loaded media resource has a video track (e.g., an audio-only element). */
+    readonly hasVideoTrack: () => boolean;
     /** Overrides requestVideoFrameCallback metadata when the media element does not expose content time. */
     readonly frameTimestampMs: (now: number, metadata: VideoFrameCallbackMetadata) => number | undefined;
     /** Uses owner-supplied seek lifecycle events instead of native seeking/seeked events. */
@@ -19,14 +33,8 @@ export interface VideoFrameTimingSource {
     /** ~0.05ms for the hot path (no state changes/actions) and <1ms otherwise per frame */
     requestVideoFrameCallback(callback: VideoFrameRequestCallback): number;
     cancelVideoFrameCallback(handle: number): void;
-    addEventListener(
-        type: 'play' | 'pause' | 'seeking' | 'seeked' | 'timeupdate' | 'ratechange' | 'durationchange' | 'error',
-        listener: EventListener
-    ): void;
-    removeEventListener(
-        type: 'play' | 'pause' | 'seeking' | 'seeked' | 'timeupdate' | 'ratechange' | 'durationchange' | 'error',
-        listener: EventListener
-    ): void;
+    addEventListener(type: VideoFrameTimingEvent, listener: EventListener): void;
+    removeEventListener(type: VideoFrameTimingEvent, listener: EventListener): void;
 }
 
 /**
@@ -163,10 +171,13 @@ export default class VideoFrameTimingDriver implements TimingDriver {
         }
         this.video.addEventListener('ratechange', this.onRateChange);
         this.video.addEventListener('durationchange', this.onDurationChange);
+        this.video.addEventListener('loadedmetadata', this.onMetadataChange);
+        this.video.addEventListener('resize', this.onMetadataChange);
+        this.video.addEventListener('emptied', this.onMetadataChange);
         this.video.addEventListener('error', this.onError);
-        document.addEventListener('visibilitychange', this.onVisibilityChange);
+        document.addEventListener('visibilitychange', this.onMetadataChange);
         this.reset();
-        this.onVisibilityChange();
+        this.onMetadataChange();
     }
 
     get bound(): boolean {
@@ -184,10 +195,13 @@ export default class VideoFrameTimingDriver implements TimingDriver {
         }
         this.video.removeEventListener('ratechange', this.onRateChange);
         this.video.removeEventListener('durationchange', this.onDurationChange);
+        this.video.removeEventListener('loadedmetadata', this.onMetadataChange);
+        this.video.removeEventListener('resize', this.onMetadataChange);
+        this.video.removeEventListener('emptied', this.onMetadataChange);
         this.video.removeEventListener('error', this.onError);
         if (this.timeUpdatesBound) this.video.removeEventListener('timeupdate', this.onTimeUpdate);
         this.timeUpdatesBound = false;
-        document.removeEventListener('visibilitychange', this.onVisibilityChange);
+        document.removeEventListener('visibilitychange', this.onMetadataChange);
         this.cancelScheduledUpdate();
         this.updates.clear({ preserveExpectedDiscontinuity: false });
         this.previousFrame = undefined;
@@ -234,10 +248,11 @@ export default class VideoFrameTimingDriver implements TimingDriver {
 
     /**
      * Browsers will no longer fire rVFC events when the document is hidden but continue playing audio.
-     * To work around this, we listen for 'timeupdate' events while the document is hidden to keep the timing driver updated.
+     * Audio-only media also has no video frames, even though rVFC is defined on the element.
+     * To work around both cases, listen for 'timeupdate' events whenever there is no usable video frame source.
      */
-    private readonly onVisibilityChange = () => {
-        if (document.hidden) {
+    private readonly onMetadataChange = () => {
+        if (document.hidden || !this.video.hasVideoTrack()) {
             this.cancelScheduledUpdate();
             this.previousFrame = undefined;
             if (this.timeUpdatesBound) return;
@@ -284,7 +299,7 @@ export default class VideoFrameTimingDriver implements TimingDriver {
 
     private schedule(): void {
         if (!this.shouldProcess()) return;
-        if (document.hidden) return; // Browser will not fire rVFC events when hidden, see onVisibilityChange
+        if (this.timeUpdatesBound) return;
         if (this.frameHandle !== undefined) return;
 
         this.frameHandle = this.video.requestVideoFrameCallback((now, metadata) => {

--- a/extension/src/services/binding.test.ts
+++ b/extension/src/services/binding.test.ts
@@ -104,7 +104,7 @@ describe('Binding playback mode integration', () => {
 
     type FrameTestVideo = HTMLVideoElement & { presentFrame(timestampMs: number): void };
 
-    const createVideo = (): FrameTestVideo => {
+    const createVideo = ({ width = 1920, height = 1080 }: { width?: number; height?: number } = {}): FrameTestVideo => {
         const video = document.createElement('video') as FrameTestVideo;
         let nextFrameHandle = 1;
         const frameCallbacks = new Map<number, VideoFrameRequestCallback>();
@@ -112,6 +112,8 @@ describe('Binding playback mode integration', () => {
         Object.defineProperties(video, {
             readyState: { configurable: true, value: 4 },
             duration: { configurable: true, value: 120 },
+            videoWidth: { configurable: true, value: width },
+            videoHeight: { configurable: true, value: height },
             paused: { configurable: true, value: false, writable: true },
             requestVideoFrameCallback: {
                 configurable: true,
@@ -244,6 +246,21 @@ describe('Binding playback mode integration', () => {
         await jest.advanceTimersByTimeAsync(100);
         expect(video.playbackRate).toBe(1.5);
 
+        binding.unbind();
+    });
+
+    it('uses timeupdate for audio-only media', async () => {
+        const video = createVideo({ width: 0, height: 0 });
+        const binding = new Binding(video, false);
+        binding.bind();
+        await jest.advanceTimersByTimeAsync(0);
+        sendSubtitles(binding, [makeSubtitle({ start: 1000, end: 2000 })]);
+
+        video.currentTime = 1.5;
+        video.dispatchEvent(new Event('timeupdate'));
+        await flushPlaybackTiming();
+
+        expect(binding.subtitleController.currentSubtitle()[0]?.text).toBe('subtitle');
         binding.unbind();
     });
 

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -387,6 +387,10 @@ export default class Binding {
                     playbackRate: () => this.video.playbackRate,
                     durationMs: () => this.video.duration * 1000,
                     currentTimeMs: () => this.currentTimeMs,
+                    hasVideoTrack: () =>
+                        video.readyState >= HTMLMediaElement.HAVE_METADATA &&
+                        video.videoWidth > 0 &&
+                        video.videoHeight > 0,
                     frameTimestampMs: disneyPlus ? (now) => this._disneyPlusTimeAt(now) : () => undefined,
                     externalSeekEvents: disneyPlus,
                     requestVideoFrameCallback: (callback) => video.requestVideoFrameCallback(callback),


### PR DESCRIPTION
This fixes the issue reported in discord where the new `PlaybackEngine` doesn't update correctly with audio only files. The detection uses the video resolution, but what we want to know (and what rVFC uses) is whether the browser will be rendering a frame. This seems to be the closest check for that.

I originally meant to test this when I decided on rVFC but forgot it and didn't put it in my notes.

- [X] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6
