### PR TITLE
jellyfin/emby treat same url video as new

### DIFF
--- a/extension/src/controllers/subtitle-controller.ts
+++ b/extension/src/controllers/subtitle-controller.ts
@@ -169,8 +169,15 @@ export default class SubtitleController {
     reset() {
         this.subtitles = [];
         this.subtitleFileNames = undefined;
+        this.timelineShowingSubtitles = [];
+        this.showingSubtitles = undefined;
+        this.showingLoadedMessage = false;
+        if (this.loadedMessageHideTimeout) clearTimeout(this.loadedMessageHideTimeout);
+        this.loadedMessageHideTimeout = undefined;
         this.cacheHtml();
         this.subtitleAnnotations.reset();
+        this.bottomSubtitlesElementOverlay.hide();
+        this.topSubtitlesElementOverlay.hide();
     }
 
     cacheHtml() {

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -52,6 +52,10 @@ interface ShowOptions {
     fromAsbplayerId?: string;
 }
 
+interface RequestSubtitlesOptions {
+    readonly videoChanged: boolean;
+}
+
 const fetchDataForLanguageOnDemand = (language: string): Promise<VideoData> => {
     return new Promise((resolve) => {
         const listener = (event: Event) => {
@@ -150,16 +154,18 @@ export default class VideoDataSyncController {
         return this._openedLocation;
     }
 
-    async requestSubtitles() {
+    async requestSubtitles({ videoChanged }: RequestSubtitlesOptions) {
         if (!this._context.hasPageScript) {
             return;
         }
 
         // While the picker is open on the same location, skip refresh so
         // player events do not clobber an in-progress user selection. On a
-        // true soft-navigation, dismiss the stale picker and continue.
+        // true soft-navigation or an explicitly reported video change,
+        // dismiss the stale picker and continue.
         if (this.pickerVisible) {
-            if (this.openedLocation !== undefined && window.location.href !== this.openedLocation) {
+            const locationChanged = this.openedLocation !== undefined && window.location.href !== this.openedLocation;
+            if (locationChanged || videoChanged) {
                 this._hideAndResume();
             } else {
                 return;

--- a/extension/src/entrypoints/video.content/index.ts
+++ b/extension/src/entrypoints/video.content/index.ts
@@ -138,7 +138,11 @@ export default defineContentScript({
                         hasValidVideoSource(videoElement, page) &&
                         !page?.shouldIgnore(videoElement)
                     ) {
-                        const b = new Binding(videoElement, hasPageScript, frameInfoBroadcaster?.frameId);
+                        const b = new Binding(videoElement, {
+                            hasPageScript,
+                            frameId: frameInfoBroadcaster?.frameId,
+                            videoSrcChangesIndicateNewVideo: page?.config.videoSrcChangesIndicateNewVideo ?? false,
+                        });
                         b.bind();
                         bindings.push(b);
                     }

--- a/extension/src/pages.json
+++ b/extension/src/pages.json
@@ -126,6 +126,7 @@
             "key": "embyJellyfin",
             "host": "(jellyfin.*)|(emby.*)|(:8096$)",
             "pageScript": "emby-jellyfin-page.js",
+            "videoSrcChangesIndicateNewVideo": true,
             "syncAllowedAtHash": "#!/videoosd/videoosd.html|#/video",
             "autoSync": {
                 "enabled": true

--- a/extension/src/services/binding.test.ts
+++ b/extension/src/services/binding.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { AutoPausePreference, PlayMode, type IndexedSubtitleModel } from '@project/common';
-import Binding from './binding';
+import Binding, { type BindingOptions } from './binding';
 import { MockStorageArea } from './mock-storage-area';
+
+const bindingOptions = (hasPageScript: boolean, videoSrcChangesIndicateNewVideo: boolean): BindingOptions => ({
+    hasPageScript,
+    videoSrcChangesIndicateNewVideo,
+});
 
 let mockPlaybackModeOverlayShows = 0;
 
@@ -44,6 +49,7 @@ jest.mock('../controllers/mobile-video-overlay-controller', () => ({
     MobileVideoOverlayController: class MobileVideoOverlayController {
         bind() {}
         unbind() {}
+        disposeOverlay() {}
         setPlaybackModes() {}
         show() {}
         showPlaybackModes() {
@@ -222,7 +228,7 @@ describe('Binding playback mode integration', () => {
 
     it('applies playback modes through real video timing without overwriting the inactive rate', async () => {
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
         sendSubtitles(binding, [
@@ -251,7 +257,7 @@ describe('Binding playback mode integration', () => {
 
     it('uses timeupdate for audio-only media', async () => {
         const video = createVideo({ width: 0, height: 0 });
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
         sendSubtitles(binding, [makeSubtitle({ start: 1000, end: 2000 })]);
@@ -264,9 +270,72 @@ describe('Binding playback mode integration', () => {
         binding.unbind();
     });
 
+    it('ignores same-source metadata events after subtitles are synced', async () => {
+        const video = createVideo();
+        const binding = new Binding(video, bindingOptions(true, false));
+        binding.bind();
+        await jest.advanceTimersByTimeAsync(0);
+        sendSubtitles(binding, [makeSubtitle()]);
+
+        const requestSubtitles = jest.spyOn(binding.videoDataSyncController, 'requestSubtitles');
+        const resetSubtitles = jest.spyOn(binding as any, '_resetSubtitles');
+
+        video.dispatchEvent(new Event('loadedmetadata'));
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(requestSubtitles).not.toHaveBeenCalled();
+        expect(resetSubtitles).not.toHaveBeenCalled();
+        binding.unbind();
+    });
+
+    it('refreshes subtitles when a configured page changes source without changing location', async () => {
+        const video = createVideo();
+        const binding = new Binding(video, bindingOptions(true, true));
+        binding.bind();
+        await jest.advanceTimersByTimeAsync(0);
+        sendSubtitles(binding, [makeSubtitle()]);
+        await jest.advanceTimersByTimeAsync(1100);
+        video.presentFrame(0);
+        await flushPlaybackTiming();
+        expect(displayedSubtitleTexts()).toContain('subtitle');
+
+        const requestSubtitles = jest.spyOn(binding.videoDataSyncController, 'requestSubtitles');
+        const resetSubtitles = jest.spyOn(binding as any, '_resetSubtitles');
+
+        video.src = 'https://example.com/episode-2.mp4';
+        // The heartbeat may update _registeredVideoSrc before loadedmetadata.
+        await jest.advanceTimersByTimeAsync(1000);
+        video.dispatchEvent(new Event('loadedmetadata'));
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(requestSubtitles).toHaveBeenCalledWith({ videoChanged: true });
+        expect(resetSubtitles).toHaveBeenCalledTimes(1);
+        expect(displayedSubtitleTexts()).toEqual([]);
+        binding.unbind();
+    });
+
+    it('keeps same-location source changes suppressed for pages without the opt-in', async () => {
+        const video = createVideo();
+        const binding = new Binding(video, bindingOptions(true, false));
+        binding.bind();
+        await jest.advanceTimersByTimeAsync(0);
+        sendSubtitles(binding, [makeSubtitle()]);
+
+        const requestSubtitles = jest.spyOn(binding.videoDataSyncController, 'requestSubtitles');
+        const resetSubtitles = jest.spyOn(binding as any, '_resetSubtitles');
+
+        video.src = 'https://example.com/rotated-stream.mp4';
+        video.dispatchEvent(new Event('loadedmetadata'));
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(requestSubtitles).not.toHaveBeenCalled();
+        expect(resetSubtitles).not.toHaveBeenCalled();
+        binding.unbind();
+    });
+
     it('does not persist empty subtitle track filenames as playback-position keys', async () => {
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
         sendSubtitles(binding, [makeSubtitle()], ['subtitle.srt', 'Empty.srt']);
@@ -282,7 +351,7 @@ describe('Binding playback mode integration', () => {
 
     it('receives play-mode intents and publishes authoritative mode state', async () => {
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
         sendSubtitles(binding, [makeSubtitle()]);
@@ -304,7 +373,7 @@ describe('Binding playback mode integration', () => {
 
     it('publishes compiled subtitle visibility changes from presented video frames', async () => {
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
         sendSubtitles(binding, [makeSubtitle({ start: 1000, end: 2000 })]);
@@ -324,7 +393,7 @@ describe('Binding playback mode integration', () => {
     it('reconciles subtitle visibility on a user seek without firing auto-pause actions', async () => {
         await storage.set({ autoPausePreference: AutoPausePreference.atStartAndEnd });
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         const pause = jest.spyOn(binding, 'pause').mockImplementation(() => {});
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
@@ -347,7 +416,7 @@ describe('Binding playback mode integration', () => {
 
     it('shifts visible subtitle state immediately when the offset changes while paused', async () => {
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
         sendSubtitles(binding, [makeSubtitle({ start: 1000, end: 2000, originalStart: 1000, originalEnd: 2000 })]);
@@ -371,7 +440,7 @@ describe('Binding playback mode integration', () => {
             subtitleTriggerEndOffset: 400,
         });
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         const pause = jest.spyOn(binding, 'pause').mockImplementation(() => {});
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
@@ -392,7 +461,7 @@ describe('Binding playback mode integration', () => {
     it('applies an initially loaded subtitle offset to playback timing', async () => {
         await storage.set({ autoPausePreference: AutoPausePreference.atStart });
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         const pause = jest.spyOn(binding, 'pause').mockImplementation(() => {});
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
@@ -425,7 +494,7 @@ describe('Binding playback mode integration', () => {
             repeatCountPreference: 1,
         });
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
         sendSubtitles(binding, [makeSubtitle({ start: 1000, end: 2000 })]);
@@ -454,7 +523,7 @@ describe('Binding playback mode integration', () => {
         };
         document.addEventListener('asbplayer-netflix-seek', onNetflixSeek);
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
 
         try {
             binding.bind();
@@ -480,7 +549,7 @@ describe('Binding playback mode integration', () => {
 
     it('resolves a Netflix play request when the owner is already playing', async () => {
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         const onPlay = () => {
             Object.defineProperty(video, 'paused', { configurable: true, value: false, writable: true });
         };
@@ -498,7 +567,7 @@ describe('Binding playback mode integration', () => {
     it('cancels an unavailable Netflix seek without persisting its target and continues timing', async () => {
         document.dispatchEvent(new CustomEvent('asbplayer-netflix-enabled', { detail: true }));
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         const netflixSeeks: number[] = [];
         const onNetflixSeek = (event: Event) => {
             netflixSeeks.push((event as CustomEvent<number>).detail);
@@ -535,7 +604,7 @@ describe('Binding playback mode integration', () => {
             subtitleTriggerGapStartOffset: 400,
         });
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         const play = jest.spyOn(binding, 'play').mockResolvedValue(undefined);
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
@@ -557,7 +626,7 @@ describe('Binding playback mode integration', () => {
 
     it('uses normal playback while recording', async () => {
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         const pause = jest.spyOn(binding, 'pause').mockImplementation(() => {});
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
@@ -602,7 +671,7 @@ describe('Binding playback mode integration', () => {
             seekableTracks: 1,
         });
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         const pause = jest.spyOn(binding, 'pause').mockImplementation(() => {});
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
@@ -634,7 +703,7 @@ describe('Binding playback mode integration', () => {
 
     it('keeps active modes for non-empty subtitles and resets them when subtitles are cleared', async () => {
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
 
         sendSubtitles(binding, [makeSubtitle({ start: 1000, end: 2000 })]);
@@ -658,7 +727,7 @@ describe('Binding playback mode integration', () => {
             rememberPlaybackModes: true,
             lastPlaybackModes: [PlayMode.fastForward, PlayMode.repeat],
         });
-        const binding = new Binding(createVideo(), false);
+        const binding = new Binding(createVideo(), bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
 
@@ -684,7 +753,7 @@ describe('Binding playback mode integration', () => {
             rememberPlaybackModes: true,
             lastPlaybackModes: [PlayMode.normal],
         });
-        const binding = new Binding(createVideo(), false);
+        const binding = new Binding(createVideo(), bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
 
@@ -711,7 +780,7 @@ describe('Binding playback mode integration', () => {
                 lastPlaybackModes: [PlayMode.fastForward],
             });
             const video = createVideo();
-            const binding = new Binding(video, false);
+            const binding = new Binding(video, bindingOptions(false, false));
 
             binding.bind();
             await jest.advanceTimersByTimeAsync(0);
@@ -747,7 +816,7 @@ describe('Binding playback mode integration', () => {
 
     it('applies the latest incoming playback rate', async () => {
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
 
@@ -765,7 +834,7 @@ describe('Binding playback mode integration', () => {
     ])('honors the playback-rate notification setting when $name', async ({ enabled, expectedNotifications }) => {
         await storage.set({ playbackRateNotificationEnabled: enabled });
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
         sendSubtitles(binding, [makeSubtitle()]);
@@ -781,7 +850,7 @@ describe('Binding playback mode integration', () => {
     it('notifies once when a keybind changes the playback rate', async () => {
         await storage.set({ playbackRateNotificationEnabled: true });
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
         sendSubtitles(binding, [makeSubtitle()]);
@@ -801,7 +870,7 @@ describe('Binding playback mode integration', () => {
     it('uses the fast-forward playback-rate localization key when a keybind changes the active rate', async () => {
         await storage.set({ playbackRateNotificationEnabled: true });
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
         sendSubtitles(binding, [
@@ -825,7 +894,7 @@ describe('Binding playback mode integration', () => {
     it('applies the configured playback rate after settings load', async () => {
         await storage.set({ playbackRate: 1.4 });
         const video = createVideo();
-        const binding = new Binding(video, false);
+        const binding = new Binding(video, bindingOptions(false, false));
 
         binding.bind();
         await jest.advanceTimersByTimeAsync(0);
@@ -844,7 +913,7 @@ describe('Binding playback mode integration', () => {
         async ({ rememberPlaybackRate }) => {
             await storage.set({ playbackRate: 1.1, rememberPlaybackRate });
             const video = createVideo();
-            const binding = new Binding(video, false);
+            const binding = new Binding(video, bindingOptions(false, false));
             binding.bind();
             await jest.advanceTimersByTimeAsync(0);
 

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -152,6 +152,12 @@ const startAudioRecordingErrorResponse: (e: any) => StartRecordingResponse = (e:
     return errorResponse;
 };
 
+export interface BindingOptions {
+    readonly hasPageScript: boolean;
+    readonly frameId?: string;
+    readonly videoSrcChangesIndicateNewVideo: boolean;
+}
+
 export default class Binding {
     private readonly _fallbackVideoSrc = uuidv4();
 
@@ -163,6 +169,8 @@ export default class Binding {
     private _synced: boolean;
     private _syncedTimestamp?: number;
     private _lastSyncedLocation?: string;
+    private _lastLoadedMetadataVideoSrc: string;
+    private readonly _videoSrcChangesIndicateNewVideo: boolean;
 
     private _recordingState: RecordingState = RecordingState.notRecording;
     recordingPostMineAction?: PostMineAction;
@@ -237,10 +245,12 @@ export default class Binding {
 
     private readonly frameId?: string;
 
-    constructor(video: HTMLMediaElement, hasPageScript: boolean, frameId?: string) {
+    constructor(video: HTMLMediaElement, options: BindingOptions) {
         this.video = video;
         this._registeredVideoSrc = video.src || this._fallbackVideoSrc;
-        this.hasPageScript = hasPageScript;
+        this._lastLoadedMetadataVideoSrc = this._registeredVideoSrc;
+        this.hasPageScript = options.hasPageScript;
+        this._videoSrcChangesIndicateNewVideo = options.videoSrcChangesIndicateNewVideo;
         this.dictionary = new DictionaryProvider(new ExtensionDictionaryStorage());
         this.settings = new SettingsProvider(new ExtensionSettingsStorage());
         this.subtitleController = new SubtitleController(this, this.dictionary, this.settings);
@@ -273,7 +283,7 @@ export default class Binding {
         this.postMinePlayback = PostMinePlayback.remember;
         this._synced = false;
         this.recordingMediaWithScreenshot = false;
-        this.frameId = frameId;
+        this.frameId = options.frameId;
     }
 
     get registeredVideoSrc() {
@@ -548,7 +558,7 @@ export default class Binding {
         this._notifyReady();
         this._subscribe();
         void this._refreshSettings().then(() => {
-            void this.videoDataSyncController.requestSubtitles();
+            void this.videoDataSyncController.requestSubtitles({ videoChanged: false });
         });
         this.subtitleController.bind();
         this.playbackEngine.bind();
@@ -696,30 +706,39 @@ export default class Binding {
         this.subtitleController.onMouseOut = (mouseEvent: MouseEvent) => this.hoveredToken.handleMouseOut(mouseEvent);
 
         if (this.hasPageScript) {
+            let forceRefreshForSameLocation = false;
             const debouncedChangeListener = debounced(
                 () => {
-                    void this.videoDataSyncController.requestSubtitles();
+                    const videoChanged = forceRefreshForSameLocation;
+                    forceRefreshForSameLocation = false;
+                    void this.videoDataSyncController.requestSubtitles({ videoChanged });
                     this._resetSubtitles();
                 },
                 disneyPlus ? 1000 : 0
             );
             this.videoChangeListener = () => {
-                this._updateRegisteredVideoSrc(this.video.src || this._fallbackVideoSrc);
+                const videoSrc = this.video.src || this._fallbackVideoSrc;
+                const sourceChanged = videoSrc !== this._lastLoadedMetadataVideoSrc;
+                this._lastLoadedMetadataVideoSrc = videoSrc;
+                this._updateRegisteredVideoSrc(videoSrc);
+                const sameLocationVideoChanged = this._videoSrcChangesIndicateNewVideo && sourceChanged;
 
                 // Player events (e.g. Hulu blob URL rotation) can fire loadedmetadata
                 // without an actual video change. Skip refresh when the picker is open
                 // here or subtitles are already synced for it.
                 if (
                     this.videoDataSyncController.pickerVisible &&
-                    this.videoDataSyncController.openedLocation === window.location.href
+                    this.videoDataSyncController.openedLocation === window.location.href &&
+                    !sameLocationVideoChanged
                 ) {
                     return;
                 }
 
-                if (this._synced && this._lastSyncedLocation === window.location.href) {
+                if (this._synced && this._lastSyncedLocation === window.location.href && !sameLocationVideoChanged) {
                     return;
                 }
 
+                forceRefreshForSameLocation ||= sameLocationVideoChanged;
                 debouncedChangeListener();
                 if (disneyPlus) this.disneyPlusClock.reset();
             };
@@ -1833,6 +1852,7 @@ export default class Binding {
     private _resetSubtitles() {
         this.subtitleController.reset();
         this.playbackEngine.playbackPositionKeysChanged([]);
+        this.playbackEngine.subtitlesChanged([]);
         this.ankiUiSavedState = undefined;
         this._synced = false;
         this._syncedTimestamp = undefined;

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -706,11 +706,8 @@ export default class Binding {
         this.subtitleController.onMouseOut = (mouseEvent: MouseEvent) => this.hoveredToken.handleMouseOut(mouseEvent);
 
         if (this.hasPageScript) {
-            let forceRefreshForSameLocation = false;
             const debouncedChangeListener = debounced(
-                () => {
-                    const videoChanged = forceRefreshForSameLocation;
-                    forceRefreshForSameLocation = false;
+                (videoChanged: boolean) => {
                     void this.videoDataSyncController.requestSubtitles({ videoChanged });
                     this._resetSubtitles();
                 },
@@ -738,8 +735,7 @@ export default class Binding {
                     return;
                 }
 
-                forceRefreshForSameLocation ||= sameLocationVideoChanged;
-                debouncedChangeListener();
+                debouncedChangeListener(sameLocationVideoChanged);
                 if (disneyPlus) this.disneyPlusClock.reset();
             };
             this.video.addEventListener('loadedmetadata', this.videoChangeListener);

--- a/extension/src/services/debounced.ts
+++ b/extension/src/services/debounced.ts
@@ -1,16 +1,16 @@
-export const debounced = (callback: () => void, delayMs: number) => {
+export const debounced = <Args extends unknown[]>(callback: (...args: Args) => void, delayMs: number) => {
     if (delayMs <= 0) {
         return callback;
     }
 
     let timeout: ReturnType<typeof setTimeout> | undefined;
 
-    return () => {
+    return (...args: Args) => {
         if (timeout !== undefined) {
             clearTimeout(timeout);
         }
         timeout = setTimeout(() => {
-            callback();
+            callback(...args);
             timeout = undefined;
         }, delayMs);
     };

--- a/extension/src/services/pages.ts
+++ b/extension/src/services/pages.ts
@@ -22,6 +22,9 @@ interface PageConfig {
     // Page script to load
     pageScript?: string;
 
+    // Whether a changed media source identifies a new video even when the page URL is unchanged
+    videoSrcChangesIndicateNewVideo?: boolean;
+
     // URL relative path regex where subtitle track data syncing is allowed
     syncAllowedAtPath?: string;
 


### PR DESCRIPTION
fixes #1082

Also, `PlaybackEngine` now clears its subtitles whenever `Binding.reset()` is called which was a missed area for subtitles changing.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6