### PR TITLE
Deduplicate Youtube subtitles

### DIFF
--- a/common/subtitle-reader/subtitle-reader.test.ts
+++ b/common/subtitle-reader/subtitle-reader.test.ts
@@ -38,10 +38,16 @@ const rubyWithPrecedingKanaXml =
     '</div></body>' +
     '</tt>';
 
-const nfimscDocument = (text: string) =>
+const nfimscDocument = (text: string, begin = '10000000', end = '30000000') =>
     '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ttp:tickRate="10000000">' +
-    `<body><div><p begin="10000000t" end="30000000t">${text}</p></div></body>` +
+    `<body><div><p begin="${begin}t" end="${end}t">${text}</p></div></body>` +
     '</tt>';
+
+const duplicateNfimscDocument = (count: number) =>
+    '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ttp:tickRate="10000000">' +
+    '<body><div>' +
+    Array.from({ length: count }, () => '<p begin="10000000t" end="30000000t">Duplicate cue</p>').join('') +
+    '</div></body></tt>';
 
 describe('SubtitleReader Netflix IMSC parsing', () => {
     it('parses Netflix IMSC cues', async () => {
@@ -145,6 +151,62 @@ describe('SubtitleReader Netflix IMSC parsing', () => {
             track: 0,
             text: 'safe',
         });
+    });
+
+    it('deduplicates duplicate cues within a track without flattening', async () => {
+        const subtitles = await parse(duplicateNfimscDocument(3));
+
+        expect(subtitles).toHaveLength(1);
+        expect(subtitles[0]).toMatchObject({ start: 1000, end: 3000, text: 'Duplicate cue', track: 0 });
+    });
+
+    it('deduplicates duplicate cues after flattening files into one track', async () => {
+        const subtitles = await parse(duplicateNfimscDocument(3), false, true, 3);
+
+        expect(subtitles).toHaveLength(1);
+        expect(subtitles[0]).toMatchObject({ start: 1000, end: 3000, text: 'Duplicate cue', track: 0 });
+    });
+
+    it.each([
+        {
+            difference: 'start',
+            first: nfimscDocument('Same text', '10000000'),
+            second: nfimscDocument('Same text', '20000000'),
+            expected: [
+                { start: 1000, end: 3000, text: 'Same text' },
+                { start: 2000, end: 3000, text: 'Same text' },
+            ],
+        },
+        {
+            difference: 'end',
+            first: nfimscDocument('Same text', '10000000', '30000000'),
+            second: nfimscDocument('Same text', '10000000', '40000000'),
+            expected: [
+                { start: 1000, end: 3000, text: 'Same text' },
+                { start: 1000, end: 4000, text: 'Same text' },
+            ],
+        },
+        {
+            difference: 'text',
+            first: nfimscDocument('First text'),
+            second: nfimscDocument('Second text'),
+            expected: [
+                { start: 1000, end: 3000, text: 'First text' },
+                { start: 1000, end: 3000, text: 'Second text' },
+            ],
+        },
+    ])('preserves flattened cues when only the $difference differs', async ({ first, second, expected }) => {
+        const subtitles = await createReader().subtitles([nfimscFile(first), nfimscFile(second)], true);
+
+        expect(subtitles).toHaveLength(2);
+        expect(subtitles).toMatchObject(expected.map((cue) => ({ ...cue, track: 0 })));
+    });
+
+    it('preserves equal cues from separate tracks without flattening', async () => {
+        const subtitles = await parse(nfimscDocument('Same text'), false, false, 2);
+
+        expect(subtitles).toHaveLength(2);
+        expect(subtitles.map((subtitle) => subtitle.track)).toEqual([0, 1]);
     });
 
     it('does not fence a reading containing a closing paren', async () => {

--- a/common/subtitle-reader/subtitle-reader.ts
+++ b/common/subtitle-reader/subtitle-reader.ts
@@ -143,14 +143,14 @@ export default class SubtitleReader {
             for (const node of allNodes) this._convertNetflixRubyToHtml(node);
         }
 
-        return flatten ? this._deduplicate(allNodes) : allNodes;
+        return this._deduplicate(allNodes);
     }
 
     private _deduplicate(nodes: SubtitleNode[]) {
         const deduplicated: SubtitleNode[] = [];
 
         for (const node of nodes) {
-            if (deduplicated.length == 0 || !this._isSame(node, deduplicated[deduplicated.length - 1])) {
+            if (!deduplicated.length || !this._isSame(node, deduplicated[deduplicated.length - 1])) {
                 deduplicated.push(node);
             }
         }
@@ -159,11 +159,8 @@ export default class SubtitleReader {
     }
 
     private _isSame(a: SubtitleNode, b: SubtitleNode) {
-        if (a.textImage || b.textImage) {
-            return false;
-        }
-
-        return a.start === b.start && a.end === b.end && a.text === b.text;
+        if (a.textImage || b.textImage) return false;
+        return a.start === b.start && a.end === b.end && a.text === b.text && a.track === b.track;
     }
 
     async _subtitles(file: File, track: number): Promise<SubtitleNode[]> {


### PR DESCRIPTION
fixes #1018

I was able to replicate this on this youtube video https://github.com/asbplayer/asbplayer/issues/1018#issuecomment-5180040257. It seems it happens to all tracks and is 100% youtube sending the duplicate subtitles. Perhaps they had a temporary bug and haven't reparsed or it's some race condition.

Either way, the solution for us is simple. We just always run `deduplicate()` within a track before subtitle reader returns. This should always be desirable with no side effects.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6
